### PR TITLE
Migrate THORP soil moisture seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ poetry run ruff check .
 - THORP `SoilHydraulics` is migrated as slice 004.
 - THORP `initial_soil_and_roots` is migrated as slice 005.
 - THORP `richards_equation` is migrated as slice 006.
+- THORP `soil_moisture` is migrated as slice 007.
 
 ## Next validation
-- Migrate the next THORP seam, likely `soil_moisture`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `e_from_soil_to_root_collar`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 006
-- Gate D. Bounded slices 001 through 006 approved for THORP
+- Gate C. Validation plan ready through slice 007
+- Gate D. Bounded slices 001 through 007 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -83,3 +83,9 @@ Slice 006:
 - target: `src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py`
 - scope: bounded Richards-equation solver with minimal parameter surface
 - excluded: `soil_moisture` and full coupled surface flux logic
+
+Slice 007:
+- source: `THORP/src/thorp/soil.py` (`soil_moisture`)
+- target: `src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py`
+- scope: bounded soil surface-coupling seam for evaporation, precipitation, and top-boundary updates
+- excluded: `e_from_soil_to_root_collar`, stomatal optimization, and the wider hydraulics stack

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -92,8 +92,16 @@ The sixth slice ports the next bounded soil-dynamics seam:
 - keep the interface bounded by a minimal `RichardsEquationParams` dataclass
 - leave `soil_moisture` blocked as the next surface-coupling seam
 
+## Slice 007: THORP Soil Moisture
+
+The seventh slice ports the bounded soil surface-coupling seam:
+- move `soil_moisture` from `soil.py` into the migrated soil-dynamics module
+- reuse migrated `SoilGrid`, `SoilHydraulics`, and `richards_equation`
+- keep the interface bounded by a minimal `SoilMoistureParams` dataclass
+- leave `e_from_soil_to_root_collar` blocked as the next hydraulics seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, and Richards-equation seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, and soil-moisture seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `soil_moisture` or another bounded surface-coupling seam
+3. prepare the next THORP source audit for `e_from_soil_to_root_collar` or another bounded hydraulics seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 006 implementation and validation
+- Current phase: slice 007 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP Richards-equation slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `soil_moisture`
+1. validate the migrated THORP soil-moisture slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `e_from_soil_to_root_collar`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-006-thorp-richards-equation.md
+++ b/docs/architecture/architecture/module_specs/module-006-thorp-richards-equation.md
@@ -33,4 +33,4 @@ Migrate the bounded Richards-equation solver so the soil column dynamics can run
 
 ## Next Seam
 
-- `soil_moisture` from `soil.py`
+- `e_from_soil_to_root_collar` from `hydraulics.py`

--- a/docs/architecture/architecture/module_specs/module-007-thorp-soil-moisture.md
+++ b/docs/architecture/architecture/module_specs/module-007-thorp-soil-moisture.md
@@ -1,0 +1,36 @@
+# Module Spec 007: THORP Soil Moisture
+
+## Purpose
+
+Migrate the bounded `soil_moisture` seam so the soil column can couple surface evaporation and precipitation to the migrated Richards-equation solver.
+
+## Source Inputs
+
+- `THORP/src/thorp/soil.py` (`soil_moisture`)
+- migrated dependencies: `SoilGrid`, `SoilHydraulics`, `richards_equation`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py`
+- `tests/test_thorp_soil_moisture.py`
+
+## Responsibilities
+
+1. preserve the legacy top-boundary source term and evaporation clamp behavior
+2. keep equation tags for `E_S2_3`, `E_S2_9`, `E_S2_11`, and `E_S2_12`
+3. expose a minimal parameter dataclass instead of porting full `THORPParams`
+
+## Non-Goals
+
+- port `e_from_soil_to_root_collar` from `hydraulics.py`
+- port stomatal optimization or forcing orchestration
+- merge the full soil and hydraulics runtime into one abstraction
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `e_from_soil_to_root_collar` from `hydraulics.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only five THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only six THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -7,7 +7,9 @@ from stomatal_optimiaztion.domains.thorp.model_card import (
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
     RichardsEquationParams,
+    SoilMoistureParams,
     richards_equation,
+    soil_moisture,
 )
 from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
