### PR TITLE
Migrate THORP soil grid helper seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ poetry run ruff check .
 - THORP `biomass_fractions` is migrated as slice 012.
 - THORP `huber_value` is migrated as slice 013.
 - THORP `rooting_depth` is migrated as slice 014.
+- THORP `soil_grid` helper is migrated as slice 015.
 
 ## Next validation
-- Migrate the next THORP seam, likely `soil_grid`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `default_params`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 014
-- Gate D. Bounded slices 001 through 014 approved for THORP
+- Gate C. Validation plan ready through slice 015
+- Gate D. Bounded slices 001 through 015 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -131,3 +131,9 @@ Slice 014:
 - target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
 - scope: bounded rooting-depth reporting from migrated root time series and `SoilGrid`
 - excluded: `soil_grid` reconstruction helper and simulation orchestration
+
+Slice 015:
+- source: `THORP/src/thorp/metrics.py` (`soil_grid`)
+- target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- scope: bounded grid-reconstruction helper using migrated soil-initialization params
+- excluded: `default_params`, the legacy `THORPParams` bundle, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -156,8 +156,16 @@ The fourteenth slice ports the next bounded reporting seam:
 - keep the interface bounded by a minimal `RootingDepthSeries` dataclass plus migrated `SoilGrid`
 - leave `soil_grid` blocked as the next helper seam
 
+## Slice 015: THORP Soil Grid Helper
+
+The fifteenth slice ports the final bounded `metrics.py` helper seam:
+- move `soil_grid` from `metrics.py` into the migrated THORP metrics module
+- reuse migrated `SoilInitializationParams` and `initial_soil_and_roots`
+- keep the helper bounded to grid reconstruction instead of porting the legacy `THORPParams` bundle
+- leave `default_params` blocked as the next config seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, and rooting-depth seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, and soil-grid seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `soil_grid` or another bounded helper seam
+3. prepare the next THORP source audit for `default_params` or another bounded config seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 014 implementation and validation
+- Current phase: slice 015 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP rooting-depth slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `soil_grid`
+1. validate the migrated THORP soil-grid helper slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `default_params`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-014-thorp-rooting-depth.md
+++ b/docs/architecture/architecture/module_specs/module-014-thorp-rooting-depth.md
@@ -33,4 +33,4 @@ Migrate the bounded `rooting_depth` seam so the new package can report THORP roo
 
 ## Next Seam
 
-- `soil_grid` from `metrics.py`
+- `default_params` from `config.py`

--- a/docs/architecture/architecture/module_specs/module-015-thorp-soil-grid-helper.md
+++ b/docs/architecture/architecture/module_specs/module-015-thorp-soil-grid-helper.md
@@ -1,0 +1,36 @@
+# Module Spec 015: THORP Soil Grid Helper
+
+## Purpose
+
+Migrate the bounded `soil_grid` helper seam so the new package can reconstruct the THORP soil grid without importing the legacy `THORPParams` bundle.
+
+## Source Inputs
+
+- `THORP/src/thorp/metrics.py` (`soil_grid`)
+- migrated `SoilInitializationParams` and `initial_soil_and_roots`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/metrics.py`
+- `tests/test_thorp_metrics.py`
+
+## Responsibilities
+
+1. preserve the legacy helper behavior of reconstructing the soil grid via initialization logic
+2. reuse migrated `SoilInitializationParams` as the helper boundary
+3. keep the wrapper narrow instead of reintroducing the legacy `THORPParams` bundle
+
+## Non-Goals
+
+- port `default_params` from `config.py`
+- port the legacy `THORPParams` dataclass
+- port simulation orchestration or forcing setup
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `default_params` from `config.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only fourteen THORP runtime and reporting seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only fifteen THORP runtime, reporting, and helper seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -31,6 +31,7 @@ from stomatal_optimiaztion.domains.thorp.metrics import (
     huber_value,
     RootingDepthSeries,
     rooting_depth,
+    soil_grid,
 )
 from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
@@ -86,5 +87,6 @@ __all__ = [
     "rooting_depth",
     "require_equation_ids",
     "soil_moisture",
+    "soil_grid",
     "stomata",
 ]

