### PR TITLE
Migrate THORP rooting depth seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ poetry run ruff check .
 - THORP `grow` is migrated as slice 011.
 - THORP `biomass_fractions` is migrated as slice 012.
 - THORP `huber_value` is migrated as slice 013.
+- THORP `rooting_depth` is migrated as slice 014.
 
 ## Next validation
-- Migrate the next THORP seam, likely `rooting_depth`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `soil_grid`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 013
-- Gate D. Bounded slices 001 through 013 approved for THORP
+- Gate C. Validation plan ready through slice 014
+- Gate D. Bounded slices 001 through 014 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -125,3 +125,9 @@ Slice 013:
 - target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
 - scope: bounded sapwood-to-leaf area reporting from migrated growth time series
 - excluded: `rooting_depth`, soil-grid reconstruction, and simulation orchestration
+
+Slice 014:
+- source: `THORP/src/thorp/metrics.py` (`rooting_depth`)
+- target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- scope: bounded rooting-depth reporting from migrated root time series and `SoilGrid`
+- excluded: `soil_grid` reconstruction helper and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -148,8 +148,16 @@ The thirteenth slice ports the next bounded reporting seam:
 - keep the interface bounded by minimal `HuberValueSeries` and `HuberValueParams` dataclasses
 - leave `rooting_depth` blocked as the next reporting seam
 
+## Slice 014: THORP Rooting Depth
+
+The fourteenth slice ports the next bounded reporting seam:
+- move `rooting_depth` from `metrics.py` into the migrated THORP metrics module
+- reuse migrated root time-series names and `SoilGrid` without pulling in the legacy `SimulationOutputs` container
+- keep the interface bounded by a minimal `RootingDepthSeries` dataclass plus migrated `SoilGrid`
+- leave `soil_grid` blocked as the next helper seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, and Huber-value seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, and rooting-depth seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `rooting_depth` or another bounded reporting seam
+3. prepare the next THORP source audit for `soil_grid` or another bounded helper seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 013 implementation and validation
+- Current phase: slice 014 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP huber-value slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `rooting_depth`
+1. validate the migrated THORP rooting-depth slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `soil_grid`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-013-thorp-huber-value.md
+++ b/docs/architecture/architecture/module_specs/module-013-thorp-huber-value.md
@@ -33,4 +33,4 @@ Migrate the bounded `huber_value` seam so the new package can report THORP sapwo
 
 ## Next Seam
 
-- `rooting_depth` from `metrics.py`
+- `soil_grid` from `metrics.py`

