### PR TITLE
Migrate THORP stomata seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ poetry run ruff check .
 - THORP `richards_equation` is migrated as slice 006.
 - THORP `soil_moisture` is migrated as slice 007.
 - THORP `e_from_soil_to_root_collar` is migrated as slice 008.
+- THORP `stomata` is migrated as slice 009.
 
 ## Next validation
-- Migrate the next THORP seam, likely `stomata`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `allocation_fractions`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 008
-- Gate D. Bounded slices 001 through 008 approved for THORP
+- Gate C. Validation plan ready through slice 009
+- Gate D. Bounded slices 001 through 009 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -95,3 +95,9 @@ Slice 008:
 - target: `src/stomatal_optimiaztion/domains/thorp/hydraulics.py`
 - scope: bounded root-uptake hydraulics and resistance bookkeeping
 - excluded: `stomata`, canopy conductance coupling, and the wider optimization stack
+
+Slice 009:
+- source: `THORP/src/thorp/hydraulics.py` (`stomata`)
+- target: `src/stomatal_optimiaztion/domains/thorp/hydraulics.py`
+- scope: bounded stomatal closure, gas-exchange coupling, and derivative bookkeeping
+- excluded: `allocation_fractions`, growth integration, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -108,8 +108,16 @@ The eighth slice ports the next bounded hydraulics seam:
 - keep the interface bounded by a minimal `RootUptakeParams` dataclass
 - leave `stomata` blocked as the next coupled hydraulics seam
 
+## Slice 009: THORP Stomata
+
+The ninth slice ports the next coupled hydraulics and gas-exchange seam:
+- move `stomata` from `hydraulics.py` into the migrated THORP hydraulics module
+- reuse migrated root-uptake, vulnerability, and traceable photosynthesis primitives
+- keep the interface bounded by a minimal `StomataParams` dataclass
+- leave `allocation_fractions` blocked as the next plant-growth seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, and root-uptake seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, and stomata seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `stomata` or another bounded coupled hydraulics seam
+3. prepare the next THORP source audit for `allocation_fractions` or another bounded plant-growth seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 008 implementation and validation
+- Current phase: slice 009 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP root-uptake slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `stomata`
+1. validate the migrated THORP stomata slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `allocation_fractions`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-008-thorp-root-uptake-hydraulics.md
+++ b/docs/architecture/architecture/module_specs/module-008-thorp-root-uptake-hydraulics.md
@@ -33,4 +33,4 @@ Migrate the bounded `e_from_soil_to_root_collar` seam so the new package can com
 
 ## Next Seam
 
-- `stomata` from `hydraulics.py`
+- `allocation_fractions` from `allocation.py`

