### PR TITLE
Migrate THORP root uptake hydraulics seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ poetry run ruff check .
 - THORP `initial_soil_and_roots` is migrated as slice 005.
 - THORP `richards_equation` is migrated as slice 006.
 - THORP `soil_moisture` is migrated as slice 007.
+- THORP `e_from_soil_to_root_collar` is migrated as slice 008.
 
 ## Next validation
-- Migrate the next THORP seam, likely `e_from_soil_to_root_collar`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `stomata`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 007
-- Gate D. Bounded slices 001 through 007 approved for THORP
+- Gate C. Validation plan ready through slice 008
+- Gate D. Bounded slices 001 through 008 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -89,3 +89,9 @@ Slice 007:
 - target: `src/stomatal_optimiaztion/domains/thorp/soil_dynamics.py`
 - scope: bounded soil surface-coupling seam for evaporation, precipitation, and top-boundary updates
 - excluded: `e_from_soil_to_root_collar`, stomatal optimization, and the wider hydraulics stack
+
+Slice 008:
+- source: `THORP/src/thorp/hydraulics.py` (`e_from_soil_to_root_collar`)
+- target: `src/stomatal_optimiaztion/domains/thorp/hydraulics.py`
+- scope: bounded root-uptake hydraulics and resistance bookkeeping
+- excluded: `stomata`, canopy conductance coupling, and the wider optimization stack

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -100,8 +100,16 @@ The seventh slice ports the bounded soil surface-coupling seam:
 - keep the interface bounded by a minimal `SoilMoistureParams` dataclass
 - leave `e_from_soil_to_root_collar` blocked as the next hydraulics seam
 
+## Slice 008: THORP Root Uptake Hydraulics
+
+The eighth slice ports the next bounded hydraulics seam:
+- move `e_from_soil_to_root_collar` from `hydraulics.py` into a dedicated THORP hydraulics module
+- reuse migrated `WeibullVC` and soil initialization outputs
+- keep the interface bounded by a minimal `RootUptakeParams` dataclass
+- leave `stomata` blocked as the next coupled hydraulics seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, and soil-moisture seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, and root-uptake seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `e_from_soil_to_root_collar` or another bounded hydraulics seam
+3. prepare the next THORP source audit for `stomata` or another bounded coupled hydraulics seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 007 implementation and validation
+- Current phase: slice 008 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP soil-moisture slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `e_from_soil_to_root_collar`
+1. validate the migrated THORP root-uptake slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `stomata`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-007-thorp-soil-moisture.md
+++ b/docs/architecture/architecture/module_specs/module-007-thorp-soil-moisture.md
@@ -33,4 +33,4 @@ Migrate the bounded `soil_moisture` seam so the soil column can couple surface e
 
 ## Next Seam
 
-- `e_from_soil_to_root_collar` from `hydraulics.py`
+- `stomata` from `hydraulics.py`

