### PR TITLE
Migrate THORP biomass fractions seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ poetry run ruff check .
 - THORP `stomata` is migrated as slice 009.
 - THORP `allocation_fractions` is migrated as slice 010.
 - THORP `grow` is migrated as slice 011.
+- THORP `biomass_fractions` is migrated as slice 012.
 
 ## Next validation
-- Migrate the next THORP seam, likely `biomass_fractions`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `huber_value`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 011
-- Gate D. Bounded slices 001 through 011 approved for THORP
+- Gate C. Validation plan ready through slice 012
+- Gate D. Bounded slices 001 through 012 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -113,3 +113,9 @@ Slice 011:
 - target: `src/stomatal_optimiaztion/domains/thorp/growth.py`
 - scope: bounded growth-state updates, senescence, and geometry reconstruction
 - excluded: `biomass_fractions`, reporting helpers, and simulation orchestration
+
+Slice 012:
+- source: `THORP/src/thorp/metrics.py` (`BiomassFractions`, `biomass_fractions`)
+- target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- scope: bounded biomass-fraction reporting from carbon-pool time series
+- excluded: `huber_value`, soil-grid helpers, rooting-depth reporting, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -132,8 +132,16 @@ The eleventh slice ports the next bounded growth-state seam:
 - keep the interface bounded by a minimal `GrowthParams` dataclass
 - leave `biomass_fractions` blocked as the next reporting seam
 
+## Slice 012: THORP Biomass Fractions
+
+The twelfth slice ports the next bounded reporting seam:
+- move `biomass_fractions` from `metrics.py` into a dedicated THORP metrics module
+- reuse migrated growth time-series names without pulling in the legacy `SimulationOutputs` container
+- keep the interface bounded by a minimal `BiomassFractionSeries` dataclass
+- leave `huber_value` blocked as the next reporting seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, and grow seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, and biomass-fraction seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `biomass_fractions` or another bounded reporting seam
+3. prepare the next THORP source audit for `huber_value` or another bounded reporting seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 011 implementation and validation
+- Current phase: slice 012 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP grow slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `biomass_fractions`
+1. validate the migrated THORP biomass-fractions slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `huber_value`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-011-thorp-grow.md
+++ b/docs/architecture/architecture/module_specs/module-011-thorp-grow.md
@@ -33,4 +33,4 @@ Migrate the bounded `grow` seam so the new package can update THORP structural c
 
 ## Next Seam
 
-- `biomass_fractions` from `metrics.py`
+- `huber_value` from `metrics.py`

