### PR TITLE
Migrate THORP grow seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ poetry run ruff check .
 - THORP `e_from_soil_to_root_collar` is migrated as slice 008.
 - THORP `stomata` is migrated as slice 009.
 - THORP `allocation_fractions` is migrated as slice 010.
+- THORP `grow` is migrated as slice 011.
 
 ## Next validation
-- Migrate the next THORP seam, likely `grow`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `biomass_fractions`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 010
-- Gate D. Bounded slices 001 through 010 approved for THORP
+- Gate C. Validation plan ready through slice 011
+- Gate D. Bounded slices 001 through 011 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -107,3 +107,9 @@ Slice 010:
 - target: `src/stomatal_optimiaztion/domains/thorp/allocation.py`
 - scope: bounded carbon-allocation scoring and fraction normalization
 - excluded: `grow`, whole-plant growth-state updates, and simulation orchestration
+
+Slice 011:
+- source: `THORP/src/thorp/growth.py` (`GrowthState`, `grow`)
+- target: `src/stomatal_optimiaztion/domains/thorp/growth.py`
+- scope: bounded growth-state updates, senescence, and geometry reconstruction
+- excluded: `biomass_fractions`, reporting helpers, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -124,8 +124,16 @@ The tenth slice ports the next bounded plant-growth seam:
 - keep the interface bounded by a minimal `AllocationParams` dataclass
 - leave `grow` blocked as the next growth-state seam
 
+## Slice 011: THORP Grow
+
+The eleventh slice ports the next bounded growth-state seam:
+- move `grow` from `growth.py` into a dedicated THORP growth module
+- reuse migrated allocation outputs without pulling in the full simulation loop
+- keep the interface bounded by a minimal `GrowthParams` dataclass
+- leave `biomass_fractions` blocked as the next reporting seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, and allocation seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, and grow seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `grow` or another bounded growth-state seam
+3. prepare the next THORP source audit for `biomass_fractions` or another bounded reporting seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 010 implementation and validation
+- Current phase: slice 011 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP allocation slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `grow`
+1. validate the migrated THORP grow slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `biomass_fractions`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-010-thorp-allocation-fractions.md
+++ b/docs/architecture/architecture/module_specs/module-010-thorp-allocation-fractions.md
@@ -33,4 +33,4 @@ Migrate the bounded `allocation_fractions` seam so the new package can convert m
 
 ## Next Seam
 
-- `grow` from `growth.py`
+- `biomass_fractions` from `metrics.py`

--- a/docs/architecture/architecture/module_specs/module-011-thorp-grow.md
+++ b/docs/architecture/architecture/module_specs/module-011-thorp-grow.md
@@ -1,0 +1,36 @@
+# Module Spec 011: THORP Grow
+
+## Purpose
+
+Migrate the bounded `grow` seam so the new package can update THORP structural carbon pools and derived geometry from migrated allocation outputs.
+
+## Source Inputs
+
+- `THORP/src/thorp/growth.py` (`GrowthState`, `grow`)
+- migrated dependencies: `AllocationFractions`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/growth.py`
+- `tests/test_thorp_growth.py`
+
+## Responsibilities
+
+1. preserve bounded growth-state updates, senescence handling, and geometry reconstruction
+2. keep equation tags for `E_S7_1` through `E_S9_9`
+3. expose a minimal parameter dataclass instead of porting full `THORPParams`
+
+## Non-Goals
+
+- port `biomass_fractions` or other reporting helpers from `metrics.py`
+- port the full simulation loop
+- merge growth, allocation, and metrics into one abstraction
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `biomass_fractions` from `metrics.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only nine THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only ten THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -3,6 +3,11 @@ from stomatal_optimiaztion.domains.thorp.allocation import (
     AllocationParams,
     allocation_fractions,
 )