--- a/docs/architecture/architecture/module_specs/module-009-thorp-stomata.md
+++ b/docs/architecture/architecture/module_specs/module-009-thorp-stomata.md
@@ -1,0 +1,36 @@
+# Module Spec 009: THORP Stomata
+
+## Purpose
+
+Migrate the bounded `stomata` seam so the new package can close coupled hydraulics and gas exchange on migrated THORP primitives.
+
+## Source Inputs
+
+- `THORP/src/thorp/hydraulics.py` (`stomata`)
+- migrated dependencies: `e_from_soil_to_root_collar`, `WeibullVC`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/hydraulics.py`
+- `tests/test_thorp_stomata.py`
+
+## Responsibilities
+
+1. preserve the bounded stomatal-closure search and photosynthesis coupling logic
+2. keep equation tags for `E_S3_6` through `E_S6_16`
+3. expose a minimal parameter dataclass instead of porting full `THORPParams`
+
+## Non-Goals
+
+- port `allocation_fractions` from `allocation.py`
+- port whole-plant growth or simulation orchestration
+- merge all remaining THORP runtime into one abstraction
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `allocation_fractions` from `allocation.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only seven THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only eight THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -1,7 +1,10 @@
 from stomatal_optimiaztion.domains.thorp.hydraulics import (
     RootUptakeParams,
     RootUptakeResult,
+    StomataParams,
+    StomataResult,
     e_from_soil_to_root_collar,
+    stomata,
 )
 from stomatal_optimiaztion.domains.thorp.model_card import (
     equation_id_set,
@@ -33,6 +36,8 @@ __all__ = [
     "RichardsEquationParams",
     "RootUptakeParams",
     "RootUptakeResult",
+    "StomataParams",
+    "StomataResult",
     "SoilGrid",
     "SoilHydraulics",
     "SoilInitializationParams",
@@ -47,4 +52,5 @@ __all__ = [
     "richards_equation",
     "require_equation_ids",
     "soil_moisture",
+    "stomata",
 ]

--- a/src/stomatal_optimiaztion/domains/thorp/hydraulics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/hydraulics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
@@ -7,6 +8,10 @@ from numpy.typing import NDArray
 
 from stomatal_optimiaztion.domains.thorp.implements import implements
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _reverse_cumsum(x: NDArray[np.floating], axis: int = 0) -> NDArray[np.floating]:
+    return np.flip(np.cumsum(np.flip(x, axis=axis), axis=axis), axis=axis)
 
 
 def _safe_div(num: float, den: float) -> float:
@@ -33,6 +38,9 @@ class RootUptakeResult:
     r_r_h: NDArray[np.floating]
     r_r_v: NDArray[np.floating]
     f_r: NDArray[np.floating]
+
+
+ResponseCurve = Callable[[NDArray[np.floating]], NDArray[np.floating]]
 
 
 @implements("E_S2_2", "E_S3_1", "E_S3_2", "E_S3_3", "E_S3_4", "E_S3_5")
@@ -116,4 +124,833 @@ def e_from_soil_to_root_collar(
         r_r_h=r_r_h.astype(float),
         r_r_v=r_r_v.astype(float),
         f_r=f_r.astype(float),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StomataParams:
+    root_uptake: RootUptakeParams
+    g_wmin: float
+    c_prime1: float
+    c_prime2: float
+    d_ref: float
+    c0: float
+    c1: float
+    b2: float
+    c2: float
+    k_l: float
+    vc_sw: WeibullVC
+    vc_l: WeibullVC
+    v_cmax_func: ResponseCurve
+    j_max_func: ResponseCurve
+    gamma_star_func: ResponseCurve
+    k_c_func: ResponseCurve
+    k_o_func: ResponseCurve
+    r_d_func: ResponseCurve
+    var_kappa: float
+    c_a: float
+    o_a: float
+
+    @property
+    def rho(self) -> float:
+        return self.root_uptake.rho
+
+    @property
+    def g(self) -> float:
+        return self.root_uptake.g
+
+    @property
+    def vc_r(self) -> WeibullVC:
+        return self.root_uptake.vc_r
+
+
+@dataclass(frozen=True, slots=True)
+class StomataResult:
+    psi_l: float
+    psi_s: float
+    psi_rc: float
+    psi_rc0: float
+    e: float
+    e_soil: NDArray[np.floating]
+    a_n: float
+    r_d: float
+    t_l: float
+    g_w: float
+    lambda_wue: float
+    d_a_n_d_r_abs: float
+    d_e_d_la: float
+    d_e_d_d: float
+    d_e_d_c_r_h: NDArray[np.floating]
+    d_e_d_c_r_v: NDArray[np.floating]
+
+
+@implements(
+    "E_S3_6",
+    "E_S3_7",
+    "E_S3_10",
+    "E_S3_8",
+    "E_S3_9",
+    "E_S3_25",
+    "E_S3_26",
+    "E_S3_27",
+    "E_S3_32",
+    "E_S3_33",
+    "E_S3_34",
+    "E_S3_42",
+    "E_S3_49_to_55_raw",
+    "E_S4_7",
+    "E_S4_8",
+    "E_S6_1",
+    "E_S6_2",
+    "E_S6_3",
+    "E_S6_4",
+    "E_S6_5",
+    "E_S6_6",
+    "E_S6_7",
+    "E_S6_8",
+    "E_S6_9",
+    "E_S6_10",
+    "E_S6_11",
+    "E_S6_12",
+    "E_S6_13",
+    "E_S6_14",
+    "E_S6_15",
+    "E_S6_16",
+)
+def stomata(
+    *,
+    params: StomataParams,
+    psi_soil_by_layer: NDArray[np.floating],
+    n_soil: int,
+    dz: NDArray[np.floating],
+    z_soil_mid: NDArray[np.floating],
+    t_a: float,
+    rh: float,
+    r_abs: float,
+    la: float,
+    c_r_h: NDArray[np.floating],
+    c_r_v: NDArray[np.floating],
+    h: float,
+    w: float,
+    d: float,
+    d_hw: float,
+    d_r_abs_d_h: float,
+    d_r_abs_d_w: float,
+    d_r_abs_d_la: float,
+) -> StomataResult:
+    c_r = c_r_h + c_r_v
+    n = 20
+
+    k_sw_max = params.b2 * (d / params.d_ref) ** params.c2 * (
+        1 - (d_hw / d) ** (params.c2 / params.c0 + 1)
+    )
+    dk_sw_max_d_d = (
+        k_sw_max
+        / d
+        * (
+            params.c2
+            + (params.c2 / params.c0 + 1 - params.c2)
+            * (d_hw / d) ** (params.c2 / params.c0 + 1)
+        )
+        / (1 - (d_hw / d) ** (params.c2 / params.c0 + 1))
+    )
+
+    d_h_d_d = params.c0 * h / d
+    d_w_d_d = params.c1 * w / d
+
+    psi_soil_min = float(np.min(psi_soil_by_layer[c_r > 0]))
+    z_psi_soil_min = float(np.max(z_soil_mid[psi_soil_by_layer == psi_soil_min]))
+    psi_soil_max = float(np.max(psi_soil_by_layer[c_r > 0]))
+
+    psi_rc_ub_0 = psi_soil_max
+    psi_rc_lb_0 = psi_soil_min - params.rho * params.g * z_psi_soil_min / 1e6
+    if abs(psi_rc_lb_0 - psi_rc_ub_0) < 1:
+        psi_rc_lb_0 = psi_rc_ub_0 - 1
+
+    psi_rc_3_0 = np.array(
+        [psi_rc_ub_0, 0.5 * (psi_rc_ub_0 + psi_rc_lb_0), psi_rc_lb_0],
+        dtype=float,
+    )
+    e_3_0 = np.array([np.nan, np.nan, np.nan], dtype=float)
+
+    while (np.sum(e_3_0 < 0) == 0) or (np.sum(e_3_0 > 0) == 0):
+        for layer_idx in range(3):
+            res = e_from_soil_to_root_collar(
+                params=params.root_uptake,
+                psi_rc=float(psi_rc_3_0[layer_idx]),
+                psi_soil_by_layer=psi_soil_by_layer,
+                z_soil_mid=z_soil_mid,
+                dz=dz,
+                la=la,
+                c_r_h=c_r_h,
+                c_r_v=c_r_v,
+            )
+            e_3_0[layer_idx] = res.e
+
+        if np.sum(e_3_0 < 0) == 0:
+            psi_rc_3_0[0] = psi_rc_3_0[0] + 0.1
+        if np.sum(e_3_0 > 0) == 0:
+            psi_rc_3_0[2] = psi_rc_3_0[2] - 0.1
+        psi_rc_3_0[1] = 0.5 * (psi_rc_3_0[0] + psi_rc_3_0[2])
+
+    iteration = 0
+    while float(np.max(psi_rc_3_0) - np.min(psi_rc_3_0)) > 1e-3:
+        iteration += 1
+        if iteration > 100:
+            raise RuntimeError("Stomata bisection (E=0) did not converge")
+        if (np.sum(e_3_0 < 0) == 0) or (np.sum(e_3_0 > 0) == 0):
+            raise RuntimeError("Invalid bisection bounds for E=0")
+
+        e_ub_0 = float(np.max(e_3_0[e_3_0 < 0]))
+        e_lb_0 = float(np.min(e_3_0[e_3_0 > 0]))
+
+        psi_rc_ub_0 = float(np.max(psi_rc_3_0[e_3_0 == e_ub_0]))
+        psi_rc_lb_0 = float(np.min(psi_rc_3_0[e_3_0 == e_lb_0]))
+        psi_rc_m_0 = 0.5 * (psi_rc_ub_0 + psi_rc_lb_0)
+
+        psi_new = np.array([psi_rc_ub_0, psi_rc_m_0, psi_rc_lb_0], dtype=float)
+        if np.all(psi_new == psi_rc_3_0):
+            raise RuntimeError("Stomata bisection stalled")
+        psi_rc_3_0 = psi_new
+        e_3_0 = np.array([e_ub_0, np.nan, e_lb_0], dtype=float)
+
+        res_mid = e_from_soil_to_root_collar(
+            params=params.root_uptake,
+            psi_rc=float(psi_rc_3_0[1]),
+            psi_soil_by_layer=psi_soil_by_layer,
+            z_soil_mid=z_soil_mid,
+            dz=dz,
+            la=la,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+        )
+        e_3_0[1] = res_mid.e
+
+    e_0 = float(np.min(e_3_0[e_3_0 > 0]))
+    psi_rc_0 = float(np.min(psi_rc_3_0[e_3_0 == e_0]))
+
+    psi_l_crit = -1.0
+    while float(params.vc_l(psi_l_crit)) > (1 - 0.999):
+        psi_l_crit -= 0.1
+
+    psi_rc_3_crit = np.array(
+        [psi_rc_0, 0.5 * (psi_l_crit + psi_rc_0), psi_l_crit],
+        dtype=float,
+    )
+    psi_l_3_crit = np.full(3, np.nan, dtype=float)
+
+    for layer_idx in range(3):
+        psi_rc_i = float(psi_rc_3_crit[layer_idx])
+        res_e = e_from_soil_to_root_collar(
+            params=params.root_uptake,
+            psi_rc=psi_rc_i,
+            psi_soil_by_layer=psi_soil_by_layer,
+            z_soil_mid=z_soil_mid,
+            dz=dz,
+            la=la,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+        )
+        e_i = res_e.e
+
+        psi_l_i = psi_rc_i
+        for _ in range(n):
+            vc = float(params.vc_sw(min(0.0, psi_l_i)))
+            psi_l_i = (
+                psi_l_i
+                - params.rho * params.g * (h / n) / 1e6
+                - _safe_div((e_i * la), (n * k_sw_max * vc))
+            )
+        for _ in range(n):
+            vc = float(params.vc_l(min(0.0, psi_l_i)))
+            psi_l_i = psi_l_i - _safe_div(e_i, (n * params.k_l * vc))
+        psi_l_3_crit[layer_idx] = psi_l_i
+
+    iteration = 0
+    while float(np.max(psi_rc_3_crit) - np.min(psi_rc_3_crit)) > 1e-3:
+        iteration += 1
+        if iteration > 100:
+            raise RuntimeError("Stomata bisection (critical) did not converge")
+
+        f_obj = psi_l_crit - psi_l_3_crit
+        f_ub = float(np.max(f_obj[f_obj < 0]))
+        f_lb = float(np.min(f_obj[f_obj > 0]))
+        psi_rc_ub_crit = float(psi_rc_3_crit[f_obj == f_ub][0])
+        psi_rc_lb_crit = float(psi_rc_3_crit[f_obj == f_lb][0])
+        psi_rc_m_crit = 0.5 * (psi_rc_lb_crit + psi_rc_ub_crit)
+
+        psi_l_ub = float(psi_l_3_crit[psi_rc_3_crit == psi_rc_ub_crit][0])
+        psi_l_lb = float(psi_l_3_crit[psi_rc_3_crit == psi_rc_lb_crit][0])
+        psi_rc_3_crit = np.array(
+            [psi_rc_ub_crit, psi_rc_m_crit, psi_rc_lb_crit],
+            dtype=float,
+        )
+        psi_l_3_crit = np.array([psi_l_ub, np.nan, psi_l_lb], dtype=float)
+
+        psi_rc_i = float(psi_rc_3_crit[1])
+        res_e = e_from_soil_to_root_collar(
+            params=params.root_uptake,
+            psi_rc=psi_rc_i,
+            psi_soil_by_layer=psi_soil_by_layer,
+            z_soil_mid=z_soil_mid,
+            dz=dz,
+            la=la,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+        )
+        e_i = res_e.e
+
+        psi_l_i = psi_rc_i
+        for _ in range(n):
+            vc = float(params.vc_sw(min(0.0, psi_l_i)))
+            psi_l_i = (
+                psi_l_i
+                - params.rho * params.g * (h / n) / 1e6
+                - _safe_div((e_i * la), (n * k_sw_max * vc))
+            )
+        for _ in range(n):
+            vc = float(params.vc_l(min(0.0, psi_l_i)))
+            psi_l_i = psi_l_i - _safe_div(e_i, (n * params.k_l * vc))
+        psi_l_3_crit[1] = psi_l_i
+
+    psi_rc_crit = float(np.min(psi_rc_3_crit[psi_l_3_crit > -np.inf]))
+    if np.isnan(psi_rc_crit):
+        raise RuntimeError("Failed to determine critical psi_rc")
+
+    psi_rc_curve = np.linspace(psi_rc_0, psi_rc_crit, 50)
+    psi_s_curve = np.full_like(psi_rc_curve, np.nan, dtype=float)
+    psi_l_curve = np.full_like(psi_rc_curve, np.nan, dtype=float)
+    e_curve = np.full_like(psi_rc_curve, np.nan, dtype=float)
+    e_soil_curve = np.full((n_soil, psi_rc_curve.size), np.nan, dtype=float)
+    r_r_h_curve = np.full((n_soil, psi_rc_curve.size), np.nan, dtype=float)
+    r_r_v_curve = np.full((n_soil, psi_rc_curve.size), np.nan, dtype=float)
+    f_r_curve = np.full((n_soil, psi_rc_curve.size), np.nan, dtype=float)
+
+    psi_l_i = float(psi_l_3_crit[1])
+    for curve_idx, psi_rc_i in enumerate(psi_rc_curve):
+        res_uptake = e_from_soil_to_root_collar(
+            params=params.root_uptake,
+            psi_rc=float(psi_rc_i),
+            psi_soil_by_layer=psi_soil_by_layer,
+            z_soil_mid=z_soil_mid,
+            dz=dz,
+            la=la,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+        )
+
+        e_i = float(res_uptake.e)
+        e_curve[curve_idx] = e_i
+        e_soil_curve[:, curve_idx] = res_uptake.e_soil
+        r_r_h_curve[:, curve_idx] = res_uptake.r_r_h
+        r_r_v_curve[:, curve_idx] = res_uptake.r_r_v
+        f_r_curve[:, curve_idx] = res_uptake.f_r
+
+        psi_s_i = float(psi_rc_i)
+        for _ in range(n):
+            vc = float(params.vc_sw(min(0.0, psi_l_i)))
+            psi_s_i = (
+                psi_s_i
+                - params.rho * params.g * (h / n) / 1e6
+                - _safe_div((e_i * la), (n * k_sw_max * vc))
+            )
+        psi_s_curve[curve_idx] = psi_s_i
+
+        psi_l_i = psi_s_i
+        for _ in range(n):
+            vc = float(params.vc_l(min(0.0, psi_l_i)))
+            psi_l_i = psi_l_i - _safe_div(e_i, (n * params.k_l * vc))
+        psi_l_curve[curve_idx] = psi_l_i
+
+    t_l_curve = np.full_like(psi_l_curve, float(t_a), dtype=float)
+
+    satur_mf_air = -0.0043 + 0.01 * np.exp(0.0511 * t_a)
+    satur_mf_leaf = -0.0043 + 0.01 * np.exp(0.0511 * t_l_curve)
+    rh_use = min(rh, 0.99)
+    vpd_air = (1 - rh_use) * 0.61094 * np.exp(17.625 * t_a / (t_a + 243.04))
+    vpd_l = satur_mf_leaf - satur_mf_air + vpd_air
+    vpd_l = np.maximum(0.0, vpd_l)
+
+    g_w_curve = np.abs(e_curve / vpd_l)
+    g_w_curve = np.where(e_curve == 0, 0.0, g_w_curve)
+    g_w_curve = np.maximum(0.0, g_w_curve)
+    g_c_curve = g_w_curve / 1.6
+
+    v_cmax = params.v_cmax_func(t_l_curve)
+    j_max = params.j_max_func(t_l_curve)
+    j_phi = params.var_kappa * r_abs
+    j = (
+        j_max
+        + j_phi
+        - np.sqrt((j_max + j_phi) ** 2 - 4 * params.c_prime2 * j_max * j_phi)
+    ) / (2 * params.c_prime2)
+    gamma_star = params.gamma_star_func(t_l_curve)
+    k_c = params.k_c_func(t_l_curve)
+    k_o = params.k_o_func(t_l_curve)
+    r_d_curve = params.r_d_func(t_l_curve)
+
+    a_c = v_cmax
+    a_j = j / 4
+    b_c = k_c * (1 + params.o_a / k_o)
+    b_j = 2 * gamma_star
+    beta_c = (r_d_curve - a_c) - g_c_curve * (params.c_a + b_c)
+    beta_j = (r_d_curve - a_j) - g_c_curve * (params.c_a + b_j)
+    gamma_c = a_c * (params.c_a - gamma_star) - r_d_curve * (params.c_a + b_c)
+    gamma_j = a_j * (params.c_a - gamma_star) - r_d_curve * (params.c_a + b_j)
+
+    a_c_rate = -beta_c / 2 - np.sqrt((beta_c / 2) ** 2 - gamma_c * g_c_curve)
+    a_c_rate = np.real(a_c_rate)
+    a_j_rate = -beta_j / 2 - np.sqrt((beta_j / 2) ** 2 - gamma_j * g_c_curve)
+    a_j_rate = np.real(a_j_rate)
+
+    inf_mask = np.isinf(g_c_curve)
+    if np.any(inf_mask):
+        a_c_rate[inf_mask] = (
+            a_c[inf_mask] * (params.c_a - gamma_star[inf_mask]) / (params.c_a + b_c[inf_mask])
+            - r_d_curve[inf_mask]
+        )
+        a_j_rate[inf_mask] = (
+            a_j[inf_mask] * (params.c_a - gamma_star[inf_mask]) / (params.c_a + b_j[inf_mask])
+            - r_d_curve[inf_mask]
+        )
+
+    a_n_curve = (
+        a_c_rate
+        + a_j_rate
+        - np.sqrt((a_c_rate + a_j_rate) ** 2 - 4 * params.c_prime1 * a_c_rate * a_j_rate)
+    ) / (2 * params.c_prime1)
+
+    d_a_n_d_a_c = (
+        1
+        - (
+            a_c_rate + (1 - 2 * params.c_prime1) * a_j_rate
+        )
+        / np.sqrt((a_c_rate + a_j_rate) ** 2 - 4 * params.c_prime1 * a_c_rate * a_j_rate)
+    ) / (2 * params.c_prime1)
+    d_a_n_d_a_j = (
+        1
+        - (
+            a_j_rate + (1 - 2 * params.c_prime1) * a_c_rate
+        )
+        / np.sqrt((a_c_rate + a_j_rate) ** 2 - 4 * params.c_prime1 * a_c_rate * a_j_rate)
+    ) / (2 * params.c_prime1)
+
+    var_h = (j / 4 + g_c_curve * (params.c_a + 2 * gamma_star) - r_d_curve) / 2
+    d_a_j_d_j = (1 / 8) * (g_c_curve * (params.c_a - gamma_star)) / (var_h - a_j_rate)
+    d_a_j_d_j = np.where(
+        inf_mask,
+        1 / 4 * (params.c_a - gamma_star) / (params.c_a + b_j),
+        d_a_j_d_j,
+    )
+
+    d_j_d_j_phi = (
+        1
+        - (
+            j_phi + (1 - 2 * params.c_prime2) * j_max
+        )
+        / np.sqrt((j_max + j_phi) ** 2 - 4 * params.c_prime2 * j_max * j_phi)
+    ) / (2 * params.c_prime2)
+    d_a_n_d_r_abs_curve = d_a_n_d_a_j * d_a_j_d_j * d_j_d_j_phi * params.var_kappa
+
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        c_i = params.c_a - a_n_curve / g_c_curve
+        d_a_c_d_c_i = a_c * (gamma_star + b_c) / (c_i + b_c) ** 2
+        d_a_j_d_c_i = a_j * (gamma_star + b_j) / (c_i + b_j) ** 2
+        x_var = d_a_n_d_a_c * d_a_c_d_c_i + d_a_n_d_a_j * d_a_j_d_c_i
+        lambda_wue_curve = a_n_curve / e_curve * x_var / (x_var + g_c_curve)
+
+        f_sw = (
+            la
+            * e_curve
+            / (psi_rc_curve - psi_s_curve - params.rho * params.g * h / 1e6)
+            / k_sw_max
+        )
+        f_sw[0] = float(
+            np.mean(
+                np.minimum(
+                    1.0,
+                    params.vc_sw(
+                        np.linspace(float(psi_rc_curve[0]), float(psi_s_curve[0]), 10)
+                    ),
+                )
+            )
+        )
+        f_l = e_curve / (psi_s_curve - psi_l_curve) / params.k_l
+        f_l[0] = float(min(1.0, params.vc_l(min(0.0, float(psi_s_curve[0])))))
+
+    d_p = 1e-2
+    d_vc_r_d_psi_rc = (
+        params.vc_r(np.minimum(0.0, psi_rc_curve + d_p))
+        - params.vc_r(np.minimum(0.0, psi_rc_curve))
+    ) / d_p
+    d_vc_r_d_psi_soil = (
+        params.vc_r(np.minimum(0.0, psi_soil_by_layer + d_p))
+        - params.vc_r(np.minimum(0.0, psi_soil_by_layer))
+    ) / d_p
+    d_vc_r_d_psi_soil = np.repeat(d_vc_r_d_psi_soil[:, None], psi_rc_curve.size, axis=1)
+    d2_vc_r_d_psi_soil2 = (
+        params.vc_r(np.minimum(0.0, psi_soil_by_layer + d_p))
+        + params.vc_r(np.minimum(0.0, psi_soil_by_layer - d_p))
+        - 2 * params.vc_r(np.minimum(0.0, psi_soil_by_layer))
+    ) / d_p**2
+    d2_vc_r_d_psi_soil2 = np.repeat(
+        d2_vc_r_d_psi_soil2[:, None],
+        psi_rc_curve.size,
+        axis=1,
+    )
+
+    df_r_d_psi_rc = (
+        f_r_curve - params.vc_r(np.minimum(0.0, psi_rc_curve))
+    ) / (psi_soil_by_layer[:, None] - psi_rc_curve[None, :])
+    close_mask = np.abs(psi_rc_curve[None, :] - psi_soil_by_layer[:, None]) < 1e-2
+    df_r_d_psi_rc = np.where(close_mask, 0.5 * d_vc_r_d_psi_soil, df_r_d_psi_rc)
+
+    d2f_r_d_psi_rc2 = (2 * df_r_d_psi_rc - d_vc_r_d_psi_rc[None, :]) / (
+        psi_soil_by_layer[:, None] - psi_rc_curve[None, :]
+    )
+    close_mask2 = np.abs(psi_rc_curve[None, :] - psi_soil_by_layer[:, None]) < 1e-1
+    d2f_r_d_psi_rc2 = np.where(
+        close_mask2,
+        (1 / 3) * d2_vc_r_d_psi_soil2,
+        d2f_r_d_psi_rc2,
+    )
+
+    df_sw_d_psi_s = (f_sw - params.vc_sw(np.minimum(0.0, psi_s_curve))) / (
+        psi_rc_curve - psi_s_curve
+    )
+    df_sw_d_psi_rc = (params.vc_sw(np.minimum(0.0, psi_rc_curve)) - f_sw) / (
+        psi_rc_curve - psi_s_curve
+    )
+
+    r_r_v_sum = np.cumsum(r_r_v_curve, axis=0)
+    r_r = r_r_h_curve + r_r_v_sum
+
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        a_var = 1 - la * e_curve / (f_sw**2) / k_sw_max * df_sw_d_psi_s
+        b_var = 1 + la * e_curve / (f_sw**2) / k_sw_max * df_sw_d_psi_rc
+        c_var = np.sum(
+            (1 / la - e_soil_curve * r_r_h_curve / f_r_curve * df_r_d_psi_rc) / r_r,
+            axis=0,
+        )
+        d_var = params.vc_l(np.minimum(0.0, psi_s_curve)) / f_l
+        e_var = params.vc_l(np.minimum(0.0, psi_l_curve)) / f_l
+
+        k_canopy_curve = e_var / (
+            1 / f_l / params.k_l
+            + d_var / a_var * (b_var / c_var + la / f_sw / k_sw_max)
+        )
+
+    c0_var = float(c_var[0])
+    idx0 = int(np.argmin(np.abs(c_var - c0_var)))
+    psi_rc0 = float(psi_rc_curve[idx0])
+    f_sw0 = float(f_sw[idx0])
+    f_r0 = f_r_curve[:, idx0]
+    df_r0_d_psi_rc0 = df_r_d_psi_rc[:, idx0]
+    d2f_r0_d_psi_rc0 = d2f_r_d_psi_rc2[:, idx0]
+
+    psi_l0 = psi_rc0 - params.rho * params.g * h / 1e6
+    f_l0 = float(params.vc_l(min(0.0, psi_l0)))
+
+    e_soil0 = e_soil_curve[:, idx0]
+    r_r0 = r_r[:, idx0]
+    r_r_h0 = r_r_h_curve[:, idx0]
+    r_r_v0 = r_r_v_curve[:, idx0]
+
+    d_psi_rc0_d_c_r_h = 1 / c0_var / c_r_h * e_soil0 * r_r_h0 / r_r0
+    d_psi_rc0_d_c_r_v = (
+        1 / c0_var / c_r_v * _reverse_cumsum(e_soil0 * r_r_v0 / r_r0, axis=0)
+    )
+
+    k_canopy_max = 1 / (
+        1 / params.k_l / f_l0 + 1 / c0_var + la / f_sw0 / k_sw_max
+    )
+    if k_canopy_max < 0:
+        raise RuntimeError("Negative k_cmax")
+
+    df_l0_d_psi_rc0 = (
+        params.vc_l(min(0.0, psi_l0 + d_p)) - params.vc_l(min(0.0, psi_l0))
+    ) / d_p
+    df_l0_d_h = -params.rho * params.g / 1e6 * float(df_l0_d_psi_rc0)
+    df_sw0_d_psi_rc0 = (
+        params.vc_sw(min(0.0, psi_rc0)) - params.vc_sw(min(0.0, psi_l0))
+    ) / (params.rho * params.g * h / 1e6)
+    df_sw0_d_h = (params.vc_sw(min(0.0, psi_l0)) - f_sw0) / h
+
+    dk_canopy_max_d_d = k_canopy_max**2 * (
+        (
+            df_l0_d_h / params.k_l / (f_l0**2)
+            + la * df_sw0_d_h / k_sw_max / (f_sw0**2)
+        )
+        * d_h_d_d
+        + la / (k_sw_max**2) / f_sw0 * dk_sw_max_d_d
+    )
+    dk_canopy_max_d_la = k_canopy_max**2 * (
+        1 / k_sw_max / f_sw0 - 1 / (c0_var**2 * la**2) * float(np.sum(1 / r_r0))
+    )
+
+    dk_canopy_max_d_c_r_h = k_canopy_max**2 * (
+        (
+            df_l0_d_psi_rc0 / params.k_l / (f_l0**2)
+            + la * df_sw0_d_psi_rc0 / k_sw_max / (f_sw0**2)
+            + 1
+            / (c0_var**2)
+            * float(
+                np.sum(
+                    (
+                        (
+                            2
+                            * e_soil0
+                            / f_r0**2
+                            * r_r_h0
+                            / r_r0
+                            * df_r0_d_psi_rc0
+                        )
+                        + (
+                            r_r_h0
+                            / f_r0
+                            / r_r0**2
+                            * (
+                                1 / la
+                                - e_soil0 * r_r_h0 / f_r0 * df_r0_d_psi_rc0
+                            )
+                        )
+                    )
+                    * df_r0_d_psi_rc0
+                    - e_soil0
+                    / f_r0
+                    * r_r_h0
+                    / r_r0
+                    * d2f_r0_d_psi_rc0
+                )
+            )
+        )
+        * d_psi_rc0_d_c_r_h
+        + 1
+        / (c0_var**2)
+        / c_r_h
+        * (
+            r_r_h0
+            / (r_r0**2)
+            * (
+                e_soil0 * (r_r0 - r_r_h0) * df_r0_d_psi_rc0 / f_r0 + 1 / la
+            )
+        )
+    )
+
+    dk_canopy_max_d_c_r_v = k_canopy_max**2 * (
+        (
+            df_l0_d_psi_rc0 / params.k_l / (f_l0**2)
+            + la * df_sw0_d_psi_rc0 / k_sw_max / (f_sw0**2)
+            + 1
+            / (c0_var**2)
+            * float(
+                np.sum(
+                    (
+                        (
+                            2
+                            * e_soil0
+                            / f_r0**2
+                            * r_r_h0
+                            / r_r0
+                            * df_r0_d_psi_rc0
+                        )
+                        + (
+                            r_r_h0
+                            / f_r0
+                            / r_r0**2
+                            * (
+                                1 / la
+                                - e_soil0 * r_r_h0 / f_r0 * df_r0_d_psi_rc0
+                            )
+                        )
+                    )
+                    * df_r0_d_psi_rc0
+                    - e_soil0
+                    / f_r0
+                    * r_r_h0
+                    / r_r0
+                    * d2f_r0_d_psi_rc0
+                )
+            )
+        )
+        * d_psi_rc0_d_c_r_v
+        + 1
+        / (c0_var**2)
+        / c_r_v
+        * _reverse_cumsum(
+            r_r_v0
+            / (r_r0**2)
+            * (-e_soil0 * r_r_h0 * df_r0_d_psi_rc0 / f_r0 + 1 / la),
+            axis=0,
+        )
+    )
+
+    psi_lcrit = float(np.min(psi_l_curve[psi_l_curve > -np.inf]))
+    a_n_max = float(a_n_curve[psi_l_curve == psi_lcrit][0])
+    e_max = float(e_curve[psi_l_curve == psi_lcrit][0])
+    lambda_wue_crit = float(lambda_wue_curve[psi_l_curve == psi_lcrit][0])
+    d_a_n_d_r_abs_crit = float(d_a_n_d_r_abs_curve[psi_l_curve == psi_lcrit][0])
+
+    if a_n_max > 0:
+        f_obj = a_n_curve / a_n_max + k_canopy_curve / k_canopy_max
+        with np.errstate(invalid="ignore", divide="ignore"):
+            d_f_d_psi_l = np.diff(f_obj) / np.diff(psi_l_curve)
+        idx = 0
+        while True:
+            idx += 1
+            if idx >= d_f_d_psi_l.size:
+                raise RuntimeError("Failed to find stomatal optimum")
+            if d_f_d_psi_l[idx] >= 0 and g_w_curve[idx] >= params.g_wmin:
+                break
+    else:
+        idx = int(np.argmin(np.abs(g_w_curve - params.g_wmin)))
+
+    psi_l = float(psi_l_curve[idx])
+    psi_s = float(psi_s_curve[idx])
+    psi_rc = float(psi_rc_curve[idx])
+    a_n = float(a_n_curve[idx])
+    e = float(e_curve[idx])
+    g_w = float(g_w_curve[idx])
+    e_soil = e_soil_curve[:, idx]
+    k_canopy = float(k_canopy_curve[idx])
+    lambda_wue = float(lambda_wue_curve[idx])
+    d_a_n_d_r_abs = float(d_a_n_d_r_abs_curve[idx])
+    t_l = float(t_l_curve[idx])
+    r_d = float(r_d_curve[idx])
+    f_sw_opt = float(f_sw[idx])
+    f_l_opt = float(f_l[idx])
+    a_opt = float(a_var[idx])
+    b_opt = float(b_var[idx])
+    c_opt = float(c_var[idx])
+    d_opt = float(d_var[idx])
+    e_opt = float(e_var[idx])
+    r_r_opt = r_r[:, idx]
+    r_r_h_opt = r_r_h_curve[:, idx]
+    r_r_v_opt = r_r_v_curve[:, idx]
+
+    if lambda_wue < 0:
+        lambda_wue = 0.0
+
+    g_var = (
+        lambda_wue_crit
+        * k_canopy_max
+        * a_n
+        / (a_n_max**2)
+        * (psi_l0 - psi_l)
+        / (
+            1
+            + lambda_wue_crit
+            * k_canopy_max
+            * a_n
+            / (a_n_max**2)
+            * (psi_l - psi_lcrit)
+        )
+    )
+    h_var = (
+        k_canopy_max / k_canopy * a_n / a_n_max
+        - g_var * (1 + k_canopy_max / k_canopy * (1 - a_n / a_n_max))
+    )
+    i_var = e / k_canopy_max + a_n / a_n_max * (psi_l0 - psi_l) - g_var * (
+        (e_max - e) / k_canopy_max + a_n / a_n_max * (psi_l - psi_lcrit)
+    )
+
+    denom = (
+        1
+        / d_opt
+        * (
+            1 / f_l_opt / params.k_l
+            + e_opt / k_canopy * (1 + g_var) / (h_var - 1)
+        )
+        + 1 / a_opt * (b_opt / c_opt + la / f_sw_opt / k_sw_max)
+    )
+
+    d_e_d_d = (
+        (
+            -(1 / a_opt + e_opt / d_opt * k_canopy_max / k_canopy / (h_var - 1))
+            * params.rho
+            * params.g
+            / 1e6
+            * d_h_d_d
+            + e_opt
+            / d_opt
+            / (h_var - 1)
+            / k_canopy
+            * (
+                i_var * dk_canopy_max_d_d
+                - g_var
+                * d_a_n_d_r_abs_crit
+                / lambda_wue_crit
+                * (d_r_abs_d_h * d_h_d_d + d_r_abs_d_w * d_w_d_d)
+            )
+            + 1 / a_opt * la * e / f_sw_opt / (k_sw_max**2) * dk_sw_max_d_d
+        )
+        / denom
+    )
+
+    d_e_d_la = (
+        (
+            -e / a_opt * (b_opt / la / c_opt + 1 / f_sw_opt / k_sw_max)
+            + e_opt
+            / d_opt
+            / (h_var - 1)
+            / k_canopy
+            * (
+                i_var * dk_canopy_max_d_la
+                - g_var * d_a_n_d_r_abs_crit / lambda_wue_crit * d_r_abs_d_la
+            )
+        )
+        / denom
+    )
+
+    d_e_d_c_r_h = (
+        (
+            e_opt
+            / d_opt
+            / (h_var - 1)
+            / k_canopy
+            * (
+                i_var * dk_canopy_max_d_c_r_h + k_canopy_max * d_psi_rc0_d_c_r_h
+            )
+            + b_opt / a_opt / c_opt / c_r_h * e_soil * r_r_h_opt / r_r_opt
+        )
+        / denom
+    )
+    d_e_d_c_r_h = np.where(psi_soil_by_layer >= 0, 0.0, d_e_d_c_r_h)
+
+    d_e_d_c_r_v = (
+        (
+            e_opt
+            / d_opt
+            / (h_var - 1)
+            / k_canopy
+            * (
+                i_var * dk_canopy_max_d_c_r_v + k_canopy_max * d_psi_rc0_d_c_r_v
+            )
+            + b_opt
+            / a_opt
+            / c_opt
+            / c_r_v
+            * _reverse_cumsum(e_soil * r_r_v_opt / r_r_opt, axis=0)
+        )
+        / denom
+    )
+    d_e_d_c_r_v = np.where(psi_soil_by_layer >= 0, 0.0, d_e_d_c_r_v)
+
+    return StomataResult(
+        psi_l=psi_l,
+        psi_s=psi_s,
+        psi_rc=psi_rc,
+        psi_rc0=psi_rc0,
+        e=e,
+        e_soil=e_soil.astype(float),
+        a_n=a_n,
+        r_d=r_d,
+        t_l=t_l,
+        g_w=g_w,
+        lambda_wue=lambda_wue,
+        d_a_n_d_r_abs=d_a_n_d_r_abs,
+        d_e_d_la=float(d_e_d_la),
+        d_e_d_d=float(d_e_d_d),
+        d_e_d_c_r_h=d_e_d_c_r_h.astype(float),
+        d_e_d_c_r_v=d_e_d_c_r_v.astype(float),
     )

--- a/tests/test_thorp_stomata.py
+++ b/tests/test_thorp_stomata.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.hydraulics import (
+    RootUptakeParams,
+    StomataParams,
+    stomata,
+)
+from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+def _legacy_default_like_initialization_params() -> SoilInitializationParams:
+    return SoilInitializationParams(
+        rho=998.0,
+        g=9.81,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=SoilHydraulics(
+            n_vg=2.70,
+            alpha_vg=1.4642,
+            l_vg=0.5,
+            e_z_n=13.6,
+            e_z_k_s_sat=3.2,
+        ),
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+    )
+
+
+def _root_uptake_params() -> RootUptakeParams:
+    return RootUptakeParams(
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        rho=998.0,
+        g=9.81,
+    )
+
+
+def _v_cmax_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+    return 60e-6 * np.exp(8e4 * (t_l + 273.15 - 290) / 290 / 8.314 / (t_l + 273.15))
+
+
+def _j_max_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+    return 110e-6 * np.exp(8e4 * (t_l + 273.15 - 290) / 290 / 8.314 / (t_l + 273.15))
+
+
+def _gamma_star_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+    return 36e-6 * 101.325 * np.ones_like(t_l)
+
+
+def _k_c_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+    return 275e-6 * 101.325 * np.ones_like(t_l)
+
+
+def _k_o_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+    return 420000e-6 * 101.325 * np.ones_like(t_l)
+
+
+def _r_d_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+    return 0.01 * _v_cmax_func(t_l)
+
+
+def _stomata_params() -> StomataParams:
+    return StomataParams(
+        root_uptake=_root_uptake_params(),
+        g_wmin=0.0,
+        c_prime1=0.98,
+        c_prime2=0.90,
+        d_ref=1.0,
+        c0=0.6411,
+        c1=0.625,
+        b2=0.9253,
+        c2=0.9296,
+        k_l=1.6e-2,
+        vc_sw=WeibullVC(b=5.3151, c=0.7951),
+        vc_l=WeibullVC(b=0.8521, c=0.8067),
+        v_cmax_func=_v_cmax_func,
+        j_max_func=_j_max_func,
+        gamma_star_func=_gamma_star_func,
+        k_c_func=_k_c_func,
+        k_o_func=_k_o_func,
+        r_d_func=_r_d_func,
+        var_kappa=6.9e-7,
+        c_a=410e-6 * 101.325,
+        o_a=21.0,
+    )
+
+
+def test_stomata_exposes_expected_equation_ids() -> None:
+    assert implemented_equations(stomata) == (
+        "E_S3_6",
+        "E_S3_7",
+        "E_S3_10",
+        "E_S3_8",
+        "E_S3_9",
+        "E_S3_25",
+        "E_S3_26",
+        "E_S3_27",
+        "E_S3_32",
+        "E_S3_33",
+        "E_S3_34",
+        "E_S3_42",
+        "E_S3_49_to_55_raw",
+        "E_S4_7",
+        "E_S4_8",
+        "E_S6_1",
+        "E_S6_2",
+        "E_S6_3",
+        "E_S6_4",
+        "E_S6_5",
+        "E_S6_6",
+        "E_S6_7",
+        "E_S6_8",
+        "E_S6_9",
+        "E_S6_10",
+        "E_S6_11",
+        "E_S6_12",
+        "E_S6_13",
+        "E_S6_14",
+        "E_S6_15",
+        "E_S6_16",
+    )
+
+
+def test_stomata_matches_legacy_snapshot() -> None:
+    init = initial_soil_and_roots(
+        params=_legacy_default_like_initialization_params(),
+        c_r_i=1.0,
+        z_i=3.0,
+    )
+
+    res = stomata(
+        params=_stomata_params(),
+        psi_soil_by_layer=init.psi_soil_by_layer,
+        n_soil=init.grid.n_soil,
+        dz=init.grid.dz,
+        z_soil_mid=init.grid.z_mid,
+        t_a=23.0,
+        rh=0.58,
+        r_abs=290.0e-6,
+        la=2.8,
+        c_r_h=init.c_r_h,
+        c_r_v=init.c_r_v,
+        h=10.5,
+        w=3.535976267996335,
+        d=0.7842320847301608,
+        d_hw=0.64,
+        d_r_abs_d_h=1.1e-5,
+        d_r_abs_d_w=-8.2e-6,
+        d_r_abs_d_la=2.6e-5,
+    )
+
+    assert np.isclose(res.psi_l, -0.8274980142031351, rtol=1e-9)
+    assert np.isclose(res.psi_s, -0.827496735626728, rtol=1e-9)
+    assert np.isclose(res.psi_rc, -0.7246973862303405, rtol=1e-9)
+    assert np.isclose(res.psi_rc0, -0.7246973862303405, rtol=1e-9)
+    assert np.isclose(res.e, 7.703644892834487e-09, rtol=1e-9)
+    assert np.isclose(res.a_n, -1.219418508959284e-06, rtol=1e-9)
+    assert np.isclose(res.r_d, 1.195083222945812e-06, rtol=1e-9)
+    assert np.isclose(res.t_l, 23.0, rtol=1e-9)
+    assert np.isclose(res.g_w, 6.541808390458893e-09, rtol=1e-9)
+    assert np.isclose(res.lambda_wue, 0.0, rtol=1e-9)
+    assert np.isclose(res.d_a_n_d_r_abs, 2.2817941489360647e-11, rtol=1e-9)
+    assert np.isclose(res.d_e_d_la, -2.7445713912098153e-09, rtol=1e-9)
+    assert np.isclose(res.d_e_d_d, -3.397358164138639e-06, rtol=1e-9)
+    np.testing.assert_allclose(
+        res.e_soil,
+        np.array(
+            [
+                1.432971136938e-09,
+                1.392441640715e-09,
+                1.344244541986e-09,
+                1.255507471463e-09,
+                1.057259277751e-09,
+                7.150174988668e-10,
+                3.576286164287e-10,
+                1.214402756633e-10,
+                2.456715289698e-11,
+                2.468889989690e-12,
+                9.727299340486e-14,
+                1.114614399939e-15,
+                2.526855860153e-18,
+                6.692746635160e-22,
+                9.881711826538e-27,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.d_e_d_c_r_h,
+        np.array(
+            [
+                7.878613638396e-09,
+                7.887221289823e-09,
+                7.898989164590e-09,
+                7.915065047779e-09,
+                7.937002447692e-09,
+                7.966897118722e-09,
+                8.007542246888e-09,
+                8.062645841691e-09,
+                8.137038074135e-09,
+                8.236864632324e-09,
+                8.369638552822e-09,
+                8.543907276974e-09,
+                8.768029978072e-09,
+                9.047107191441e-09,
+                9.705827166129e-09,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.d_e_d_c_r_v,
+        np.array(
+            [
+                6.960067286759e-06,
+                3.960978855595e-08,
+                2.548304961295e-08,
+                2.619226573405e-08,
+                3.541508668020e-08,
+                4.314971183106e-08,
+                3.883815009087e-08,
+                2.917278094764e-08,
+                1.981111453478e-08,
+                1.242192501561e-08,
+                7.250790690462e-09,
+                3.997758129529e-09,
+                2.127873356901e-09,
+                1.113954269321e-09,
+                5.252315315750e-10,
+            ],
+            dtype=float,
+        ),
+        rtol=1e-9,
+    )
+
+
+def test_stomata_low_radiation_matches_legacy_snapshot() -> None:
+    init = initial_soil_and_roots(
+        params=_legacy_default_like_initialization_params(),
+        c_r_i=1.0,
+        z_i=3.0,
+    )
+
+    res = stomata(
+        params=_stomata_params(),
+        psi_soil_by_layer=init.psi_soil_by_layer,
+        n_soil=init.grid.n_soil,
+        dz=init.grid.dz,
+        z_soil_mid=init.grid.z_mid,
+        t_a=18.0,
+        rh=0.99,
+        r_abs=1.0e-9,
+        la=2.8,
+        c_r_h=init.c_r_h,
+        c_r_v=init.c_r_v,
+        h=10.5,
+        w=3.535976267996335,
+        d=0.7842320847301608,
+        d_hw=0.64,
+        d_r_abs_d_h=0.0,
+        d_r_abs_d_w=0.0,
+        d_r_abs_d_la=0.0,
+    )
+
+    assert np.isclose(res.g_w, 3.7401253245854565e-07, rtol=1e-9)
+    assert np.isclose(res.a_n, -6.978034670863326e-07, rtol=1e-9)
+    assert np.isclose(res.lambda_wue, 0.0, rtol=1e-9)
+    assert np.isclose(res.psi_l, -0.8274980142031351, rtol=1e-9)
+    assert np.isclose(res.d_a_n_d_r_abs, 2.242118058507526e-09, rtol=1e-9)


### PR DESCRIPTION
## Summary
- migrate the THORP `stomata` seam into the new package
- add bounded stomatal-closure parameter handling and regression tests
- document slice 009 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #11