--- a/src/stomatal_optimiaztion/domains/thorp/metrics.py
+++ b/src/stomatal_optimiaztion/domains/thorp/metrics.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
-from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilGrid,
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,6 +90,13 @@ def huber_value(
     with np.errstate(divide="ignore", invalid="ignore"):
         hv = sapwood_area / leaf_area
     return hv.astype(float)
+
+
+def soil_grid(*, params: SoilInitializationParams) -> SoilGrid:
+    """Reconstruct the THORP soil grid from migrated soil-initialization params."""
+
+    init = initial_soil_and_roots(params=params, c_r_i=1.0, z_i=1.0)
+    return init.grid
 
 
 def rooting_depth(

--- a/tests/test_thorp_metrics.py
+++ b/tests/test_thorp_metrics.py
@@ -9,8 +9,15 @@ from stomatal_optimiaztion.domains.thorp.metrics import (
     biomass_fractions,
     huber_value,
     rooting_depth,
+    soil_grid,
 )
-from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilGrid,
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _series() -> BiomassFractionSeries:
@@ -60,6 +67,27 @@ def _rooting_series() -> RootingDepthSeries:
                 [0.05, 0.005, 0.0, 0.05],
             ]
         ),
+    )
+
+
+def _soil_params() -> SoilInitializationParams:
+    return SoilInitializationParams(
+        rho=998.0,
+        g=9.81,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=SoilHydraulics(
+            n_vg=2.70,
+            alpha_vg=1.4642,
+            l_vg=0.5,
+            e_z_n=13.6,
+            e_z_k_s_sat=3.2,
+        ),
+        vc_r=WeibullVC(b=1.2949, c=2.6471),
+        beta_r_h=3388.15038831676,
+        beta_r_v=941.1528856435444,
     )
 
 
@@ -199,3 +227,65 @@ def test_rooting_depth_invalid_percentile_raises() -> None:
         assert "percentile" in str(exc)
     else:
         raise AssertionError("rooting_depth should reject percentile <= 0")
+
+
+def test_soil_grid_matches_legacy_snapshot() -> None:
+    grid = soil_grid(params=_soil_params())
+
+    assert_allclose(
+        grid.dz,
+        np.array(
+            [
+                0.09966816,
+                0.13654095,
+                0.18705502,
+                0.25625706,
+                0.35106077,
+                0.48093763,
+                0.65886316,
+                0.90261322,
+                1.23653995,
+                1.69400471,
+                2.32071109,
+                3.17927095,
+                4.35545976,
+                5.96678609,
+                8.17423149,
+            ]
+        ),
+        rtol=1e-7,
+    )
+    assert_allclose(
+        grid.z_bttm,
+        np.array(
+            [
+                0.09966816,
+                0.23620911,
+                0.42326413,
+                0.67952119,
+                1.03058196,
+                1.51151959,
+                2.17038275,
+                3.07299597,
+                4.30953592,
+                6.00354063,
+                8.32425172,
+                11.50352267,
+                15.85898243,
+                21.82576851,
+                30.0,
+            ]
+        ),
+        rtol=1e-7,
+    )
+    assert grid.n_soil == 15
+
+
+def test_soil_grid_matches_migrated_initialization_behavior() -> None:
+    grid = soil_grid(params=_soil_params())
+    init = initial_soil_and_roots(params=_soil_params(), c_r_i=5.0, z_i=3.0)
+
+    assert_allclose(grid.dz, init.grid.dz)
+    assert_allclose(grid.z_bttm, init.grid.z_bttm)
+    assert_allclose(grid.z_mid, init.grid.z_mid)
+    assert_allclose(grid.dz_c, init.grid.dz_c)


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `soil_grid` helper seam from legacy `metrics.py`.
- The scope stays limited to grid reconstruction and its minimal parameter contract.

## Changes
- add a dedicated THORP `soil_grid` helper in the migrated metrics module
- add regression coverage for legacy grid snapshots and parity with migrated initialization
- update architecture docs for slice 015 and point the next seam to a config/default-parameter adapter

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- keeps the remaining `metrics.py` helper in the new package without importing the legacy `THORPParams` bundle
- reuses migrated `initial_soil_and_roots` and `SoilInitializationParams` as the source of truth

## Linked issue
Closes #23