--- a/docs/architecture/architecture/module_specs/module-008-thorp-root-uptake-hydraulics.md
+++ b/docs/architecture/architecture/module_specs/module-008-thorp-root-uptake-hydraulics.md
@@ -1,0 +1,36 @@
+# Module Spec 008: THORP Root Uptake Hydraulics
+
+## Purpose
+
+Migrate the bounded `e_from_soil_to_root_collar` seam so the new package can compute root uptake from migrated soil, root, and vulnerability primitives.
+
+## Source Inputs
+
+- `THORP/src/thorp/hydraulics.py` (`e_from_soil_to_root_collar`)
+- migrated dependencies: `WeibullVC`, `SoilGrid`, `InitialSoilAndRoots`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/hydraulics.py`
+- `tests/test_thorp_root_uptake.py`
+
+## Responsibilities
+
+1. preserve the bounded soil-to-root-collar uptake calculation and resistance bookkeeping
+2. keep equation tags for `E_S2_2` and `E_S3_1` through `E_S3_5`
+3. expose a minimal parameter dataclass instead of porting full `THORPParams`
+
+## Non-Goals
+
+- port `stomata` from `hydraulics.py`
+- port canopy conductance or photosynthesis coupling
+- merge all THORP hydraulics into one large translation unit
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `stomata` from `hydraulics.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only six THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only seven THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -1,3 +1,8 @@
+from stomatal_optimiaztion.domains.thorp.hydraulics import (
+    RootUptakeParams,
+    RootUptakeResult,
+    e_from_soil_to_root_collar,
+)
 from stomatal_optimiaztion.domains.thorp.model_card import (
     equation_id_set,
     iter_equation_refs,
@@ -26,11 +31,14 @@ __all__ = [
     "InitialSoilAndRoots",
     "RadiationResult",
     "RichardsEquationParams",
+    "RootUptakeParams",
+    "RootUptakeResult",
     "SoilGrid",
     "SoilHydraulics",
     "SoilInitializationParams",
     "SoilMoistureParams",
     "WeibullVC",
+    "e_from_soil_to_root_collar",
     "equation_id_set",
     "initial_soil_and_roots",
     "iter_equation_refs",

--- a/src/stomatal_optimiaztion/domains/thorp/hydraulics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/hydraulics.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.implements import implements
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _safe_div(num: float, den: float) -> float:
+    if den == 0.0:
+        if num == 0.0:
+            return float("nan")
+        return float(np.copysign(float("inf"), num))
+    return num / den
+
+
+@dataclass(frozen=True, slots=True)
+class RootUptakeParams:
+    beta_r_h: float
+    beta_r_v: float
+    vc_r: WeibullVC
+    rho: float
+    g: float
+
+
+@dataclass(frozen=True, slots=True)
+class RootUptakeResult:
+    e: float
+    e_soil: NDArray[np.floating]
+    r_r_h: NDArray[np.floating]
+    r_r_v: NDArray[np.floating]
+    f_r: NDArray[np.floating]
+
+
+@implements("E_S2_2", "E_S3_1", "E_S3_2", "E_S3_3", "E_S3_4", "E_S3_5")
+def e_from_soil_to_root_collar(
+    *,
+    params: RootUptakeParams,
+    psi_rc: float,
+    psi_soil_by_layer: NDArray[np.floating],
+    z_soil_mid: NDArray[np.floating],
+    dz: NDArray[np.floating],
+    la: float,
+    c_r_h: NDArray[np.floating],
+    c_r_v: NDArray[np.floating],
+) -> RootUptakeResult:
+    n = 20
+
+    c_r = c_r_h + c_r_v
+    r_r_h_min = np.divide(
+        params.beta_r_h,
+        c_r_h,
+        out=np.full_like(c_r_h, np.inf, dtype=float),
+        where=c_r_h != 0,
+    )
+    r_r_v = np.divide(
+        params.beta_r_v * dz**2,
+        c_r_v,
+        out=np.full_like(c_r_v, np.inf, dtype=float),
+        where=c_r_v != 0,
+    )
+    r_r_v_sum = np.cumsum(r_r_v)
+
+    e_soil = np.full_like(psi_soil_by_layer, np.nan, dtype=float)
+    f_r = np.full_like(psi_soil_by_layer, np.nan, dtype=float)
+
+    for layer_idx in range(psi_soil_by_layer.size):
+        if c_r[layer_idx] > 0:
+            psi_soil_i = float(psi_soil_by_layer[layer_idx])
+            z_soil_i = float(z_soil_mid[layer_idx])
+            psi_src_min = float(min(psi_soil_i, psi_rc))
+            psi_src_max = float(max(psi_soil_i, psi_rc))
+
+            if psi_rc == psi_soil_i:
+                f_ri = float(params.vc_r(psi_src_min))
+                if psi_src_min > 0:
+                    f_ri = float(params.vc_r(0.0))
+                r_r_h = _safe_div(float(r_r_h_min[layer_idx]), f_ri)
+                r_r = r_r_h + float(r_r_v_sum[layer_idx])
+                e_i = -(params.rho * params.g * z_soil_i / 1e6) / r_r / la
+            elif (psi_soil_i - psi_rc) == (params.rho * params.g * z_soil_i / 1e6):
+                e_i = 0.0
+                f_ri = float(params.vc_r(psi_src_min if psi_src_min <= 0 else 0.0))
+            else:
+                psi_src = np.linspace(psi_src_min, psi_src_max, n)
+                f_vals = np.asarray(params.vc_r(psi_src), dtype=float)
+                f_vals = np.where(psi_src > 0, float(params.vc_r(0.0)), f_vals)
+                f_ri = float(np.sum(f_vals) / n)
+                r_r_h = _safe_div(float(r_r_h_min[layer_idx]), f_ri)
+                r_r = r_r_h + float(r_r_v_sum[layer_idx])
+                e_i = (psi_soil_i - psi_rc - params.rho * params.g * z_soil_i / 1e6) / r_r / la
+
+            e_soil[layer_idx] = e_i
+            f_r[layer_idx] = f_ri
+        else:
+            e_soil[layer_idx] = 0.0
+            f_r[layer_idx] = float(params.vc_r(float(psi_soil_by_layer[layer_idx])))
+
+    e = float(np.sum(e_soil))
+
+    z_ref = float(z_soil_mid[-1])
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        r_r = (psi_soil_by_layer - psi_rc - params.rho * params.g * z_ref / 1e6) / e_soil / la
+        r_r_h = r_r - r_r_v_sum
+    r_r_h = np.maximum(r_r_h, r_r_h_min)
+
+    if np.isnan(e):
+        raise RuntimeError("Error calculating E (NaN)")
+
+    return RootUptakeResult(
+        e=e,
+        e_soil=e_soil.astype(float),
+        r_r_h=r_r_h.astype(float),
+        r_r_v=r_r_v.astype(float),
+        f_r=f_r.astype(float),
+    )

--- a/tests/test_thorp_root_uptake.py
+++ b/tests/test_thorp_root_uptake.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import numpy as np
+
+from stomatal_optimiaztion.domains.thorp.hydraulics import (
+    RootUptakeParams,
+    e_from_soil_to_root_collar,
+)
+from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _legacy_default_like_initialization_params() -> SoilInitializationParams:
+    return SoilInitializationParams(
+        rho=998.0,
+        g=9.81,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=SoilHydraulics(
+            n_vg=2.70,
+            alpha_vg=1.4642,
+            l_vg=0.5,
+            e_z_n=13.6,
+            e_z_k_s_sat=3.2,
+        ),
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+    )
+
+
+def _root_uptake_params() -> RootUptakeParams:
+    return RootUptakeParams(
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        rho=998.0,
+        g=9.81,
+    )
+
+
+def test_root_uptake_exposes_expected_equation_ids() -> None:
+    assert implemented_equations(e_from_soil_to_root_collar) == (
+        "E_S2_2",
+        "E_S3_1",
+        "E_S3_2",
+        "E_S3_3",
+        "E_S3_4",
+        "E_S3_5",
+    )
+
+
+def test_root_uptake_matches_legacy_snapshot() -> None:
+    init = initial_soil_and_roots(
+        params=_legacy_default_like_initialization_params(),
+        c_r_i=1.0,
+        z_i=3.0,
+    )
+
+    res = e_from_soil_to_root_collar(
+        params=_root_uptake_params(),
+        psi_rc=-0.92,
+        psi_soil_by_layer=init.psi_soil_by_layer,
+        z_soil_mid=init.grid.z_mid,
+        dz=init.grid.dz,
+        la=2.8,
+        c_r_h=init.c_r_h,
+        c_r_v=init.c_r_v,
+    )
+
+    assert np.isclose(res.e, 6.884642523943817e-06, rtol=1e-9)
+    np.testing.assert_allclose(
+        res.e_soil,
+        np.array(
+            [
+                1.280442933780e-06,
+                1.244268543400e-06,
+                1.201254558213e-06,
+                1.122026210588e-06,
+                9.449354372979e-07,
+                6.391281629058e-07,
+                3.197223862699e-07,
+                1.085922733647e-07,
+                2.197465269729e-08,
+                2.209270684139e-09,
+                8.709372077427e-11,
+                9.987552765547e-13,
+                2.266632961253e-15,
+                6.012325240698e-19,
+                8.894765280060e-24,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.r_r_h,
+        np.array(
+            [
+                2.103866031355e04,
+                2.166574948795e04,
+                2.246341108006e04,
+                2.408158190822e04,
+                2.864657746040e04,
+                4.245779988867e04,
+                8.515794433283e04,
+                2.518625932233e05,
+                1.252228294335e06,
+                1.255705451880e07,
+                3.219746493151e08,
+                2.847373339395e10,
+                1.277363250320e13,
+                4.924023303409e16,
+                4.189964032392e21,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.r_r_v,
+        np.array(
+            [
+                2.607439614352e04,
+                7.528697266108e02,
+                9.532962393053e02,
+                1.950971410513e03,
+                5.554815545838e03,
+                1.684930947798e04,
+                5.199166328596e04,
+                2.020859178251e05,
+                1.204629149619e06,
+                1.348608209770e07,
+                3.644281784752e08,
+                3.260002753075e10,
+                1.444340282199e13,
+                5.433656334475e16,
+                3.660179933224e21,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.f_r,
+        np.array(
+            [
+                0.739287067722,
+                0.739683162319,
+                0.740225158896,
+                0.740966474178,
+                0.741979789953,
+                0.743363736536,
+                0.745251647189,
+                0.747822778616,
+                0.751316185958,
+                0.756046810515,
+                0.762421778909,
+                0.770951392441,
+                0.782241806065,
+                0.796941500755,
+                0.815587117471,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+
+
+def test_root_uptake_handles_zero_root_layers_like_legacy() -> None:
+    res = e_from_soil_to_root_collar(
+        params=_root_uptake_params(),
+        psi_rc=-0.9,
+        psi_soil_by_layer=np.array([-0.4, -0.8, -1.2], dtype=float),
+        z_soil_mid=np.array([0.1, 0.3, 0.8], dtype=float),
+        dz=np.array([0.2, 0.2, 0.4], dtype=float),
+        la=2.1,
+        c_r_h=np.array([0.05, 0.0, 0.08], dtype=float),
+        c_r_v=np.array([0.03, 0.0, 0.04], dtype=float),
+    )
+
+    assert np.isclose(res.e, 2.8980452474028086e-06, rtol=1e-9)
+    np.testing.assert_allclose(
+        res.e_soil,
+        np.array([2.898045247403e-06, 0.0, -0.0], dtype=float),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.r_r_h,
+        np.array([7.961535390133316e04, np.nan, np.nan], dtype=float),
+        rtol=1e-9,
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        res.r_r_v,
+        np.array([1.254870514191393e03, np.inf, 3.764611542574178e03], dtype=float),
+        rtol=1e-9,
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        res.f_r,
+        np.array([0.839259300135, 0.756167973539, 0.562799719214], dtype=float),
+        rtol=1e-9,
+    )


### PR DESCRIPTION
## Summary
- migrate the THORP `e_from_soil_to_root_collar` seam into the new package
- add bounded root-uptake parameter handling and regression tests
- document slice 008 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #9
