### PR TITLE
Migrate THORP soil initialization seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -14,3 +14,4 @@ Current status:
 - Slice 002 migrated: THORP radiation runtime seam
 - Slice 003 migrated: THORP Weibull vulnerability-curve primitive
 - Slice 004 migrated: THORP soil hydraulics dataclass
+- Slice 005 migrated: THORP soil initialization seam

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ poetry run ruff check .
 - THORP `radiation` runtime seam is migrated as slice 002.
 - THORP `WeibullVC` runtime primitive is migrated as slice 003.
 - THORP `SoilHydraulics` is migrated as slice 004.
+- THORP `initial_soil_and_roots` is migrated as slice 005.
 
 ## Next validation
-- Migrate the next THORP seam, likely `initial_soil_and_roots`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `richards_equation`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 004
-- Gate D. Bounded slices 001 through 004 approved for THORP
+- Gate C. Validation plan ready through slice 005
+- Gate D. Bounded slices 001 through 005 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -71,3 +71,9 @@ Slice 004:
 - target: `src/stomatal_optimiaztion/domains/thorp/soil_hydraulics.py`
 - scope: soil hydraulic relationships and equation-tagged methods
 - excluded: `THORPParams` and `initial_soil_and_roots`
+
+Slice 005:
+- source: `THORP/src/thorp/soil.py` (`SoilGrid`, `InitialSoilAndRoots`, `initial_soil_and_roots`)
+- target: `src/stomatal_optimiaztion/domains/thorp/soil_initialization.py`
+- scope: bounded soil discretization and root initialization
+- excluded: `richards_equation`, `soil_moisture`, and full soil time stepping

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -76,8 +76,16 @@ The fourth slice ports the next bounded hydraulic dataclass:
 - keep the implementation vectorized and numerically aligned with legacy snapshots
 - leave `THORPParams` and `initial_soil_and_roots` blocked for the next seam
 
+## Slice 005: THORP Soil Initialization
+
+The fifth slice ports the first bounded soil-setup function:
+- move `SoilGrid`, `InitialSoilAndRoots`, and `initial_soil_and_roots` from `soil.py`
+- depend only on migrated primitives plus a minimal parameter dataclass
+- validate soil-grid geometry and initialization outputs against legacy snapshots
+- keep `richards_equation` and `soil_moisture` blocked for a later slice
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, Weibull, and soil-hydraulics seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, and soil-initialization seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `initial_soil_and_roots` or another bounded soil seam
+3. prepare the next THORP source audit for `richards_equation` or another bounded soil-dynamics seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 004 implementation and validation
+- Current phase: slice 005 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP soil-hydraulics slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `initial_soil_and_roots`
+1. validate the migrated THORP soil-initialization slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `richards_equation`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-004-thorp-soil-hydraulics.md
+++ b/docs/architecture/architecture/module_specs/module-004-thorp-soil-hydraulics.md
@@ -33,4 +33,4 @@ Migrate the THORP soil hydraulic dataclass as the first bounded hydraulic seam a
 
 ## Next Seam
 
-- `initial_soil_and_roots` from `soil.py`
+- `richards_equation` from `soil.py`

--- a/docs/architecture/architecture/module_specs/module-005-thorp-soil-initialization.md
+++ b/docs/architecture/architecture/module_specs/module-005-thorp-soil-initialization.md
@@ -1,0 +1,36 @@
+# Module Spec 005: THORP Soil Initialization
+
+## Purpose
+
+Migrate the `initial_soil_and_roots` seam as the first bounded function that composes migrated hydraulic primitives into a full initialization output.
+
+## Source Inputs
+
+- `THORP/src/thorp/soil.py` (`SoilGrid`, `InitialSoilAndRoots`, `initial_soil_and_roots`)
+- migrated dependencies: `SoilHydraulics`, `WeibullVC`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/soil_initialization.py`
+- `tests/test_thorp_soil_initialization.py`
+
+## Responsibilities
+
+1. discretize the soil column consistently with legacy THORP behavior
+2. initialize `psi_soil_by_layer`, `vwc`, `c_r_h`, and `c_r_v`
+3. keep the function bounded by a minimal soil-initialization parameter dataclass rather than porting full `THORPParams`
+
+## Non-Goals
+
+- port `richards_equation` or `soil_moisture`
+- port the full THORP configuration bundle
+- absorb full soil time-stepping into this slice
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `richards_equation` from `soil.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-004 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only three THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-005 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
+| GAP-008 | Only four THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -6,13 +6,25 @@ from stomatal_optimiaztion.domains.thorp.model_card import (
 )
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
 from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    BottomBoundaryCondition,
