### PR TITLE
Migrate THORP huber value seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ poetry run ruff check .
 - THORP `allocation_fractions` is migrated as slice 010.
 - THORP `grow` is migrated as slice 011.
 - THORP `biomass_fractions` is migrated as slice 012.
+- THORP `huber_value` is migrated as slice 013.
 
 ## Next validation
-- Migrate the next THORP seam, likely `huber_value`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `rooting_depth`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 012
-- Gate D. Bounded slices 001 through 012 approved for THORP
+- Gate C. Validation plan ready through slice 013
+- Gate D. Bounded slices 001 through 013 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -119,3 +119,9 @@ Slice 012:
 - target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
 - scope: bounded biomass-fraction reporting from carbon-pool time series
 - excluded: `huber_value`, soil-grid helpers, rooting-depth reporting, and simulation orchestration
+
+Slice 013:
+- source: `THORP/src/thorp/metrics.py` (`huber_value`)
+- target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- scope: bounded sapwood-to-leaf area reporting from migrated growth time series
+- excluded: `rooting_depth`, soil-grid reconstruction, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -140,8 +140,16 @@ The twelfth slice ports the next bounded reporting seam:
 - keep the interface bounded by a minimal `BiomassFractionSeries` dataclass
 - leave `huber_value` blocked as the next reporting seam
 
+## Slice 013: THORP Huber Value
+
+The thirteenth slice ports the next bounded reporting seam:
+- move `huber_value` from `metrics.py` into the migrated THORP metrics module
+- reuse migrated growth geometry time-series names without pulling in the legacy `SimulationOutputs` container
+- keep the interface bounded by minimal `HuberValueSeries` and `HuberValueParams` dataclasses
+- leave `rooting_depth` blocked as the next reporting seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, and biomass-fraction seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, and Huber-value seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `huber_value` or another bounded reporting seam
+3. prepare the next THORP source audit for `rooting_depth` or another bounded reporting seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 012 implementation and validation
+- Current phase: slice 013 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP biomass-fractions slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `huber_value`
+1. validate the migrated THORP huber-value slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `rooting_depth`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-012-thorp-biomass-fractions.md
+++ b/docs/architecture/architecture/module_specs/module-012-thorp-biomass-fractions.md
@@ -33,4 +33,4 @@ Migrate the bounded `biomass_fractions` seam so the new package can convert THOR
 
 ## Next Seam
 
-- `huber_value` from `metrics.py`
+- `rooting_depth` from `metrics.py`