--- a/docs/architecture/architecture/module_specs/module-012-thorp-biomass-fractions.md
+++ b/docs/architecture/architecture/module_specs/module-012-thorp-biomass-fractions.md
@@ -1,0 +1,36 @@
+# Module Spec 012: THORP Biomass Fractions
+
+## Purpose
+
+Migrate the bounded `biomass_fractions` seam so the new package can convert THORP carbon-pool time series into reported biomass fractions without importing the legacy simulation container.
+
+## Source Inputs
+
+- `THORP/src/thorp/metrics.py` (`BiomassFractions`, `biomass_fractions`)
+- `MODEL_CARD:C010` biomass-conversion assumptions
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- `tests/test_thorp_metrics.py`
+
+## Responsibilities
+
+1. preserve the legacy LMF, SMF, and RMF conversions from carbon pools
+2. expose a minimal time-series dataclass instead of porting `SimulationOutputs`
+3. keep zero-total reporting behavior aligned with legacy `NaN` outputs
+
+## Non-Goals
+
+- port `huber_value` from `metrics.py`
+- port soil-grid reconstruction helpers or rooting-depth metrics
+- port the full simulation output container
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `huber_value` from `metrics.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only ten THORP runtime seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only twelve THORP runtime and reporting seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -22,6 +22,11 @@ from stomatal_optimiaztion.domains.thorp.model_card import (
     model_card_document_names,
     require_equation_ids,
 )
+from stomatal_optimiaztion.domains.thorp.metrics import (
+    BiomassFractions,
+    BiomassFractionSeries,
+    biomass_fractions,
+)
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
     RichardsEquationParams,
@@ -42,6 +47,8 @@ from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 __all__ = [
     "AllocationFractions",
     "AllocationParams",
+    "BiomassFractions",
+    "BiomassFractionSeries",
     "BottomBoundaryCondition",
     "GrowthParams",
     "GrowthState",
@@ -58,6 +65,7 @@ __all__ = [
     "SoilMoistureParams",
     "WeibullVC",
     "allocation_fractions",
+    "biomass_fractions",
     "e_from_soil_to_root_collar",
     "equation_id_set",
     "grow",

--- a/src/stomatal_optimiaztion/domains/thorp/metrics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/metrics.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True, slots=True)
+class BiomassFractionSeries:
+    c_l_ts: NDArray[np.floating]
+    c_sw_ts: NDArray[np.floating]
+    c_hw_ts: NDArray[np.floating]
+    c_r_h_by_layer_ts: NDArray[np.floating]
+    c_r_v_by_layer_ts: NDArray[np.floating]
+
+
+@dataclass(frozen=True, slots=True)
+class BiomassFractions:
+    lmf: NDArray[np.floating]
+    smf: NDArray[np.floating]
+    rmf: NDArray[np.floating]
+
+
+def biomass_fractions(
+    *,
+    series: BiomassFractionSeries,
+    leaf_c_fraction: float = 0.5,
+    wood_c_fraction: float = 0.5,
+    root_c_fraction: float = 0.55,
+) -> BiomassFractions:
+    """Compute THORP-reported biomass fractions from carbon-pool time series.
+
+    Paper-derived conversion (MODEL_CARD:C010 assumption):
+      - dry biomass assumed 50% carbon by weight, except roots 55% carbon by weight.
+    """
+
+    leaf_biomass = series.c_l_ts / float(leaf_c_fraction)
+    wood_biomass = (series.c_sw_ts + series.c_hw_ts) / float(wood_c_fraction)
+    root_c = np.sum(series.c_r_h_by_layer_ts + series.c_r_v_by_layer_ts, axis=0)
+    root_biomass = root_c / float(root_c_fraction)
+
+    total = leaf_biomass + wood_biomass + root_biomass
+    with np.errstate(divide="ignore", invalid="ignore"):
+        lmf = leaf_biomass / total
+        smf = wood_biomass / total
+        rmf = root_biomass / total
+
+    return BiomassFractions(
+        lmf=lmf.astype(float),
+        smf=smf.astype(float),
+        rmf=rmf.astype(float),
+    )

--- a/tests/test_thorp_metrics.py
+++ b/tests/test_thorp_metrics.py
@@ -1,0 +1,82 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.thorp.metrics import (
+    BiomassFractionSeries,
+    biomass_fractions,
+)
+
+
+def _series() -> BiomassFractionSeries:
+    return BiomassFractionSeries(
+        c_l_ts=np.array([10.0, 20.0, 30.0]),
+        c_sw_ts=np.array([50.0, 60.0, 70.0]),
+        c_hw_ts=np.array([20.0, 30.0, 40.0]),
+        c_r_h_by_layer_ts=np.array(
+            [
+                [5.0, 6.0, 7.0],
+                [8.0, 9.0, 10.0],
+            ]
+        ),
+        c_r_v_by_layer_ts=np.array(
+            [
+                [2.0, 3.0, 4.0],
+                [1.0, 2.0, 3.0],
+            ]
+        ),
+    )
+
+
+def test_biomass_fractions_matches_legacy_snapshot() -> None:
+    res = biomass_fractions(series=_series())
+
+    assert_allclose(
+        res.lmf,
+        np.array([0.1057692307692308, 0.1560283687943262, 0.1853932584269663]),
+    )
+    assert_allclose(
+        res.smf,
+        np.array([0.7403846153846154, 0.7021276595744681, 0.6797752808988764]),
+    )
+    assert_allclose(
+        res.rmf,
+        np.array([0.1538461538461538, 0.1418439716312057, 0.1348314606741573]),
+    )
+
+
+def test_biomass_fractions_zero_total_matches_legacy_behavior() -> None:
+    res = biomass_fractions(
+        series=BiomassFractionSeries(
+            c_l_ts=np.zeros(2),
+            c_sw_ts=np.zeros(2),
+            c_hw_ts=np.zeros(2),
+            c_r_h_by_layer_ts=np.zeros((2, 2)),
+            c_r_v_by_layer_ts=np.zeros((2, 2)),
+        )
+    )
+
+    assert np.isnan(res.lmf).all()
+    assert np.isnan(res.smf).all()
+    assert np.isnan(res.rmf).all()
+
+
+def test_biomass_fractions_supports_custom_carbon_fractions() -> None:
+    res = biomass_fractions(
+        series=_series(),
+        leaf_c_fraction=0.4,
+        wood_c_fraction=0.45,
+        root_c_fraction=0.6,
+    )
+
+    assert_allclose(
+        res.lmf,
+        np.array([0.1206434316353888, 0.1764705882352941, 0.2086553323029366]),
+    )
+    assert_allclose(
+        res.smf,
+        np.array([0.7506702412868633, 0.7058823529411765, 0.6800618238021637]),
+    )
+    assert_allclose(
+        res.rmf,
+        np.array([0.128686327077748, 0.1176470588235294, 0.1112828438948995]),
+    )


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `biomass_fractions` reporting seam from legacy `metrics.py`.
- The scope stays limited to biomass-fraction reporting and its minimal time-series input contract.

## Changes
- add a dedicated THORP metrics module for biomass-fraction reporting
- add regression coverage for legacy snapshot and zero-total behavior
- update architecture docs for slice 012 and point the next seam to `huber_value`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- keeps a reporting helper in the new package without importing the legacy simulation container
- preserves legacy biomass-fraction conversions for leaves, wood, and roots

## Linked issue
Closes #17