--- a/docs/architecture/architecture/module_specs/module-014-thorp-rooting-depth.md
+++ b/docs/architecture/architecture/module_specs/module-014-thorp-rooting-depth.md
@@ -1,0 +1,36 @@
+# Module Spec 014: THORP Rooting Depth
+
+## Purpose
+
+Migrate the bounded `rooting_depth` seam so the new package can report THORP root-distribution depth percentiles without importing the legacy simulation container.
+
+## Source Inputs
+
+- `THORP/src/thorp/metrics.py` (`rooting_depth`)
+- migrated `SoilGrid` from `soil_initialization.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- `tests/test_thorp_metrics.py`
+
+## Responsibilities
+
+1. preserve the legacy percentile-based rooting-depth calculation
+2. expose a minimal root time-series dataclass instead of porting `SimulationOutputs`
+3. reuse migrated `SoilGrid` rather than reconstructing the legacy `THORPParams` bundle
+
+## Non-Goals
+
+- port `soil_grid` from `metrics.py`
+- port the full simulation output container
+- port broader soil reporting utilities beyond `rooting_depth`
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `soil_grid` from `metrics.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only thirteen THORP runtime and reporting seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only fourteen THORP runtime and reporting seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -29,6 +29,8 @@ from stomatal_optimiaztion.domains.thorp.metrics import (
     HuberValueParams,
     HuberValueSeries,
     huber_value,
+    RootingDepthSeries,
+    rooting_depth,
 )
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
@@ -58,6 +60,7 @@ __all__ = [
     "HuberValueParams",
     "HuberValueSeries",
     "InitialSoilAndRoots",
+    "RootingDepthSeries",
     "RadiationResult",
     "RichardsEquationParams",
     "RootUptakeParams",
@@ -80,6 +83,7 @@ __all__ = [
     "model_card_document_names",
     "radiation",
     "richards_equation",
+    "rooting_depth",
     "require_equation_ids",
     "soil_moisture",
     "stomata",

--- a/src/stomatal_optimiaztion/domains/thorp/metrics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/metrics.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
+from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
+
 
 @dataclass(frozen=True, slots=True)
 class BiomassFractionSeries:
@@ -33,6 +35,12 @@ class HuberValueSeries:
 class HuberValueParams:
     sla: float
     xi: float
+
+
+@dataclass(frozen=True, slots=True)
+class RootingDepthSeries:
+    c_r_h_by_layer_ts: NDArray[np.floating]
+    c_r_v_by_layer_ts: NDArray[np.floating]
 
 
 def biomass_fractions(
@@ -78,3 +86,32 @@ def huber_value(
     with np.errstate(divide="ignore", invalid="ignore"):
         hv = sapwood_area / leaf_area
     return hv.astype(float)
+
+
+def rooting_depth(
+    *,
+    series: RootingDepthSeries,
+    grid: SoilGrid,
+    percentile: float,
+) -> NDArray[np.floating]:
+    """Compute the depth above which `percentile` of root biomass is present."""
+
+    if not (0.0 < percentile <= 1.0):
+        raise ValueError("percentile must be in (0, 1].")
+
+    z_bttm = grid.z_bttm.astype(float)
+    root = (series.c_r_h_by_layer_ts + series.c_r_v_by_layer_ts).astype(float)
+    total = np.sum(root, axis=0)
+
+    depth = np.full(total.shape, np.nan, dtype=float)
+    for time_idx in range(total.size):
+        total_root = float(total[time_idx])
+        if total_root <= 0.0:
+            continue
+        cum = np.cumsum(root[:, time_idx])
+        frac = cum / total_root
+        layer_idx = int(np.searchsorted(frac, percentile, side="left"))
+        layer_idx = min(max(layer_idx, 0), z_bttm.size - 1)
+        depth[time_idx] = float(z_bttm[layer_idx])
+
+    return depth.astype(float)

--- a/tests/test_thorp_metrics.py
+++ b/tests/test_thorp_metrics.py
@@ -5,9 +5,12 @@ from stomatal_optimiaztion.domains.thorp.metrics import (
     BiomassFractionSeries,
     HuberValueParams,
     HuberValueSeries,
+    RootingDepthSeries,
     biomass_fractions,
     huber_value,
+    rooting_depth,
 )
+from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
 
 
 def _series() -> BiomassFractionSeries:
@@ -25,6 +28,36 @@ def _series() -> BiomassFractionSeries:
             [
                 [2.0, 3.0, 4.0],
                 [1.0, 2.0, 3.0],
+            ]
+        ),
+    )
+
+
+def _rooting_grid() -> SoilGrid:
+    return SoilGrid(
+        dz=np.array([0.1, 0.2, 0.3, 0.4]),
+        z_bttm=np.array([0.1, 0.3, 0.6, 1.0]),
+        z_mid=np.array([0.05, 0.2, 0.45, 0.8]),
+        dz_c=np.array([0.05, 0.15, 0.25, 0.35, 0.2]),
+    )
+
+
+def _rooting_series() -> RootingDepthSeries:
+    return RootingDepthSeries(
+        c_r_h_by_layer_ts=np.array(
+            [
+                [0.3, 0.90, 0.0, 0.10],
+                [0.2, 0.01, 0.0, 0.20],
+                [0.05, 0.005, 0.0, 0.25],
+                [0.05, 0.005, 0.0, 0.00],
+            ]
+        ),
+        c_r_v_by_layer_ts=np.array(
+            [
+                [0.2, 0.06, 0.0, 0.10],
+                [0.1, 0.01, 0.0, 0.20],
+                [0.05, 0.005, 0.0, 0.10],
+                [0.05, 0.005, 0.0, 0.05],
             ]
         ),
     )
@@ -111,3 +144,58 @@ def test_huber_value_zero_leaf_area_matches_legacy_behavior() -> None:
     assert np.isinf(res[0])
     assert_allclose(res[1], 0.1)
     assert np.isnan(res[2])
+
+
+def test_rooting_depth_matches_legacy_snapshot() -> None:
+    res = rooting_depth(
+        series=_rooting_series(),
+        grid=_rooting_grid(),
+        percentile=0.95,
+    )
+
+    assert_allclose(res[:2], np.array([1.0, 0.1]))
+    assert np.isnan(res[2])
+    assert_allclose(res[3:], np.array([0.6]))
+
+
+def test_rooting_depth_supports_alternate_percentile() -> None:
+    res = rooting_depth(
+        series=_rooting_series(),
+        grid=_rooting_grid(),
+        percentile=0.5,
+    )
+
+    assert_allclose(res[:2], np.array([0.1, 0.1]))
+    assert np.isnan(res[2])
+    assert_allclose(res[3:], np.array([0.3]))
+
+
+def test_rooting_depth_zero_total_matches_legacy_behavior() -> None:
+    res = rooting_depth(
+        series=RootingDepthSeries(
+            c_r_h_by_layer_ts=np.zeros((3, 2)),
+            c_r_v_by_layer_ts=np.zeros((3, 2)),
+        ),
+        grid=SoilGrid(
+            dz=np.array([0.2, 0.3, 0.5]),
+            z_bttm=np.array([0.2, 0.5, 1.0]),
+            z_mid=np.array([0.1, 0.35, 0.75]),
+            dz_c=np.array([0.1, 0.25, 0.4, 0.25]),
+        ),
+        percentile=0.95,
+    )
+
+    assert np.isnan(res).all()
+
+
+def test_rooting_depth_invalid_percentile_raises() -> None:
+    try:
+        rooting_depth(
+            series=_rooting_series(),
+            grid=_rooting_grid(),
+            percentile=0.0,
+        )
+    except ValueError as exc:
+        assert "percentile" in str(exc)
+    else:
+        raise AssertionError("rooting_depth should reject percentile <= 0")


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `rooting_depth` reporting seam from legacy `metrics.py`.
- The scope stays limited to percentile-based rooting-depth reporting and its minimal grid/time-series input contract.

## Changes
- add dedicated THORP rooting-depth reporting inputs in the migrated metrics module
- add regression coverage for legacy snapshots, zero-root behavior, and percentile validation
- update architecture docs for slice 014 and point the next seam to `soil_grid`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- keeps another reporting helper in the new package without importing the legacy simulation container
- preserves legacy rooting-depth calculations while reusing migrated `SoilGrid`

## Linked issue
Closes #21