--- a/docs/architecture/architecture/module_specs/module-013-thorp-huber-value.md
+++ b/docs/architecture/architecture/module_specs/module-013-thorp-huber-value.md
@@ -1,0 +1,36 @@
+# Module Spec 013: THORP Huber Value
+
+## Purpose
+
+Migrate the bounded `huber_value` seam so the new package can report THORP sapwood-to-leaf area ratios without importing the legacy simulation container.
+
+## Source Inputs
+
+- `THORP/src/thorp/metrics.py` (`huber_value`)
+- `MODEL_CARD:C010` Huber-value reporting context
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- `tests/test_thorp_metrics.py`
+
+## Responsibilities
+
+1. preserve the legacy sapwood-to-leaf area ratio calculation
+2. expose minimal geometry-series and parameter dataclasses instead of porting `SimulationOutputs` and `THORPParams`
+3. keep zero-leaf-area reporting behavior aligned with legacy `inf` and `NaN` outputs
+
+## Non-Goals
+
+- port `rooting_depth` from `metrics.py`
+- port `soil_grid` reconstruction helpers
+- port the full simulation output container
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `rooting_depth` from `metrics.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only twelve THORP runtime and reporting seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only thirteen THORP runtime and reporting seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -26,6 +26,9 @@ from stomatal_optimiaztion.domains.thorp.metrics import (
     BiomassFractions,
     BiomassFractionSeries,
     biomass_fractions,
+    HuberValueParams,
+    HuberValueSeries,
+    huber_value,
 )
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
@@ -52,6 +55,8 @@ __all__ = [
     "BottomBoundaryCondition",
     "GrowthParams",
     "GrowthState",
+    "HuberValueParams",
+    "HuberValueSeries",
     "InitialSoilAndRoots",
     "RadiationResult",
     "RichardsEquationParams",
@@ -69,6 +74,7 @@ __all__ = [
     "e_from_soil_to_root_collar",
     "equation_id_set",
     "grow",
+    "huber_value",
     "initial_soil_and_roots",
     "iter_equation_refs",
     "model_card_document_names",

--- a/src/stomatal_optimiaztion/domains/thorp/metrics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/metrics.py
@@ -22,6 +22,19 @@ class BiomassFractions:
     rmf: NDArray[np.floating]
 
 
+@dataclass(frozen=True, slots=True)
+class HuberValueSeries:
+    c_l_ts: NDArray[np.floating]
+    d_ts: NDArray[np.floating]
+    d_hw_ts: NDArray[np.floating]
+
+
+@dataclass(frozen=True, slots=True)
+class HuberValueParams:
+    sla: float
+    xi: float
+
+
 def biomass_fractions(
     *,
     series: BiomassFractionSeries,
@@ -51,3 +64,17 @@ def biomass_fractions(
         smf=smf.astype(float),
         rmf=rmf.astype(float),
     )
+
+
+def huber_value(
+    *,
+    series: HuberValueSeries,
+    params: HuberValueParams,
+) -> NDArray[np.floating]:
+    """Compute the sapwood-to-leaf area ratio from migrated THORP time series."""
+
+    leaf_area = float(params.sla) * series.c_l_ts
+    sapwood_area = float(params.xi) * (series.d_ts**2 - series.d_hw_ts**2)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        hv = sapwood_area / leaf_area
+    return hv.astype(float)

--- a/tests/test_thorp_metrics.py
+++ b/tests/test_thorp_metrics.py
@@ -3,7 +3,10 @@ from numpy.testing import assert_allclose
 
 from stomatal_optimiaztion.domains.thorp.metrics import (
     BiomassFractionSeries,
+    HuberValueParams,
+    HuberValueSeries,
     biomass_fractions,
+    huber_value,
 )
 
 
@@ -80,3 +83,31 @@ def test_biomass_fractions_supports_custom_carbon_fractions() -> None:
         res.rmf,
         np.array([0.128686327077748, 0.1176470588235294, 0.1112828438948995]),
     )
+
+
+def test_huber_value_matches_legacy_snapshot() -> None:
+    res = huber_value(
+        series=HuberValueSeries(
+            c_l_ts=np.array([10.0, 20.0, 25.0]),
+            d_ts=np.array([0.30, 0.45, 0.50]),
+            d_hw_ts=np.array([0.10, 0.20, 0.25]),
+        ),
+        params=HuberValueParams(sla=0.08, xi=0.5),
+    )
+
+    assert_allclose(res, np.array([0.05, 0.05078125, 0.046875]))
+
+
+def test_huber_value_zero_leaf_area_matches_legacy_behavior() -> None:
+    res = huber_value(
+        series=HuberValueSeries(
+            c_l_ts=np.array([0.0, 5.0, 0.0]),
+            d_ts=np.array([0.2, 0.3, 0.0]),
+            d_hw_ts=np.array([0.0, 0.1, 0.0]),
+        ),
+        params=HuberValueParams(sla=0.08, xi=0.5),
+    )
+
+    assert np.isinf(res[0])
+    assert_allclose(res[1], 0.1)
+    assert np.isnan(res[2])


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `huber_value` reporting seam from legacy `metrics.py`.
- The scope stays limited to sapwood-to-leaf area reporting and its minimal time-series input contract.

## Changes
- add dedicated THORP `huber_value` reporting inputs and params in the migrated metrics module
- add regression coverage for legacy snapshot and zero-leaf-area behavior
- update architecture docs for slice 013 and point the next seam to `rooting_depth`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- keeps another reporting helper in the new package without importing the legacy simulation container
- preserves legacy Huber-value calculations from migrated growth time series

## Linked issue
Closes #19