@@ -27,6 +29,7 @@ __all__ = [
     "SoilGrid",
     "SoilHydraulics",
     "SoilInitializationParams",
+    "SoilMoistureParams",
     "WeibullVC",
     "equation_id_set",
     "initial_soil_and_roots",
@@ -35,4 +38,5 @@ __all__ = [
     "radiation",
     "richards_equation",
     "require_equation_ids",
+    "soil_moisture",
 ]

--- a/src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py
@@ -24,6 +24,13 @@ class RichardsEquationParams:
     soil: SoilHydraulics
 
 
+@dataclass(frozen=True, slots=True)
+class SoilMoistureParams:
+    richards: RichardsEquationParams
+    m_h2o: float
+    r_gas: float
+
+
 @implements(
     "E_S2_1",
     "E_S2_10",
@@ -134,3 +141,85 @@ def richards_equation(
         q_bttm = -float(params.soil.k_soil_sat(np.array([z_mid_true[n_soil_true - 1]]))[0])
 
     return psi_new.astype(float), q_bttm
+
+
+@implements("E_S2_3", "E_S2_9", "E_S2_11", "E_S2_12")
+def soil_moisture(
+    *,
+    params: SoilMoistureParams,
+    grid: SoilGrid,
+    psi_soil_by_layer: NDArray[np.floating],
+    t_a: float,
+    t_soil: float,
+    rh: float,
+    u10: float,
+    precip: float,
+    e_soil: NDArray[np.floating],
+    la: float,
+    w: float,
+) -> tuple[NDArray[np.floating], float]:
+    dz = grid.dz
+    z_mid = grid.z_mid
+    richards = params.richards
+    soil = richards.soil
+
+    f = -la * e_soil * params.m_h2o / richards.rho / w**2 / dz
+
+    dhd_p = 1e6 / richards.g / richards.rho
+    with np.errstate(over="ignore", invalid="ignore"):
+        rh_soil = float(
+            np.exp(
+                dhd_p
+                * float(psi_soil_by_layer[0])
+                * richards.g
+                * params.m_h2o
+                / params.r_gas
+                / (t_soil + 273.15)
+            )
+        )
+    rh_soil = min(1.0, rh_soil)
+
+    e_vsat = 0.61094 * np.exp(17.625 * t_a / (t_a + 243.04))
+    e_vsat_soil = 0.61094 * np.exp(17.625 * t_soil / (t_soil + 243.04))
+    e_v = rh * e_vsat
+    e_v_soil = rh_soil * e_vsat_soil
+    vpd_soil = e_v_soil - e_v
+
+    g_a = 0.147 * (u10 / 10.0) ** 0.5
+    evap = g_a * vpd_soil / 101.325
+    evap = params.m_h2o / richards.rho * evap
+    evap = max(0.0, float(evap))
+
+    vwc_min = float(soil.vwc(np.array([-np.inf]), np.array([z_mid[0]]))[0]) + 0.1 * (
+        float(soil.vwc(np.array([0.0]), np.array([z_mid[0]]))[0])
+        - float(soil.vwc(np.array([-np.inf]), np.array([z_mid[0]]))[0])
+    )
+    evap_max = (
+        (
+            float(
+                soil.vwc(
+                    np.array([psi_soil_by_layer[0]]),
+                    np.array([z_mid[0]]),
+                )[0]
+            )
+            - vwc_min
+        )
+        / richards.dt
+        - float(f[0])
+    ) * float(dz[0])
+    evap_max = max(0.0, 0.95 * float(evap_max))
+    evap = min(evap, evap_max)
+
+    q_top = evap
+    if precip > 0:
+        q_top = -precip
+        evap = float("nan")
+
+    psi_new, _ = richards_equation(
+        params=richards,
+        grid=grid,
+        q_top=float(q_top),
+        f=f,
+        psi_soil_by_layer=psi_soil_by_layer,
+    )
+    return psi_new, float(evap)

--- a/tests/test_thorp_soil_moisture.py
+++ b/tests/test_thorp_soil_moisture.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import numpy as np
+
+from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
+    RichardsEquationParams,
+    SoilMoistureParams,
+    soil_moisture,
+)
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _legacy_default_like_params() -> SoilInitializationParams:
+    return SoilInitializationParams(
+        rho=998.0,
+        g=9.81,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=SoilHydraulics(
+            n_vg=2.70,
+            alpha_vg=1.4642,
+            l_vg=0.5,
+            e_z_n=13.6,
+            e_z_k_s_sat=3.2,
+        ),
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+    )
+
+
+def _richards_params() -> RichardsEquationParams:
+    return RichardsEquationParams(
+        dt=6 * 3600.0,
+        rho=998.0,
+        g=9.81,
+        bc_bttm="FreeDrainage",
+        z_wt=74.0,
+        p_bttm=998.0 * 9.81 * (30.0 - 74.0) / 1e6,
+        soil=SoilHydraulics(
+            n_vg=2.70,
+            alpha_vg=1.4642,
+            l_vg=0.5,
+            e_z_n=13.6,
+            e_z_k_s_sat=3.2,
+        ),
+    )
+
+
+def _soil_moisture_params() -> SoilMoistureParams:
+    return SoilMoistureParams(
+        richards=_richards_params(),
+        m_h2o=18.01528e-3,
+        r_gas=8.314,
+    )
+
+
+def test_soil_moisture_exposes_expected_equation_ids() -> None:
+    assert implemented_equations(soil_moisture) == (
+        "E_S2_3",
+        "E_S2_9",
+        "E_S2_11",
+        "E_S2_12",
+    )
+
+
+def test_soil_moisture_matches_legacy_snapshot() -> None:
+    init = initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=3.0)
+    e_soil = np.linspace(2.0e-8, 9.0e-8, init.grid.n_soil, dtype=float)
+
+    psi_new, evap = soil_moisture(
+        params=_soil_moisture_params(),
+        grid=init.grid,
+        psi_soil_by_layer=init.psi_soil_by_layer,
+        t_a=23.5,
+        t_soil=19.0,
+        rh=0.58,
+        u10=2.4,
+        precip=0.0,
+        e_soil=e_soil,
+        la=2.8,
+        w=0.35,
+    )
+
+    np.testing.assert_allclose(
+        psi_new,
+        np.array(
+            [
+                -0.724746382349,
+                -0.723464513999,
+                -0.721741394133,
+                -0.719429772846,
+                -0.716329150385,
+                -0.712159589631,
+                -0.706523289824,
+                -0.698856884808,
+                -0.688380017144,
+                -0.674032325222,
+                -0.654375120965,
+                -0.627444896569,
+                -0.59055385189,
+                -0.540019340893,
+                -0.470796140108,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    assert np.isclose(evap, 6.478907185751277e-09, rtol=1e-9)
+
+
+def test_soil_moisture_precipitation_branch_matches_legacy_behavior() -> None:
+    init = initial_soil_and_roots(params=_legacy_default_like_params(), c_r_i=1.0, z_i=3.0)
+    e_soil = np.full(init.grid.n_soil, 4.0e-8, dtype=float)
+
+    psi_new, evap = soil_moisture(
+        params=_soil_moisture_params(),
+        grid=init.grid,
+        psi_soil_by_layer=init.psi_soil_by_layer,
+        t_a=18.0,
+        t_soil=18.0,
+        rh=0.92,
+        u10=1.5,
+        precip=1.2e-7,
+        e_soil=e_soil,
+        la=2.4,
+        w=0.4,
+    )
+
+    np.testing.assert_allclose(
+        psi_new,
+        np.array(
+            [
+                -0.708667913141,
+                -0.710154706354,
+                -0.711503826413,
+                -0.712330190004,
+                -0.712079195313,
+                -0.71009729718,
+                -0.705781204182,
+                -0.698680807107,
+                -0.688355530231,
+                -0.674029867441,
+                -0.65437420987,
+                -0.627444042788,
+                -0.590552955073,
+                -0.540018290537,
+                -0.470794672267,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    assert np.isnan(evap)


### PR DESCRIPTION
## Summary
- migrate the THORP `soil_moisture` seam into the new package
- add bounded soil-moisture parameter handling and regression tests
- document slice 007 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #7