+    InitialSoilAndRoots,
+    SoilGrid,
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 __all__ = [
+    "BottomBoundaryCondition",
+    "InitialSoilAndRoots",
     "RadiationResult",
+    "SoilGrid",
     "SoilHydraulics",
+    "SoilInitializationParams",
     "WeibullVC",
     "equation_id_set",
+    "initial_soil_and_roots",
     "iter_equation_refs",
     "model_card_document_names",
     "radiation",

--- a/src/stomatal_optimiaztion/domains/thorp/soil_initialization.py
+++ b/src/stomatal_optimiaztion/domains/thorp/soil_initialization.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+BottomBoundaryCondition = Literal["ConstantPressure", "FreeDrainage", "GroundwaterTable"]
+
+
+@dataclass(frozen=True, slots=True)
+class SoilInitializationParams:
+    rho: float
+    g: float
+    z_wt: float
+    z_soil: float
+    n_soil: int
+    bc_bttm: BottomBoundaryCondition
+    soil: SoilHydraulics
+    vc_r: WeibullVC
+    beta_r_h: float
+    beta_r_v: float
+
+
+@dataclass(frozen=True, slots=True)
+class SoilGrid:
+    dz: NDArray[np.floating]
+    z_bttm: NDArray[np.floating]
+    z_mid: NDArray[np.floating]
+    dz_c: NDArray[np.floating]
+
+    @property
+    def n_soil(self) -> int:
+        return int(self.z_mid.size)
+
+
+@dataclass(frozen=True, slots=True)
+class InitialSoilAndRoots:
+    grid: SoilGrid
+    psi_soil_by_layer: NDArray[np.floating]
+    vwc: NDArray[np.floating]
+    c_r_h: NDArray[np.floating]
+    c_r_v: NDArray[np.floating]
+
+
+def initial_soil_and_roots(
+    *,
+    params: SoilInitializationParams,
+    c_r_i: float,
+    z_i: float,
+) -> InitialSoilAndRoots:
+    z_wt = float(params.z_wt)
+    z_soil = float(params.z_soil)
+    n_soil = int(params.n_soil)
+
+    dz_top = z_soil if n_soil == 1 else 0.1
+    if dz_top > z_soil:
+        dz_top = z_soil * 0.1 / 30.0
+
+    if (z_soil / dz_top) < 1:
+        raise ValueError("Cannot discretize soil column")
+
+    if n_soil > 1:
+        r_min = 1.0
+        r_max = (z_soil / dz_top) ** (1 / (n_soil - 1))
+
+        err = float("inf")
+        iteration = 0
+        while err > 1e-4:
+            iteration += 1
+            if iteration > 100:
+                raise RuntimeError("Soil column discretization not converging")
+
+            r_half = 0.5 * (r_min + r_max)
+            ratio_grid = np.array([r_min, r_half, r_max], dtype=float)
+            exponents = np.arange(1, n_soil, dtype=float)[:, None]
+            closure = np.sum(ratio_grid[None, :] ** exponents, axis=0) - z_soil / dz_top
+            err = float(np.abs(closure[1]))
+
+            lt = ratio_grid[closure < 0]
+            gt = ratio_grid[closure > 0]
+            if lt.size == 0 or gt.size == 0:
+                raise RuntimeError("Soil column discretization not converging")
+
+            r_min = float(np.max(lt))
+            r_max = float(np.min(gt))
+
+        ratio = 0.5 * (r_min + r_max)
+        dz = ratio ** np.arange(0, n_soil, dtype=float)
+        dz = dz * z_soil / float(np.sum(dz))
+        z_bttm = np.cumsum(dz)
+        z_bttm[-1] = z_soil
+        n_soil_true = n_soil
+
+        if params.bc_bttm == "GroundwaterTable":
+            while z_bttm[-1] < z_wt:
+                n_soil += 1
+                dz = ratio ** np.arange(0, n_soil, dtype=float)
+                dz = dz * z_soil / float(np.sum(dz[:n_soil_true]))
+                z_bttm = np.cumsum(dz)
+                z_bttm[n_soil_true - 1] = z_soil
+    elif n_soil == 1:
+        dz = np.array([max(z_soil, z_wt)], dtype=float)
+        z_bttm = dz.copy()
+    else:
+        raise ValueError("Invalid n_soil")
+
+    z_top = np.concatenate([np.array([0.0]), z_bttm[:-1]])
+    z_mid = (z_bttm + z_top) / 2.0
+
+    dz_c = 0.5 * (dz[:-1] + dz[1:])
+    dz_c = np.concatenate([np.array([dz[0] / 2.0]), dz_c, np.array([dz[-1] / 2.0])])
+
+    grid = SoilGrid(
+        dz=dz.astype(float),
+        z_bttm=z_bttm.astype(float),
+        z_mid=z_mid.astype(float),
+        dz_c=dz_c.astype(float),
+    )
+
+    m_max = 0.995
+    if z_i <= 0:
+        raise ValueError("Initial rooting depth Z_i must be > 0")
+    root_decay_base = (1 - m_max) ** (1 / z_i)
+    root_biomass_fraction = (root_decay_base**z_top) - (root_decay_base**z_bttm)
+    c_r = c_r_i * root_biomass_fraction
+
+    psi_soil_by_layer = params.rho * params.g * (z_mid - z_wt) / 1e6
+    vwc = params.soil.vwc(psi_soil_by_layer, z_mid)
+
+    c_r_h = np.full_like(c_r, np.nan, dtype=float)
+    c_r_v = np.full_like(c_r, np.nan, dtype=float)
+
+    for layer_idx in range(grid.n_soil):
+        vc_r_i = float(params.vc_r(min(0.0, float(psi_soil_by_layer[layer_idx]))))
+        if layer_idx == 0:
+            split_ratio = params.beta_r_h / params.beta_r_v / (float(dz[layer_idx]) ** 2) / vc_r_i
+            c_r_v[layer_idx] = c_r[layer_idx] / (1 + split_ratio)
+            c_r_h[layer_idx] = c_r[layer_idx] - c_r_v[layer_idx]
+        else:
+            a_coef = params.beta_r_v * float(np.sum(dz[:layer_idx] ** 2 / c_r_v[:layer_idx]))
+            b_coef = (
+                -a_coef * c_r[layer_idx]
+                - params.beta_r_h / vc_r_i
+                - params.beta_r_v * float(dz[layer_idx]) ** 2
+            )
+            c_coef = c_r[layer_idx] * params.beta_r_h / vc_r_i
+            discriminant = float(b_coef**2 - 4 * a_coef * c_coef)
+            c_r_h_i = -(b_coef + np.sqrt(discriminant)) / (2 * a_coef)
+            c_r_h_i = max(float(c_r_h_i), 1e-4 * float(c_r[layer_idx]))
+            c_r_h[layer_idx] = c_r_h_i
+            c_r_v[layer_idx] = c_r[layer_idx] - c_r_h[layer_idx]
+
+    if np.any(c_r_h < 0) or np.any(c_r_v < 0):
+        raise RuntimeError("Negative root carbon upon initialization")
+
+    return InitialSoilAndRoots(
+        grid=grid,
+        psi_soil_by_layer=psi_soil_by_layer.astype(float),
+        vwc=vwc.astype(float),
+        c_r_h=c_r_h.astype(float),
+        c_r_v=c_r_v.astype(float),
+    )

--- a/tests/test_thorp_soil_initialization.py
+++ b/tests/test_thorp_soil_initialization.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    InitialSoilAndRoots,
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _legacy_default_like_params() -> SoilInitializationParams:
+    return SoilInitializationParams(
+        rho=998.0,
+        g=9.81,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=SoilHydraulics(n_vg=2.70, alpha_vg=1.4642, l_vg=0.5, e_z_n=13.6, e_z_k_s_sat=3.2),
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+    )
+
+
+def test_initial_soil_and_roots_matches_legacy_snapshot() -> None:
+    out = initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=3.0)
+
+    np.testing.assert_allclose(
+        out.grid.dz,
+        np.array(
+            [
+                0.09966816,
+                0.13654095,
+                0.18705502,
+                0.25625706,
+                0.35106077,
+                0.48093763,
+                0.65886316,
+                0.90261322,
+                1.23653995,
+                1.69400471,
+                2.32071109,
+                3.17927095,
+                4.35545976,
+                5.96678609,
+                8.17423149,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-7,
+    )
+    np.testing.assert_allclose(
+        out.psi_soil_by_layer,
+        np.array(
+            [
+                -0.72400023,
+                -0.72284394,
+                -0.72125987,
+                -0.71908978,
+                -0.71611684,
+                -0.71204405,
+                -0.70646451,
+                -0.69882079,
+                -0.68834922,
+                -0.67400365,
+                -0.65435085,
+                -0.6274274,
+                -0.59054346,
+                -0.5400141,
+                -0.47079114,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-7,
+    )
+    np.testing.assert_allclose(
+        out.vwc,
+        np.array(
+            [
+                0.24465022,
+                0.24289015,
+                0.24049925,
+                0.23726156,
+                0.23289589,
+                0.22704372,
+                0.21926159,
+                0.20902614,
+                0.19576482,
+                0.1789328,
+                0.15816094,
+                0.13349355,
+                0.10569986,
+                0.0765592,
+                0.04889254,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-7,
+    )
+    np.testing.assert_allclose(
+        out.c_r_h,
+        np.array(
+            [
+                1.61044018e-01,
+                1.56382792e-01,
+                1.50829737e-01,
+                1.40694677e-01,
+                1.18274178e-01,
+                7.98004229e-02,
+                3.97866625e-02,
+                1.34523763e-02,
+                2.70569704e-03,
+                2.69820473e-04,
+                1.05230346e-05,
+                1.18992137e-07,
+                2.65245645e-10,
+                6.88085774e-14,
+                9.91475591e-19,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-7,
+    )
+    np.testing.assert_allclose(
+        out.c_r_v,
+        np.array(
+            [
+                3.58557495e-04,
+                2.33059149e-02,
+                3.45438738e-02,
+                3.16782324e-02,
+                2.08811845e-02,
+                1.29197941e-02,
+                7.85808849e-03,
+                3.79426363e-03,
+                1.19460166e-03,
+                2.00264333e-04,
+                1.39088231e-05,
+                2.91808068e-07,
+                1.23611440e-09,
+                6.16664502e-13,
+                1.71811254e-17,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-7,
+    )
+    assert out.grid.n_soil == 15
+
+
+def test_initial_soil_and_roots_returns_expected_shapes() -> None:
+    out = initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=3.0)
+
+    assert isinstance(out, InitialSoilAndRoots)
+    assert out.grid.dz.shape == (15,)
+    assert out.grid.z_bttm.shape == (15,)
+    assert out.grid.z_mid.shape == (15,)
+    assert out.grid.dz_c.shape == (16,)
+    assert out.psi_soil_by_layer.shape == (15,)
+    assert out.vwc.shape == (15,)
+    assert out.c_r_h.shape == (15,)
+    assert out.c_r_v.shape == (15,)
+
+
+def test_initial_soil_and_roots_rejects_nonpositive_rooting_depth() -> None:
+    with pytest.raises(ValueError, match="Initial rooting depth Z_i must be > 0"):
+        initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=0.0)


### PR DESCRIPTION
## Summary
- migrate the THORP `initial_soil_and_roots` seam into the new package
- add bounded soil-initialization parameter and result dataclasses
- document slice 005 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #3
