### PR TITLE
Migrate THORP richards equation seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -15,3 +15,4 @@ Current status:
 - Slice 003 migrated: THORP Weibull vulnerability-curve primitive
 - Slice 004 migrated: THORP soil hydraulics dataclass
 - Slice 005 migrated: THORP soil initialization seam
+- Slice 006 migrated: THORP Richards-equation seam

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ poetry run ruff check .
 - THORP `WeibullVC` runtime primitive is migrated as slice 003.
 - THORP `SoilHydraulics` is migrated as slice 004.
 - THORP `initial_soil_and_roots` is migrated as slice 005.
+- THORP `richards_equation` is migrated as slice 006.
 
 ## Next validation
-- Migrate the next THORP seam, likely `richards_equation`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `soil_moisture`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 005
-- Gate D. Bounded slices 001 through 005 approved for THORP
+- Gate C. Validation plan ready through slice 006
+- Gate D. Bounded slices 001 through 006 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -77,3 +77,9 @@ Slice 005:
 - target: `src/stomatal_optimiaztion/domains/thorp/soil_initialization.py`
 - scope: bounded soil discretization and root initialization
 - excluded: `richards_equation`, `soil_moisture`, and full soil time stepping
+
+Slice 006:
+- source: `THORP/src/thorp/soil.py` (`richards_equation`)
+- target: `src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py`
+- scope: bounded Richards-equation solver with minimal parameter surface
+- excluded: `soil_moisture` and full coupled surface flux logic

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -84,8 +84,16 @@ The fifth slice ports the first bounded soil-setup function:
 - validate soil-grid geometry and initialization outputs against legacy snapshots
 - keep `richards_equation` and `soil_moisture` blocked for a later slice
 
+## Slice 006: THORP Richards Equation
+
+The sixth slice ports the next bounded soil-dynamics seam:
+- move `richards_equation` from `soil.py` into a dedicated dynamics module
+- reuse migrated `SoilGrid` and `SoilHydraulics`
+- keep the interface bounded by a minimal `RichardsEquationParams` dataclass
+- leave `soil_moisture` blocked as the next surface-coupling seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, and soil-initialization seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, and Richards-equation seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `richards_equation` or another bounded soil-dynamics seam
+3. prepare the next THORP source audit for `soil_moisture` or another bounded surface-coupling seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 005 implementation and validation
+- Current phase: slice 006 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP soil-initialization slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `richards_equation`
+1. validate the migrated THORP Richards-equation slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `soil_moisture`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-005-thorp-soil-initialization.md
+++ b/docs/architecture/architecture/module_specs/module-005-thorp-soil-initialization.md
@@ -33,4 +33,4 @@ Migrate the `initial_soil_and_roots` seam as the first bounded function that com
 
 ## Next Seam
 
-- `richards_equation` from `soil.py`
+- `soil_moisture` from `soil.py`

--- a/docs/architecture/architecture/module_specs/module-006-thorp-richards-equation.md
+++ b/docs/architecture/architecture/module_specs/module-006-thorp-richards-equation.md
@@ -1,0 +1,36 @@
+# Module Spec 006: THORP Richards Equation
+
+## Purpose
+
+Migrate the bounded Richards-equation solver so the soil column dynamics can run on migrated primitives without pulling in the full surface-flux layer.
+
+## Source Inputs
+
+- `THORP/src/thorp/soil.py` (`richards_equation`)
+- migrated dependencies: `SoilGrid`, `SoilHydraulics`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py`
+- `tests/test_thorp_richards_equation.py`
+
+## Responsibilities
+
+1. preserve the THORP Richards-equation matrix solve and boundary-condition handling
+2. keep equation tags for `E_S2_1`, `E_S2_10`, and `E_S2_13` through `E_S2_26`
+3. expose a minimal parameter dataclass instead of porting full `THORPParams`
+
+## Non-Goals
+
+- port `soil_moisture`
+- port surface energy or evaporation coupling
+- merge the full soil module into one large translation unit
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `soil_moisture` from `soil.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-005 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only four THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
+| GAP-008 | Only five THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -5,6 +5,10 @@ from stomatal_optimiaztion.domains.thorp.model_card import (
     require_equation_ids,
 )
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
+    RichardsEquationParams,
+    richards_equation,
+)
 from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     BottomBoundaryCondition,
