### PR TITLE
Migrate THORP allocation fractions seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ poetry run ruff check .
 - THORP `soil_moisture` is migrated as slice 007.
 - THORP `e_from_soil_to_root_collar` is migrated as slice 008.
 - THORP `stomata` is migrated as slice 009.
+- THORP `allocation_fractions` is migrated as slice 010.
 
 ## Next validation
-- Migrate the next THORP seam, likely `allocation_fractions`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `grow`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 009
-- Gate D. Bounded slices 001 through 009 approved for THORP
+- Gate C. Validation plan ready through slice 010
+- Gate D. Bounded slices 001 through 010 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -101,3 +101,9 @@ Slice 009:
 - target: `src/stomatal_optimiaztion/domains/thorp/hydraulics.py`
 - scope: bounded stomatal closure, gas-exchange coupling, and derivative bookkeeping
 - excluded: `allocation_fractions`, growth integration, and simulation orchestration
+
+Slice 010:
+- source: `THORP/src/thorp/allocation.py` (`allocation_fractions`)
+- target: `src/stomatal_optimiaztion/domains/thorp/allocation.py`
+- scope: bounded carbon-allocation scoring and fraction normalization
+- excluded: `grow`, whole-plant growth-state updates, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -116,8 +116,16 @@ The ninth slice ports the next coupled hydraulics and gas-exchange seam:
 - keep the interface bounded by a minimal `StomataParams` dataclass
 - leave `allocation_fractions` blocked as the next plant-growth seam
 
+## Slice 010: THORP Allocation Fractions
+
+The tenth slice ports the next bounded plant-growth seam:
+- move `allocation_fractions` from `allocation.py` into a dedicated THORP allocation module
+- reuse migrated stomatal derivative outputs without pulling in full growth state integration
+- keep the interface bounded by a minimal `AllocationParams` dataclass
+- leave `grow` blocked as the next growth-state seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, and stomata seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, and allocation seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `allocation_fractions` or another bounded plant-growth seam
+3. prepare the next THORP source audit for `grow` or another bounded growth-state seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 009 implementation and validation
+- Current phase: slice 010 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP stomata slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `allocation_fractions`
+1. validate the migrated THORP allocation slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `grow`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-009-thorp-stomata.md
+++ b/docs/architecture/architecture/module_specs/module-009-thorp-stomata.md
@@ -33,4 +33,4 @@ Migrate the bounded `stomata` seam so the new package can close coupled hydrauli
 
 ## Next Seam
 
-- `allocation_fractions` from `allocation.py`
+- `grow` from `growth.py`