+from stomatal_optimiaztion.domains.thorp.growth import (
+    GrowthParams,
+    GrowthState,
+    grow,
+)
 from stomatal_optimiaztion.domains.thorp.hydraulics import (
     RootUptakeParams,
     RootUptakeResult,
@@ -38,6 +43,8 @@ __all__ = [
     "AllocationFractions",
     "AllocationParams",
     "BottomBoundaryCondition",
+    "GrowthParams",
+    "GrowthState",
     "InitialSoilAndRoots",
     "RadiationResult",
     "RichardsEquationParams",
@@ -53,6 +60,7 @@ __all__ = [
     "allocation_fractions",
     "e_from_soil_to_root_collar",
     "equation_id_set",
+    "grow",
     "initial_soil_and_roots",
     "iter_equation_refs",
     "model_card_document_names",

--- a/src/stomatal_optimiaztion/domains/thorp/growth.py
+++ b/src/stomatal_optimiaztion/domains/thorp/growth.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.allocation import AllocationParams
+from stomatal_optimiaztion.domains.thorp.implements import implements
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthParams:
+    allocation: AllocationParams
+    dt: float
+    f_c: float
+    rho_cw: float
+    xi: float
+    b0: float
+    d_ref: float
+    c0: float
+    b1: float
+    c1: float
+
+    @property
+    def sla(self) -> float:
+        return self.allocation.sla
+
+    @property
+    def tau_l(self) -> float:
+        return self.allocation.tau_l
+
+    @property
+    def tau_r(self) -> float:
+        return self.allocation.tau_r
+
+    @property
+    def tau_sw(self) -> float:
+        return self.allocation.tau_sw
+
+    def r_m_sw(self, t_a: float) -> float:
+        return float(self.allocation.r_m_sw_func(t_a))
+
+    def r_m_r(self, t_soil: float) -> float:
+        return float(self.allocation.r_m_r_func(t_soil))
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthState:
+    c_l: float
+    c_r_h: NDArray[np.floating]
+    c_r_v: NDArray[np.floating]
+    c_sw: float
+    c_hw: float
+    c_nsc: float
+    r_m: float
+    u: float
+    la: float
+    h: float
+    w: float
+    d: float
+    d_hw: float
+
+    @property
+    def c_w(self) -> float:
+        return float(self.c_sw + self.c_hw)
+
+
+@implements(
+    "E_S7_1",
+    "E_S7_2",
+    "E_S7_3",
+    "E_S7_4",
+    "E_S7_5",
+    "E_S9_1",
+    "E_S9_2",
+    "E_S9_3",
+    "E_S9_4",
+    "E_S9_5",
+    "E_S9_6",
+    "E_S9_7",
+    "E_S9_8",
+    "E_S9_9",
+)
+def grow(
+    *,
+    params: GrowthParams,
+    u_l: float,
+    u_r_h: NDArray[np.floating],
+    u_r_v: NDArray[np.floating],
+    u_sw: float,
+    a_n: float,
+    r_d: float,
+    c_l: float,
+    c_r_h: NDArray[np.floating],
+    c_r_v: NDArray[np.floating],
+    c_sw: float,
+    c_hw: float,
+    c_nsc: float,
+    t_a: float,
+    t_soil: float,
+) -> GrowthState:
+    s_l = c_l / params.tau_l
+    s_r_h = c_r_h / params.tau_r
+    s_r_v = c_r_v / params.tau_r
+    s_sw = c_sw / params.tau_sw
+
+    la = params.sla * c_l
+    c_r = c_r_h + c_r_v
+
+    r_m = la * r_d + float(np.sum(c_r)) * params.r_m_r(t_soil) + c_sw * params.r_m_sw(t_a)
+    a_g = a_n + r_d
+
+    u = 1e-7 * c_nsc
+    u_mod_t = 1.0 / (1.0 + np.exp(-0.185 * (t_a - 18.4)))
+    if t_a < 0:
+        u_mod_t = 0.0
+    u = float(u * u_mod_t)
+
+    nan_count = int(np.sum(np.isnan(np.concatenate([[u_l, u_sw], (u_r_h + u_r_v)]))))
+    if nan_count == (u_r_h.size + 2):
+        u = 0.0
+        u_l = 0.0
+        u_r_h = np.zeros_like(u_r_h, dtype=float)
+        u_r_v = np.zeros_like(u_r_v, dtype=float)
+        u_sw = 0.0
+    elif nan_count > 0:
+        raise RuntimeError("Invalid allocation fractions (partial NaNs)")
+
+    g_rate = u * (1 - params.f_c)
+
+    c_l = c_l + params.dt * (u_l * g_rate - s_l)
+    c_r_h = c_r_h + params.dt * (u_r_h * g_rate - s_r_h)
+    c_r_v = c_r_v + params.dt * (u_r_v * g_rate - s_r_v)
+    c_sw = c_sw + params.dt * (u_sw * g_rate - s_sw)
+    c_hw = c_hw + params.dt * s_sw
+    c_nsc = c_nsc + params.dt * (la * a_g - r_m - u)
+
+    if c_l < 0:
+        raise RuntimeError("negative leaf carbon")
+    if np.any(c_r_h < 0):
+        raise RuntimeError("negative lateral root carbon")
+    if np.any(c_r_v < 0):
+        raise RuntimeError("negative vertical root carbon")
+    if c_sw < 0:
+        raise RuntimeError("negative sapwood carbon")
+    if c_nsc < 0:
+        raise RuntimeError("negative NSC")
+    if np.any(np.isnan(np.concatenate([[c_l, c_sw, c_nsc], c_r_h]))):
+        raise RuntimeError("NaNs in growth state")
+
+    c_w = c_sw + c_hw
+    d = float(
+        (
+            c_w
+            / (params.rho_cw * params.xi * params.b0 * (params.d_ref ** (-params.c0)))
+        )
+        ** (1 / (2 + params.c0))
+    )
+    h = float(params.b0 * (d / params.d_ref) ** params.c0)
+    w = float(params.b1 * (d / params.d_ref) ** params.c1)
+    d_hw = float((c_hw / (params.rho_cw * params.xi * h)) ** 0.5)
+    la = float(params.sla * c_l)
+
+    return GrowthState(
+        c_l=float(c_l),
+        c_r_h=c_r_h.astype(float),
+        c_r_v=c_r_v.astype(float),
+        c_sw=float(c_sw),
+        c_hw=float(c_hw),
+        c_nsc=float(c_nsc),
+        r_m=float(r_m),
+        u=float(u),
+        la=la,
+        h=h,
+        w=w,
+        d=d,
+        d_hw=d_hw,
+    )

--- a/tests/test_thorp_growth.py
+++ b/tests/test_thorp_growth.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.allocation import AllocationParams
+from stomatal_optimiaztion.domains.thorp.growth import GrowthParams, grow
+from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
+
+
+def _r_m_sw_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
+    return 2.2e-12 * 1.8 ** ((np.asarray(t) - 15.0) / 10.0)
+
+
+def _r_m_r_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
+    return 7.0e-9 * 1.98 ** ((np.asarray(t) - 15.0) / 10.0)
+
+
+def _growth_params() -> GrowthParams:
+    return GrowthParams(
+        allocation=AllocationParams(
+            sla=0.08,
+            r_m_sw_func=_r_m_sw_func,
+            r_m_r_func=_r_m_r_func,
+            tau_l=9.5e7,
+            tau_sw=1.2e9,
+            tau_r=9.6e7,
+        ),
+        dt=6 * 3600.0,
+        f_c=0.28,
+        rho_cw=1.4e4,
+        xi=0.5,
+        b0=64.6,
+        d_ref=1.0,
+        c0=0.6411,
+        b1=8.5,
+        c1=0.625,
+    )
+
+
+def test_grow_exposes_expected_equation_ids() -> None:
+    assert implemented_equations(grow) == (
+        "E_S7_1",
+        "E_S7_2",
+        "E_S7_3",
+        "E_S7_4",
+        "E_S7_5",
+        "E_S9_1",
+        "E_S9_2",
+        "E_S9_3",
+        "E_S9_4",
+        "E_S9_5",
+        "E_S9_6",
+        "E_S9_7",
+        "E_S9_8",
+        "E_S9_9",
+    )
+
+
+def test_grow_matches_legacy_snapshot() -> None:
+    res = grow(
+        params=_growth_params(),
+        u_l=0.008950899416306649,
+        u_r_h=np.array([0.110060123417, 0.192605321847, 0.247635454133], dtype=float),
+        u_r_v=np.array([0.082545057274, 0.13757518956, 0.22012038799], dtype=float),
+        u_sw=0.0005075663633865423,
+        a_n=2.0e-4,
+        r_d=1.2e-6,
+        c_l=30.0,
+        c_r_h=np.array([5.0, 7.0, 9.0], dtype=float),
+        c_r_v=np.array([3.0, 4.0, 6.0], dtype=float),
+        c_sw=1200.0,
+        c_hw=800.0,
+        c_nsc=50.0,
+        t_a=25.0,
+        t_soil=20.0,
+    )
+
+    assert np.isclose(res.c_l, 29.993716442990433, rtol=1e-9)
+    np.testing.assert_allclose(
+        res.c_r_h,
+        np.array([5.005484038013, 7.00999082288, 9.012845346125], dtype=float),
+        rtol=1e-9,
+    )
+    np.testing.assert_allclose(
+        res.c_r_v,
+        np.array([3.004281776391, 4.007361299636, 6.011868084503], dtype=float),
+        rtol=1e-9,
+    )
+    assert np.isclose(res.c_sw, 1199.9784304790262, rtol=1e-9)
+    assert np.isclose(res.c_hw, 800.0216, rtol=1e-9)
+    assert np.isclose(res.c_nsc, 60.277261745837585, rtol=1e-9)
+    assert np.isclose(res.r_m, 3.2196476852513927e-06, rtol=1e-9)
+    assert np.isclose(res.u, 3.861197414860456e-06, rtol=1e-9)
+    assert np.isclose(res.la, 2.3994973154392345, rtol=1e-9)
+    assert np.isclose(res.h, 17.328068193518018, rtol=1e-9)
+    assert np.isclose(res.w, 2.356612855934848, rtol=1e-9)
+    assert np.isclose(res.d, 0.1284076526429208, rtol=1e-9)
+    assert np.isclose(res.d_hw, 0.08121322600700721, rtol=1e-9)
+    assert np.isclose(res.c_w, 2000.0000304790262, rtol=1e-9)
+
+
+def test_grow_all_nan_allocation_matches_legacy_behavior() -> None:
+    res = grow(
+        params=_growth_params(),
+        u_l=float("nan"),
+        u_r_h=np.array([float("nan"), float("nan")], dtype=float),
+        u_r_v=np.array([float("nan"), float("nan")], dtype=float),
+        u_sw=float("nan"),
+        a_n=0.0,
+        r_d=1.0e-6,
+        c_l=20.0,
+        c_r_h=np.array([2.0, 3.0], dtype=float),
+        c_r_v=np.array([1.0, 1.5], dtype=float),
+        c_sw=500.0,
+        c_hw=300.0,
+        c_nsc=40.0,
+        t_a=10.0,
+        t_soil=8.0,
+    )
+
+    assert np.isclose(res.c_l, 19.995452631578946, rtol=1e-9)
+    np.testing.assert_allclose(res.c_r_h, np.array([1.99955, 2.999325], dtype=float), rtol=1e-9)
+    np.testing.assert_allclose(res.c_r_v, np.array([0.999775, 1.4996625], dtype=float), rtol=1e-9)
+    assert np.isclose(res.c_sw, 499.991, rtol=1e-9)
+    assert np.isclose(res.c_hw, 300.009, rtol=1e-9)
+    assert np.isclose(res.c_nsc, 39.99927930313527, rtol=1e-9)
+    assert np.isclose(res.r_m, 1.6333655955893297e-06, rtol=1e-9)
+    assert np.isclose(res.u, 0.0, rtol=1e-9)
+    assert np.isclose(res.la, 1.5996362105263158, rtol=1e-9)
+    assert np.isclose(res.h, 13.872485566353639, rtol=1e-9)
+    assert np.isclose(res.w, 1.8972221926169024, rtol=1e-9)
+    assert np.isclose(res.d, 0.09076508792150462, rtol=1e-9)
+    assert np.isclose(res.d_hw, 0.055582871690951344, rtol=1e-9)
+
+
+def test_grow_partial_nan_allocation_raises() -> None:
+    try:
+        grow(
+            params=_growth_params(),
+            u_l=float("nan"),
+            u_r_h=np.array([0.1, 0.2], dtype=float),
+            u_r_v=np.array([0.1, 0.2], dtype=float),
+            u_sw=0.3,
+            a_n=0.0,
+            r_d=1.0e-6,
+            c_l=20.0,
+            c_r_h=np.array([2.0, 3.0], dtype=float),
+            c_r_v=np.array([1.0, 1.5], dtype=float),
+            c_sw=500.0,
+            c_hw=300.0,
+            c_nsc=40.0,
+            t_a=10.0,
+            t_soil=8.0,
+        )
+    except RuntimeError as exc:
+        assert "partial NaNs" in str(exc)
+    else:
+        raise AssertionError("grow should reject partially NaN allocation fractions")


### PR DESCRIPTION
## Summary
- migrate the THORP `grow` seam into the new package
- add bounded growth parameter handling and regression tests
- document slice 011 in the architecture artifacts

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

Closes #15