@@ -19,6 +23,7 @@ __all__ = [
     "BottomBoundaryCondition",
     "InitialSoilAndRoots",
     "RadiationResult",
+    "RichardsEquationParams",
     "SoilGrid",
     "SoilHydraulics",
     "SoilInitializationParams",
@@ -28,5 +33,6 @@ __all__ = [
     "iter_equation_refs",
     "model_card_document_names",
     "radiation",
+    "richards_equation",
     "require_equation_ids",
 ]

--- a/src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.implements import implements
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    BottomBoundaryCondition,
+    SoilGrid,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RichardsEquationParams:
+    dt: float
+    rho: float
+    g: float
+    bc_bttm: BottomBoundaryCondition
+    z_wt: float
+    p_bttm: float
+    soil: SoilHydraulics
+
+
+@implements(
+    "E_S2_1",
+    "E_S2_10",
+    "E_S2_13",
+    "E_S2_14",
+    "E_S2_15",
+    "E_S2_16",
+    "E_S2_17",
+    "E_S2_18",
+    "E_S2_19",
+    "E_S2_20",
+    "E_S2_21",
+    "E_S2_22",
+    "E_S2_23",
+    "E_S2_24",
+    "E_S2_25",
+    "E_S2_26",
+)
+def richards_equation(
+    *,
+    params: RichardsEquationParams,
+    grid: SoilGrid,
+    q_top: float,
+    f: NDArray[np.floating],
+    psi_soil_by_layer: NDArray[np.floating],
+) -> tuple[NDArray[np.floating], float]:
+    dz = grid.dz
+    dz_c = grid.dz_c
+    z_mid = grid.z_mid
+    z_bttm = grid.z_bttm
+    n_soil_true = grid.n_soil
+    z_mid_true = z_mid
+
+    bc_bttm = params.bc_bttm
+    psi_bttm = float(params.p_bttm)
+    z_wt = float(params.z_wt)
+
+    if bc_bttm == "GroundwaterTable":
+        idx = int(np.argmin(np.abs(z_bttm - z_wt)))
+        n_soil = idx + 1
+
+        dz = dz[:n_soil]
+        dz_c = dz_c[: n_soil + 1]
+        z_mid = z_mid[:n_soil]
+        z_bttm = z_bttm[:n_soil]
+        f = f[:n_soil]
+        psi_soil_by_layer = psi_soil_by_layer[:n_soil]
+
+        psi_bttm = params.rho * params.g * (float(z_bttm[n_soil - 1]) - z_wt) / 1e6
+        bc_bttm = "ConstantPressure"
+
+    dhd_p = 1e6 / params.rho / params.g
+
+    k_soil = params.soil.k_soil(psi_soil_by_layer, z_mid)
+    k_soil_sat = params.soil.k_soil_sat(z_mid)
+    k_soil = np.where(psi_soil_by_layer > 0, k_soil_sat, k_soil)
+
+    # Match legacy THORP behavior when intermediate arrays contain inf values.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        d_k_soil_dz = np.concatenate([-(np.diff(k_soil) / dz_c[1:-1]), np.array([0.0])])
+        d_k_soil_sat_dz = np.concatenate([-(np.diff(k_soil_sat) / dz_c[1:-1]), np.array([0.0])])
+
+    d_p = 1e-3
+    d_k_d_p = (k_soil - params.soil.k_soil(psi_soil_by_layer - d_p, z_mid)) / d_p
+    d_k_d_p = np.where(psi_soil_by_layer > 0, 0.0, d_k_d_p)
+
+    d_vwc_d_p = (params.soil.vwc(psi_soil_by_layer, z_mid) - params.soil.vwc(psi_soil_by_layer - d_p, z_mid)) / d_p
+    d_vwc_d_p = np.where(psi_soil_by_layer > 0, 0.0, d_vwc_d_p)
+
+    a = 1 / dz_c[:-1] * (dhd_p * (k_soil / dz + d_k_soil_dz) + d_k_d_p)
+    c = dhd_p * k_soil / dz / dz_c[1:]
+    b = -a - c - d_vwc_d_p / params.dt
+    d = -f - d_vwc_d_p * psi_soil_by_layer / params.dt - k_soil / k_soil_sat * d_k_soil_sat_dz
+
+    a[0] = 0.0
+    c[0] = dhd_p * k_soil[0] / dz_c[0] / dz_c[1]
+    b[0] = -c[0] - d_vwc_d_p[0] / params.dt
+    d[0] = d[0] + (q_top + k_soil[0]) / dz_c[0]
+
+    q_bttm = float("nan")
+    if bc_bttm == "ConstantPressure":
+        d[-1] = d[-1] - c[-1] * psi_bttm
+        c[-1] = 0.0
+    elif bc_bttm == "FreeDrainage":
+        q_bttm_bc = -float(k_soil[-1])
+        d[-1] = d[-1] - (q_bttm_bc + k_soil[-1]) / dz_c[-1]
+        a[-1] = 1 / dz_c[-2] * dhd_p * k_soil[-1] / dz[-1]
+        b[-1] = -a[-1] - d_vwc_d_p[-1] / params.dt
+        c[-1] = 0.0
+    else:
+        raise ValueError("Bottom boundary condition not correctly specified")
+
+    matrix = np.diag(b) + np.diag(a[1:], k=-1) + np.diag(c[:-1], k=1)
+    psi_new = np.linalg.solve(matrix, d)
+    if np.any(np.isnan(psi_new)):
+        raise RuntimeError("Richards equation not converging to a solution")
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        d_p_dz = np.concatenate(
+            [-(np.diff(psi_new) / dz_c[1:-1]), np.array([(psi_new[-1] - psi_bttm) / dz_c[-1]])]
+        )
+    q = -k_soil * (dhd_p * d_p_dz + 1)
+    q_bttm = float(q[-1])
+
+    if n_soil_true > psi_new.size:
+        extra = params.rho * params.g * (z_mid_true[psi_new.size:n_soil_true] - z_wt) / 1e6
+        psi_new = np.concatenate([psi_new, extra])
+        q_bttm = -float(params.soil.k_soil_sat(np.array([z_mid_true[n_soil_true - 1]]))[0])
+
+    return psi_new.astype(float), q_bttm

--- a/tests/test_thorp_richards_equation.py
+++ b/tests/test_thorp_richards_equation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import numpy as np
+
+from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
+    RichardsEquationParams,
+    richards_equation,
+)
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _legacy_default_like_params() -> SoilInitializationParams:
+    return SoilInitializationParams(
+        rho=998.0,
+        g=9.81,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=SoilHydraulics(n_vg=2.70, alpha_vg=1.4642, l_vg=0.5, e_z_n=13.6, e_z_k_s_sat=3.2),
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+    )
+
+
+def _richards_params() -> RichardsEquationParams:
+    return RichardsEquationParams(
+        dt=6 * 3600.0,
+        rho=998.0,
+        g=9.81,
+        bc_bttm="FreeDrainage",
+        z_wt=74.0,
+        p_bttm=998.0 * 9.81 * (30.0 - 74.0) / 1e6,
+        soil=SoilHydraulics(n_vg=2.70, alpha_vg=1.4642, l_vg=0.5, e_z_n=13.6, e_z_k_s_sat=3.2),
+    )
+
+
+def test_richards_equation_exposes_expected_equation_ids() -> None:
+    assert implemented_equations(richards_equation) == (
+        "E_S2_1",
+        "E_S2_10",
+        "E_S2_13",
+        "E_S2_14",
+        "E_S2_15",
+        "E_S2_16",
+        "E_S2_17",
+        "E_S2_18",
+        "E_S2_19",
+        "E_S2_20",
+        "E_S2_21",
+        "E_S2_22",
+        "E_S2_23",
+        "E_S2_24",
+        "E_S2_25",
+        "E_S2_26",
+    )
+
+
+def test_richards_equation_matches_legacy_snapshot() -> None:
+    init = initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=3.0)
+    f = np.linspace(-2.0e-8, 3.0e-8, init.grid.n_soil, dtype=float)
+
+    psi_new, q_bttm = richards_equation(
+        params=_richards_params(),
+        grid=init.grid,
+        q_top=1.5e-7,
+        f=f,
+        psi_soil_by_layer=init.psi_soil_by_layer,
+    )
+
+    np.testing.assert_allclose(
+        psi_new,
+        np.array(
+            [
+                -0.743731887744,
+                -0.739297104874,
+                -0.734044024112,
+                -0.728079779475,
+                -0.721592460027,
+                -0.714721557817,
+                -0.707310452885,
+                -0.698680930269,
+                -0.68766782867,
+                -0.672859019015,
+                -0.652624919511,
+                -0.624845487042,
+                -0.586527820747,
+                -0.533185016128,
+                -0.457109513213,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    assert np.isclose(q_bttm, -1.7961954716762443e-11, rtol=1e-9)
+
+
+def test_richards_equation_preserves_shape() -> None:
+    init = initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=3.0)
+    f = np.zeros(init.grid.n_soil, dtype=float)
+
+    psi_new, q_bttm = richards_equation(
+        params=_richards_params(),
+        grid=init.grid,
+        q_top=0.0,
+        f=f,
+        psi_soil_by_layer=init.psi_soil_by_layer,
+    )
+
+    assert psi_new.shape == init.psi_soil_by_layer.shape
+    assert np.isfinite(q_bttm)


### PR DESCRIPTION
## Summary
- migrate the THORP `richards_equation` seam into the new package
- add bounded Richards-equation parameter handling and regression tests
- document slice 006 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #5