--- a/docs/architecture/architecture/module_specs/module-010-thorp-allocation-fractions.md
+++ b/docs/architecture/architecture/module_specs/module-010-thorp-allocation-fractions.md
@@ -1,0 +1,36 @@
+# Module Spec 010: THORP Allocation Fractions
+
+## Purpose
+
+Migrate the bounded `allocation_fractions` seam so the new package can convert migrated stomatal outputs into plant carbon allocation fractions.
+
+## Source Inputs
+
+- `THORP/src/thorp/allocation.py` (`allocation_fractions`)
+- migrated dependencies: stomatal derivative outputs
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/allocation.py`
+- `tests/test_thorp_allocation.py`
+
+## Responsibilities
+
+1. preserve bounded carbon-allocation scoring and normalization logic
+2. keep equation tags for `E_S8_1` through `E_S8_12`
+3. expose a minimal parameter dataclass instead of porting full `THORPParams`
+
+## Non-Goals
+
+- port `grow` from `growth.py`
+- port whole-plant carbon state integration
+- merge allocation and growth into one abstraction
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `grow` from `growth.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only eight THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only nine THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -1,3 +1,8 @@
+from stomatal_optimiaztion.domains.thorp.allocation import (
+    AllocationFractions,
+    AllocationParams,
+    allocation_fractions,
+)
 from stomatal_optimiaztion.domains.thorp.hydraulics import (
     RootUptakeParams,
     RootUptakeResult,
@@ -30,6 +35,8 @@ from stomatal_optimiaztion.domains.thorp.soil_initialization import (
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 __all__ = [
+    "AllocationFractions",
+    "AllocationParams",
     "BottomBoundaryCondition",
     "InitialSoilAndRoots",
     "RadiationResult",
@@ -43,6 +50,7 @@ __all__ = [
     "SoilInitializationParams",
     "SoilMoistureParams",
     "WeibullVC",
+    "allocation_fractions",
     "e_from_soil_to_root_collar",
     "equation_id_set",
     "initial_soil_and_roots",

--- a/src/stomatal_optimiaztion/domains/thorp/allocation.py
+++ b/src/stomatal_optimiaztion/domains/thorp/allocation.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.implements import implements
+
+
+MaintenanceRespiration = Callable[[float | NDArray[np.floating]], float | NDArray[np.floating]]
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationParams:
+    sla: float
+    r_m_sw_func: MaintenanceRespiration
+    r_m_r_func: MaintenanceRespiration
+    tau_l: float
+    tau_sw: float
+    tau_r: float
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationFractions:
+    u_l: float
+    u_r_h: NDArray[np.floating]
+    u_r_v: NDArray[np.floating]
+    u_sw: float
+
+
+@implements(
+    "E_S8_1",
+    "E_S8_2",
+    "E_S8_3",
+    "E_S8_4",
+    "E_S8_5",
+    "E_S8_6",
+    "E_S8_7",
+    "E_S8_8",
+    "E_S8_9",
+    "E_S8_10",
+    "E_S8_11",
+    "E_S8_12",
+)
+def allocation_fractions(
+    *,
+    params: AllocationParams,
+    a_n: float,
+    lambda_wue: float,
+    d_a_n_d_r_abs: float,
+    d_e_d_la: float,
+    d_e_d_d: float,
+    d_e_d_c_r_h: NDArray[np.floating],
+    d_e_d_c_r_v: NDArray[np.floating],
+    d_r_abs_d_h: float,
+    d_r_abs_d_w: float,
+    d_r_abs_d_la: float,
+    h: float,
+    w: float,
+    d: float,
+    c_w: float,
+    c_l: float,
+    c0: float,
+    c1: float,
+    t_a: float,
+    t_soil: float,
+) -> AllocationFractions:
+    if c_l == 0:
+        return AllocationFractions(
+            u_l=1.0,
+            u_r_h=np.zeros_like(d_e_d_c_r_h, dtype=float),
+            u_r_v=np.zeros_like(d_e_d_c_r_v, dtype=float),
+            u_sw=0.0,
+        )
+
+    la = c_l * params.sla
+
+    d_h_d_d = c0 * h / d
+    d_w_d_d = c1 * w / d
+    d_d_d_c_w = d / c_w / (2 + c0)
+
+    r_m_sw = float(params.r_m_sw_func(t_a))
+    r_m_r = float(params.r_m_r_func(t_soil))
+
+    d_gain_d_c_l = params.sla * (
+        a_n + la * (lambda_wue * d_e_d_la + d_a_n_d_r_abs * d_r_abs_d_la)
+    )
+    d_gain_d_c_l = float(max(0.0, d_gain_d_c_l))
+
+    d_gain_d_c_r_h = la * lambda_wue * d_e_d_c_r_h - r_m_r
+    d_gain_d_c_r_h = np.maximum(0.0, d_gain_d_c_r_h)
+
+    d_gain_d_c_r_v = la * lambda_wue * d_e_d_c_r_v - r_m_r
+    d_gain_d_c_r_v = np.maximum(0.0, d_gain_d_c_r_v)
+
+    d_gain_d_c_sw = (
+        la
+        * (
+            lambda_wue * d_e_d_d
+            + (d_r_abs_d_h * d_h_d_d + d_r_abs_d_w * d_w_d_d) * d_a_n_d_r_abs
+        )
+        * d_d_d_c_w
+        - r_m_sw
+    )
+    d_gain_d_c_sw = float(max(0.0, d_gain_d_c_sw))
+
+    d_cost_d_c_l = 1.0 / params.tau_l
+    d_cost_d_c_r = 1.0 / params.tau_r
+    d_cost_d_c_sw = 1.0 / params.tau_sw
+
+    u_l_raw = d_gain_d_c_l / d_cost_d_c_l
+    u_r_h_raw = d_gain_d_c_r_h / d_cost_d_c_r
+    u_r_v_raw = d_gain_d_c_r_v / d_cost_d_c_r
+    u_sw_raw = d_gain_d_c_sw / d_cost_d_c_sw
+
+    sum_u = float(u_l_raw + u_sw_raw + np.sum(u_r_h_raw + u_r_v_raw))
+    if sum_u > 0:
+        return AllocationFractions(
+            u_l=float(u_l_raw / sum_u),
+            u_r_h=(u_r_h_raw / sum_u).astype(float),
+            u_r_v=(u_r_v_raw / sum_u).astype(float),
+            u_sw=float(u_sw_raw / sum_u),
+        )
+    if sum_u == 0:
+        return AllocationFractions(
+            u_l=float("nan"),
+            u_r_h=np.full_like(d_e_d_c_r_h, np.nan, dtype=float),
+            u_r_v=np.full_like(d_e_d_c_r_v, np.nan, dtype=float),
+            u_sw=float("nan"),
+        )
+    raise RuntimeError("Unexpected allocation sum")

--- a/tests/test_thorp_allocation.py
+++ b/tests/test_thorp_allocation.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.allocation import (
+    AllocationParams,
+    allocation_fractions,
+)
+from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
+
+
+def _r_m_sw_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
+    return 2.2e-12 * 1.8 ** ((np.asarray(t) - 15.0) / 10.0)
+
+
+def _r_m_r_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
+    return 7.0e-9 * 1.98 ** ((np.asarray(t) - 15.0) / 10.0)
+
+
+def _allocation_params() -> AllocationParams:
+    return AllocationParams(
+        sla=0.08,
+        r_m_sw_func=_r_m_sw_func,
+        r_m_r_func=_r_m_r_func,
+        tau_l=9.5e7,
+        tau_sw=1.2e9,
+        tau_r=9.6e7,
+    )
+
+
+def test_allocation_fractions_exposes_expected_equation_ids() -> None:
+    assert implemented_equations(allocation_fractions) == (
+        "E_S8_1",
+        "E_S8_2",
+        "E_S8_3",
+        "E_S8_4",
+        "E_S8_5",
+        "E_S8_6",
+        "E_S8_7",
+        "E_S8_8",
+        "E_S8_9",
+        "E_S8_10",
+        "E_S8_11",
+        "E_S8_12",
+    )
+
+
+def test_allocation_fractions_matches_legacy_snapshot() -> None:
+    res = allocation_fractions(
+        params=_allocation_params(),
+        a_n=2.0e-4,
+        lambda_wue=8.0e3,
+        d_a_n_d_r_abs=5.0e-4,
+        d_e_d_la=4.0e-7,
+        d_e_d_d=1.0e-6,
+        d_e_d_c_r_h=np.array([4.0e-7, 7.0e-7, 9.0e-7], dtype=float),
+        d_e_d_c_r_v=np.array([3.0e-7, 5.0e-7, 8.0e-7], dtype=float),
+        d_r_abs_d_h=5.0e-3,
+        d_r_abs_d_w=-2.0e-3,
+        d_r_abs_d_la=8.0e-3,
+        h=9.0,
+        w=3.0,
+        d=0.7,
+        c_w=1800.0,
+        c_l=30.0,
+        c0=0.6411,
+        c1=0.625,
+        t_a=25.0,
+        t_soil=20.0,
+    )
+
+    assert np.isclose(res.u_l, 0.008950899416306649, rtol=1e-9)
+    np.testing.assert_allclose(
+        res.u_r_h,
+        np.array([0.110060123417, 0.192605321847, 0.247635454133], dtype=float),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.u_r_v,
+        np.array([0.082545057274, 0.13757518956, 0.22012038799], dtype=float),
+        rtol=1e-9,
+    )
+    assert np.isclose(res.u_sw, 0.0005075663633865423, rtol=1e-9)
+    assert np.isclose(res.u_l + np.sum(res.u_r_h) + np.sum(res.u_r_v) + res.u_sw, 1.0, rtol=1e-9)
+
+
+def test_allocation_fractions_zero_leaf_matches_legacy_behavior() -> None:
+    res = allocation_fractions(
+        params=_allocation_params(),
+        a_n=1.0e-6,
+        lambda_wue=0.2,
+        d_a_n_d_r_abs=1.0e-9,
+        d_e_d_la=2.0e-9,
+        d_e_d_d=3.0e-9,
+        d_e_d_c_r_h=np.array([1.0e-9, 2.0e-9], dtype=float),
+        d_e_d_c_r_v=np.array([3.0e-9, 4.0e-9], dtype=float),
+        d_r_abs_d_h=5.0e-6,
+        d_r_abs_d_w=6.0e-6,
+        d_r_abs_d_la=7.0e-6,
+        h=5.0,
+        w=2.0,
+        d=0.5,
+        c_w=100.0,
+        c_l=0.0,
+        c0=0.6,
+        c1=0.5,
+        t_a=20.0,
+        t_soil=18.0,
+    )
+
+    assert res.u_l == 1.0
+    np.testing.assert_allclose(res.u_r_h, np.zeros(2, dtype=float))
+    np.testing.assert_allclose(res.u_r_v, np.zeros(2, dtype=float))
+    assert res.u_sw == 0.0
+
+
+def test_allocation_fractions_zero_sum_matches_legacy_behavior() -> None:
+    res = allocation_fractions(
+        params=_allocation_params(),
+        a_n=-1.0e-6,
+        lambda_wue=0.0,
+        d_a_n_d_r_abs=0.0,
+        d_e_d_la=0.0,
+        d_e_d_d=0.0,
+        d_e_d_c_r_h=np.zeros(3, dtype=float),
+        d_e_d_c_r_v=np.zeros(3, dtype=float),
+        d_r_abs_d_h=0.0,
+        d_r_abs_d_w=0.0,
+        d_r_abs_d_la=0.0,
+        h=8.0,
+        w=2.5,
+        d=0.6,
+        c_w=1200.0,
+        c_l=20.0,
+        c0=0.6411,
+        c1=0.625,
+        t_a=22.0,
+        t_soil=18.0,
+    )
+
+    assert np.isnan(res.u_l)
+    np.testing.assert_allclose(
+        res.u_r_h,
+        np.array([np.nan, np.nan, np.nan], dtype=float),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        res.u_r_v,
+        np.array([np.nan, np.nan, np.nan], dtype=float),
+        equal_nan=True,
+    )
+    assert np.isnan(res.u_sw)


### PR DESCRIPTION
## Summary
- migrate the THORP `allocation_fractions` seam into the new package
- add bounded allocation parameter handling and regression tests
- document slice 010 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #13
