### PR TITLE
Migrate THORP default params bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ poetry run ruff check .
 - THORP `huber_value` is migrated as slice 013.
 - THORP `rooting_depth` is migrated as slice 014.
 - THORP `soil_grid` helper is migrated as slice 015.
+- THORP `default_params` is migrated as a bounded defaults bundle in slice 016.
 
 ## Next validation
-- Migrate the next THORP seam, likely `default_params`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `THORPParams`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 015
-- Gate D. Bounded slices 001 through 015 approved for THORP
+- Gate C. Validation plan ready through slice 016
+- Gate D. Bounded slices 001 through 016 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -137,3 +137,9 @@ Slice 015:
 - target: `src/stomatal_optimiaztion/domains/thorp/metrics.py`
 - scope: bounded grid-reconstruction helper using migrated soil-initialization params
 - excluded: `default_params`, the legacy `THORPParams` bundle, and simulation orchestration
+
+Slice 016:
+- source: `THORP/src/thorp/config.py` (`default_params`)
+- target: `src/stomatal_optimiaztion/domains/thorp/defaults.py`
+- scope: bounded default-parameter bundle for already migrated THORP seams
+- excluded: the legacy `THORPParams` dataclass, forcing-path setup, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -164,8 +164,16 @@ The fifteenth slice ports the final bounded `metrics.py` helper seam:
 - keep the helper bounded to grid reconstruction instead of porting the legacy `THORPParams` bundle
 - leave `default_params` blocked as the next config seam
 
+## Slice 016: THORP Default Params Bundle
+
+The sixteenth slice ports the next bounded config seam:
+- move the legacy `default_params` logic into a migrated defaults bundle for already ported THORP seams
+- expose canonical defaults for `soil_initialization`, `richards`, `soil_moisture`, `root_uptake`, `stomata`, `allocation`, `growth`, and `huber_value`
+- keep the implementation bounded to migrated parameter dataclasses instead of reintroducing the full legacy `THORPParams` bundle
+- leave `THORPParams` blocked as the next config seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, and soil-grid seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, and defaults-bundle seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `default_params` or another bounded config seam
+3. prepare the next THORP source audit for `THORPParams` or another bounded config seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 015 implementation and validation
+- Current phase: slice 016 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP soil-grid helper slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `default_params`
+1. validate the migrated THORP defaults-bundle slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `THORPParams`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-015-thorp-soil-grid-helper.md
+++ b/docs/architecture/architecture/module_specs/module-015-thorp-soil-grid-helper.md
@@ -33,4 +33,4 @@ Migrate the bounded `soil_grid` helper seam so the new package can reconstruct t
 
 ## Next Seam
 
-- `default_params` from `config.py`
+- `THORPParams` from `config.py`

--- a/docs/architecture/architecture/module_specs/module-016-thorp-default-params-bundle.md
+++ b/docs/architecture/architecture/module_specs/module-016-thorp-default-params-bundle.md
@@ -1,0 +1,36 @@
+# Module Spec 016: THORP Default Params Bundle
+
+## Purpose
+
+Migrate the bounded `default_params` seam so the new package can expose canonical legacy-like defaults for already migrated THORP seams without porting the full legacy `THORPParams` dataclass.
+
+## Source Inputs
+
+- `THORP/src/thorp/config.py` (`default_params`)
+- migrated parameter dataclasses across `soil_initialization`, `soil_dynamics`, `hydraulics`, `allocation`, `growth`, and `metrics`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/defaults.py`
+- `tests/test_thorp_defaults.py`
+
+## Responsibilities
+
+1. preserve legacy default constants and closure outputs for already migrated seams
+2. expose one bounded defaults bundle instead of reintroducing the full `THORPParams` structure
+3. allow migrated tests and adapters to reuse a single canonical source of default parameter values
+
+## Non-Goals
+
+- port the legacy `THORPParams` dataclass
+- port forcing-path setup or file-system dependent configuration
+- port simulation orchestration or remaining config-only seams
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `THORPParams` from `config.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only fifteen THORP runtime, reporting, and helper seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only sixteen THORP runtime, reporting, helper, and config-adapter seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -3,6 +3,10 @@ from stomatal_optimiaztion.domains.thorp.allocation import (
     AllocationParams,
     allocation_fractions,
 )
+from stomatal_optimiaztion.domains.thorp.defaults import (
+    ThorpDefaultParams,
+    default_params,
+)
 from stomatal_optimiaztion.domains.thorp.growth import (
     GrowthParams,
     GrowthState,
@@ -72,9 +76,11 @@ __all__ = [
     "SoilHydraulics",
     "SoilInitializationParams",
     "SoilMoistureParams",
+    "ThorpDefaultParams",
     "WeibullVC",
     "allocation_fractions",
     "biomass_fractions",
+    "default_params",
     "e_from_soil_to_root_collar",
     "equation_id_set",
     "grow",

--- a/src/stomatal_optimiaztion/domains/thorp/defaults.py
+++ b/src/stomatal_optimiaztion/domains/thorp/defaults.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.allocation import AllocationParams
+from stomatal_optimiaztion.domains.thorp.growth import GrowthParams
+from stomatal_optimiaztion.domains.thorp.hydraulics import RootUptakeParams, StomataParams
+from stomatal_optimiaztion.domains.thorp.metrics import HuberValueParams
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
+    RichardsEquationParams,
+    SoilMoistureParams,
+)
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilInitializationParams
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+
+@dataclass(frozen=True, slots=True)
+class ThorpDefaultParams:
+    soil_initialization: SoilInitializationParams
+    richards: RichardsEquationParams
+    soil_moisture: SoilMoistureParams
+    root_uptake: RootUptakeParams
+    stomata: StomataParams
+    allocation: AllocationParams
+    growth: GrowthParams
+    huber_value: HuberValueParams
+
+
+def default_params() -> ThorpDefaultParams:
+    """Return canonical legacy-like defaults for already migrated THORP seams."""
+
+    rho = 998.0
+    g = 9.81
+    r_gas = 8.314
+    m_h2o = 18.01528e-3
+
+    sla = 0.08
+    xi = 0.5
+    rho_cw = 1.4e4
+
+    d_ref = 1.0
+    b0 = 64.6
+    c0 = 0.6411
+    b1 = 8.5
+    c1 = 0.625
+
+    soil = SoilHydraulics(
+        n_vg=2.70,
+        alpha_vg=1.4642,
+        l_vg=0.5,
+        e_z_n=13.6,
+        e_z_k_s_sat=3.2,
+    )
+    vc_r = WeibullVC(b=1.2949, c=2.6471)
+    beta_r_h = 3388.15038831676
+    beta_r_v = 941.1528856435444
+
+    soil_initialization = SoilInitializationParams(
+        rho=rho,
+        g=g,
+        z_wt=74.0,
+        z_soil=30.0,
+        n_soil=15,
+        bc_bttm="FreeDrainage",
+        soil=soil,
+        vc_r=vc_r,
+        beta_r_h=beta_r_h,
+        beta_r_v=beta_r_v,
+    )
+
+    richards = RichardsEquationParams(
+        dt=6 * 3600.0,
+        rho=rho,
+        g=g,
+        bc_bttm=soil_initialization.bc_bttm,
+        z_wt=soil_initialization.z_wt,
+        p_bttm=rho * g * (soil_initialization.z_soil - soil_initialization.z_wt) / 1e6,
+        soil=soil,
+    )
+
+    soil_moisture = SoilMoistureParams(
+        richards=richards,
+        m_h2o=m_h2o,
+        r_gas=r_gas,
+    )
+
+    root_uptake = RootUptakeParams(
+        beta_r_h=beta_r_h,
+        beta_r_v=beta_r_v,
+        vc_r=vc_r,
+        rho=rho,
+        g=g,
+    )
+
+    def v_cmax_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+        return 60e-6 * np.exp(8e4 * (t_l + 273.15 - 290) / 290 / r_gas / (t_l + 273.15))
+
+    def j_max_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+        return 110e-6 * np.exp(8e4 * (t_l + 273.15 - 290) / 290 / r_gas / (t_l + 273.15))
+
+    def gamma_star_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+        return 36e-6 * 101.325 * np.ones_like(t_l)
+
+    def k_c_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+        return 275e-6 * 101.325 * np.ones_like(t_l)
+
+    def k_o_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+        return 420000e-6 * 101.325 * np.ones_like(t_l)
+
+    def r_d_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
+        return 0.01 * v_cmax_func(t_l)
+
+    stomata = StomataParams(
+        root_uptake=root_uptake,
+        g_wmin=0.0,
+        c_prime1=0.98,
+        c_prime2=0.90,
+        d_ref=d_ref,
+        c0=c0,
+        c1=c1,
+        b2=0.9253,
+        c2=0.9296,
+        k_l=1.6e-2,
+        vc_sw=WeibullVC(b=5.3151, c=0.7951),
+        vc_l=WeibullVC(b=0.8521, c=0.8067),
+        v_cmax_func=v_cmax_func,
+        j_max_func=j_max_func,
+        gamma_star_func=gamma_star_func,
+        k_c_func=k_c_func,
+        k_o_func=k_o_func,
+        r_d_func=r_d_func,
+        var_kappa=6.9e-7,
+        c_a=410e-6 * 101.325,
+        o_a=21.0,
+    )
+
+    def r_m_sw_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
+        return 2.2e-12 * 1.8 ** ((np.asarray(t) - 15.0) / 10.0)
+
+    def r_m_r_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
+        return 7.0e-9 * 1.98 ** ((np.asarray(t) - 15.0) / 10.0)
+
+    allocation = AllocationParams(
+        sla=sla,
+        r_m_sw_func=r_m_sw_func,
+        r_m_r_func=r_m_r_func,
+        tau_l=9.5e7,
+        tau_sw=1.2e9,
+        tau_r=9.6e7,
+    )
+
+    growth = GrowthParams(
+        allocation=allocation,
+        dt=richards.dt,
+        f_c=0.28,
+        rho_cw=rho_cw,
+        xi=xi,
+        b0=b0,
+        d_ref=d_ref,
+        c0=c0,
+        b1=b1,
+        c1=c1,
+    )
+
+    huber_value = HuberValueParams(sla=sla, xi=xi)
+
+    return ThorpDefaultParams(
+        soil_initialization=soil_initialization,
+        richards=richards,
+        soil_moisture=soil_moisture,
+        root_uptake=root_uptake,
+        stomata=stomata,
+        allocation=allocation,
+        growth=growth,
+        huber_value=huber_value,
+    )

--- a/tests/test_thorp_allocation.py
+++ b/tests/test_thorp_allocation.py
@@ -1,32 +1,17 @@
 from __future__ import annotations
 
 import numpy as np
-from numpy.typing import NDArray
 
 from stomatal_optimiaztion.domains.thorp.allocation import (
     AllocationParams,
     allocation_fractions,
 )
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
 
 
-def _r_m_sw_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
-    return 2.2e-12 * 1.8 ** ((np.asarray(t) - 15.0) / 10.0)
-
-
-def _r_m_r_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
-    return 7.0e-9 * 1.98 ** ((np.asarray(t) - 15.0) / 10.0)
-
-
 def _allocation_params() -> AllocationParams:
-    return AllocationParams(
-        sla=0.08,
-        r_m_sw_func=_r_m_sw_func,
-        r_m_r_func=_r_m_r_func,
-        tau_l=9.5e7,
-        tau_sw=1.2e9,
-        tau_r=9.6e7,
-    )
+    return default_params().allocation
 
 
 def test_allocation_fractions_exposes_expected_equation_ids() -> None:

--- a/tests/test_thorp_defaults.py
+++ b/tests/test_thorp_defaults.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.thorp.defaults import ThorpDefaultParams, default_params
+from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilInitializationParams
+
+
+def test_default_params_returns_expected_bundle_types() -> None:
+    params = default_params()
+
+    assert isinstance(params, ThorpDefaultParams)
+    assert isinstance(params.soil_initialization, SoilInitializationParams)
+    assert params.growth.allocation is params.allocation
+    assert params.stomata.root_uptake is params.root_uptake
+    assert params.soil_moisture.richards is params.richards
+
+
+def test_default_params_matches_legacy_value_snapshot() -> None:
+    params = default_params()
+
+    assert params.soil_initialization.rho == 998.0
+    assert params.soil_initialization.g == 9.81
+    assert params.soil_initialization.z_wt == 74.0
+    assert params.soil_initialization.z_soil == 30.0
+    assert params.soil_initialization.n_soil == 15
+    assert params.soil_initialization.bc_bttm == "FreeDrainage"
+    assert params.soil_initialization.beta_r_h == 3388.15038831676
+    assert params.soil_initialization.beta_r_v == 941.1528856435444
+    assert params.soil_initialization.soil.n_vg == 2.70
+    assert params.soil_initialization.soil.alpha_vg == 1.4642
+    assert params.soil_initialization.vc_r.b == 1.2949
+    assert params.soil_initialization.vc_r.c == 2.6471
+
+    assert params.richards.dt == 6 * 3600.0
+    assert np.isclose(params.richards.p_bttm, -0.43077672000000006)
+    assert params.soil_moisture.m_h2o == 18.01528e-3
+    assert params.soil_moisture.r_gas == 8.314
+
+    assert params.root_uptake.beta_r_h == 3388.15038831676
+    assert params.root_uptake.beta_r_v == 941.1528856435444
+    assert params.stomata.g_wmin == 0.0
+    assert params.stomata.c_prime1 == 0.98
+    assert params.stomata.c_prime2 == 0.90
+    assert params.stomata.k_l == 1.6e-2
+    assert params.stomata.var_kappa == 6.9e-7
+    assert params.stomata.c_a == 0.04154325
+    assert params.stomata.o_a == 21.0
+
+    assert params.allocation.sla == 0.08
+    assert params.allocation.tau_l == 9.5e7
+    assert params.allocation.tau_sw == 1.2e9
+    assert params.allocation.tau_r == 9.6e7
+
+    assert params.growth.dt == 6 * 3600.0
+    assert params.growth.f_c == 0.28
+    assert params.growth.rho_cw == 1.4e4
+    assert params.growth.xi == 0.5
+    assert params.growth.b0 == 64.6
+    assert params.growth.d_ref == 1.0
+    assert params.growth.c0 == 0.6411
+    assert params.growth.b1 == 8.5
+    assert params.growth.c1 == 0.625
+
+    assert params.huber_value.sla == 0.08
+    assert params.huber_value.xi == 0.5
+
+
+def test_default_params_matches_legacy_function_outputs() -> None:
+    params = default_params()
+    t_l = np.array([15.0, 25.0], dtype=float)
+
+    assert_allclose(
+        params.stomata.v_cmax_func(t_l),
+        np.array([4.8488048999784482e-05, 1.4861206096092956e-04]),
+    )
+    assert_allclose(
+        params.stomata.j_max_func(t_l),
+        np.array([8.889475649960488e-05, 2.724554450950375e-04]),
+    )
+    assert_allclose(
+        params.stomata.gamma_star_func(t_l),
+        np.array([0.0036477, 0.0036477]),
+    )
+    assert_allclose(
+        params.stomata.k_c_func(t_l),
+        np.array([0.027864375, 0.027864375]),
+    )
+    assert_allclose(
+        params.stomata.k_o_func(t_l),
+        np.array([42.5565, 42.5565]),
+    )
+    assert_allclose(
+        params.stomata.r_d_func(t_l),
+        np.array([4.8488048999784479e-07, 1.4861206096092957e-06]),
+    )
+    assert_allclose(
+        params.allocation.r_m_sw_func(t_l),
+        np.array([2.20e-12, 3.96e-12]),
+    )
+    assert_allclose(
+        params.allocation.r_m_r_func(t_l),
+        np.array([7.000e-09, 1.386e-08]),
+    )

--- a/tests/test_thorp_growth.py
+++ b/tests/test_thorp_growth.py
@@ -1,41 +1,14 @@
 from __future__ import annotations
 
 import numpy as np
-from numpy.typing import NDArray
 
-from stomatal_optimiaztion.domains.thorp.allocation import AllocationParams
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.growth import GrowthParams, grow
 from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
 
 
-def _r_m_sw_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
-    return 2.2e-12 * 1.8 ** ((np.asarray(t) - 15.0) / 10.0)
-
-
-def _r_m_r_func(t: float | NDArray[np.floating]) -> float | NDArray[np.floating]:
-    return 7.0e-9 * 1.98 ** ((np.asarray(t) - 15.0) / 10.0)
-
-
 def _growth_params() -> GrowthParams:
-    return GrowthParams(
-        allocation=AllocationParams(
-            sla=0.08,
-            r_m_sw_func=_r_m_sw_func,
-            r_m_r_func=_r_m_r_func,
-            tau_l=9.5e7,
-            tau_sw=1.2e9,
-            tau_r=9.6e7,
-        ),
-        dt=6 * 3600.0,
-        f_c=0.28,
-        rho_cw=1.4e4,
-        xi=0.5,
-        b0=64.6,
-        d_ref=1.0,
-        c0=0.6411,
-        b1=8.5,
-        c1=0.625,
-    )
+    return default_params().growth
 
 
 def test_grow_exposes_expected_equation_ids() -> None:

--- a/tests/test_thorp_metrics.py
+++ b/tests/test_thorp_metrics.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.metrics import (
     BiomassFractionSeries,
-    HuberValueParams,
     HuberValueSeries,
     RootingDepthSeries,
     biomass_fractions,
@@ -11,13 +11,11 @@ from stomatal_optimiaztion.domains.thorp.metrics import (
     rooting_depth,
     soil_grid,
 )
-from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilGrid,
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _series() -> BiomassFractionSeries:
@@ -71,24 +69,7 @@ def _rooting_series() -> RootingDepthSeries:
 
 
 def _soil_params() -> SoilInitializationParams:
-    return SoilInitializationParams(
-        rho=998.0,
-        g=9.81,
-        z_wt=74.0,
-        z_soil=30.0,
-        n_soil=15,
-        bc_bttm="FreeDrainage",
-        soil=SoilHydraulics(
-            n_vg=2.70,
-            alpha_vg=1.4642,
-            l_vg=0.5,
-            e_z_n=13.6,
-            e_z_k_s_sat=3.2,
-        ),
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-    )
+    return default_params().soil_initialization
 
 
 def test_biomass_fractions_matches_legacy_snapshot() -> None:
@@ -153,7 +134,7 @@ def test_huber_value_matches_legacy_snapshot() -> None:
             d_ts=np.array([0.30, 0.45, 0.50]),
             d_hw_ts=np.array([0.10, 0.20, 0.25]),
         ),
-        params=HuberValueParams(sla=0.08, xi=0.5),
+        params=default_params().huber_value,
     )
 
     assert_allclose(res, np.array([0.05, 0.05078125, 0.046875]))
@@ -166,7 +147,7 @@ def test_huber_value_zero_leaf_area_matches_legacy_behavior() -> None:
             d_ts=np.array([0.2, 0.3, 0.0]),
             d_hw_ts=np.array([0.0, 0.1, 0.0]),
         ),
-        params=HuberValueParams(sla=0.08, xi=0.5),
+        params=default_params().huber_value,
     )
 
     assert np.isinf(res[0])

--- a/tests/test_thorp_richards_equation.py
+++ b/tests/test_thorp_richards_equation.py
@@ -2,44 +2,24 @@ from __future__ import annotations
 
 import numpy as np
 
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
     RichardsEquationParams,
     richards_equation,
 )
-from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _legacy_default_like_params() -> SoilInitializationParams:
-    return SoilInitializationParams(
-        rho=998.0,
-        g=9.81,
-        z_wt=74.0,
-        z_soil=30.0,
-        n_soil=15,
-        bc_bttm="FreeDrainage",
-        soil=SoilHydraulics(n_vg=2.70, alpha_vg=1.4642, l_vg=0.5, e_z_n=13.6, e_z_k_s_sat=3.2),
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-    )
+    return default_params().soil_initialization
 
 
 def _richards_params() -> RichardsEquationParams:
-    return RichardsEquationParams(
-        dt=6 * 3600.0,
-        rho=998.0,
-        g=9.81,
-        bc_bttm="FreeDrainage",
-        z_wt=74.0,
-        p_bttm=998.0 * 9.81 * (30.0 - 74.0) / 1e6,
-        soil=SoilHydraulics(n_vg=2.70, alpha_vg=1.4642, l_vg=0.5, e_z_n=13.6, e_z_k_s_sat=3.2),
-    )
+    return default_params().richards
 
 
 def test_richards_equation_exposes_expected_equation_ids() -> None:

--- a/tests/test_thorp_root_uptake.py
+++ b/tests/test_thorp_root_uptake.py
@@ -2,48 +2,24 @@ from __future__ import annotations
 
 import numpy as np
 
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.hydraulics import (
     RootUptakeParams,
     e_from_soil_to_root_collar,
 )
 from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
-from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _legacy_default_like_initialization_params() -> SoilInitializationParams:
-    return SoilInitializationParams(
-        rho=998.0,
-        g=9.81,
-        z_wt=74.0,
-        z_soil=30.0,
-        n_soil=15,
-        bc_bttm="FreeDrainage",
-        soil=SoilHydraulics(
-            n_vg=2.70,
-            alpha_vg=1.4642,
-            l_vg=0.5,
-            e_z_n=13.6,
-            e_z_k_s_sat=3.2,
-        ),
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-    )
+    return default_params().soil_initialization
 
 
 def _root_uptake_params() -> RootUptakeParams:
-    return RootUptakeParams(
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        rho=998.0,
-        g=9.81,
-    )
+    return default_params().root_uptake
 
 
 def test_root_uptake_exposes_expected_equation_ids() -> None:

--- a/tests/test_thorp_soil_initialization.py
+++ b/tests/test_thorp_soil_initialization.py
@@ -3,28 +3,16 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     InitialSoilAndRoots,
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _legacy_default_like_params() -> SoilInitializationParams:
-    return SoilInitializationParams(
-        rho=998.0,
-        g=9.81,
-        z_wt=74.0,
-        z_soil=30.0,
-        n_soil=15,
-        bc_bttm="FreeDrainage",
-        soil=SoilHydraulics(n_vg=2.70, alpha_vg=1.4642, l_vg=0.5, e_z_n=13.6, e_z_k_s_sat=3.2),
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-    )
+    return default_params().soil_initialization
 
 
 def test_initial_soil_and_roots_matches_legacy_snapshot() -> None:

--- a/tests/test_thorp_soil_moisture.py
+++ b/tests/test_thorp_soil_moisture.py
@@ -2,65 +2,29 @@ from __future__ import annotations
 
 import numpy as np
 
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
 from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
     RichardsEquationParams,
     SoilMoistureParams,
     soil_moisture,
 )
-from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _legacy_default_like_params() -> SoilInitializationParams:
-    return SoilInitializationParams(
-        rho=998.0,
-        g=9.81,
-        z_wt=74.0,
-        z_soil=30.0,
-        n_soil=15,
-        bc_bttm="FreeDrainage",
-        soil=SoilHydraulics(
-            n_vg=2.70,
-            alpha_vg=1.4642,
-            l_vg=0.5,
-            e_z_n=13.6,
-            e_z_k_s_sat=3.2,
-        ),
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-    )
+    return default_params().soil_initialization
 
 
 def _richards_params() -> RichardsEquationParams:
-    return RichardsEquationParams(
-        dt=6 * 3600.0,
-        rho=998.0,
-        g=9.81,
-        bc_bttm="FreeDrainage",
-        z_wt=74.0,
-        p_bttm=998.0 * 9.81 * (30.0 - 74.0) / 1e6,
-        soil=SoilHydraulics(
-            n_vg=2.70,
-            alpha_vg=1.4642,
-            l_vg=0.5,
-            e_z_n=13.6,
-            e_z_k_s_sat=3.2,
-        ),
-    )
+    return default_params().richards
 
 
 def _soil_moisture_params() -> SoilMoistureParams:
-    return SoilMoistureParams(
-        richards=_richards_params(),
-        m_h2o=18.01528e-3,
-        r_gas=8.314,
-    )
+    return default_params().soil_moisture
 
 
 def test_soil_moisture_exposes_expected_equation_ids() -> None:

--- a/tests/test_thorp_stomata.py
+++ b/tests/test_thorp_stomata.py
@@ -1,101 +1,30 @@
 from __future__ import annotations
 
 import numpy as np
-from numpy.typing import NDArray
 
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
 from stomatal_optimiaztion.domains.thorp.hydraulics import (
     RootUptakeParams,
     StomataParams,
     stomata,
 )
 from stomatal_optimiaztion.domains.thorp.implements import implemented_equations
-from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
 from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 
 def _legacy_default_like_initialization_params() -> SoilInitializationParams:
-    return SoilInitializationParams(
-        rho=998.0,
-        g=9.81,
-        z_wt=74.0,
-        z_soil=30.0,
-        n_soil=15,
-        bc_bttm="FreeDrainage",
-        soil=SoilHydraulics(
-            n_vg=2.70,
-            alpha_vg=1.4642,
-            l_vg=0.5,
-            e_z_n=13.6,
-            e_z_k_s_sat=3.2,
-        ),
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-    )
+    return default_params().soil_initialization
 
 
 def _root_uptake_params() -> RootUptakeParams:
-    return RootUptakeParams(
-        beta_r_h=3388.15038831676,
-        beta_r_v=941.1528856435444,
-        vc_r=WeibullVC(b=1.2949, c=2.6471),
-        rho=998.0,
-        g=9.81,
-    )
-
-
-def _v_cmax_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
-    return 60e-6 * np.exp(8e4 * (t_l + 273.15 - 290) / 290 / 8.314 / (t_l + 273.15))
-
-
-def _j_max_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
-    return 110e-6 * np.exp(8e4 * (t_l + 273.15 - 290) / 290 / 8.314 / (t_l + 273.15))
-
-
-def _gamma_star_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
-    return 36e-6 * 101.325 * np.ones_like(t_l)
-
-
-def _k_c_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
-    return 275e-6 * 101.325 * np.ones_like(t_l)
-
-
-def _k_o_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
-    return 420000e-6 * 101.325 * np.ones_like(t_l)
-
-
-def _r_d_func(t_l: NDArray[np.floating]) -> NDArray[np.floating]:
-    return 0.01 * _v_cmax_func(t_l)
+    return default_params().root_uptake
 
 
 def _stomata_params() -> StomataParams:
-    return StomataParams(
-        root_uptake=_root_uptake_params(),
-        g_wmin=0.0,
-        c_prime1=0.98,
-        c_prime2=0.90,
-        d_ref=1.0,
-        c0=0.6411,
-        c1=0.625,
-        b2=0.9253,
-        c2=0.9296,
-        k_l=1.6e-2,
-        vc_sw=WeibullVC(b=5.3151, c=0.7951),
-        vc_l=WeibullVC(b=0.8521, c=0.8067),
-        v_cmax_func=_v_cmax_func,
-        j_max_func=_j_max_func,
-        gamma_star_func=_gamma_star_func,
-        k_c_func=_k_c_func,
-        k_o_func=_k_o_func,
-        r_d_func=_r_d_func,
-        var_kappa=6.9e-7,
-        c_a=410e-6 * 101.325,
-        o_a=21.0,
-    )
+    return default_params().stomata
 
 
 def test_stomata_exposes_expected_equation_ids() -> None:


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `default_params` seam from legacy `config.py` as a migrated default-parameter bundle.
- The scope stays limited to defaults for already-migrated seams and does not reintroduce the full legacy `THORPParams` dataclass.

## Changes
- add a THORP defaults module that exposes canonical migrated defaults for soil initialization, hydraulics, stomata, allocation, growth, and metrics helpers
- add regression coverage for legacy default values and function outputs
- update selected tests to consume the migrated defaults bundle instead of duplicating legacy constants
- update architecture docs for slice 016 and point the next seam to `THORPParams`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- creates a single source of truth for legacy default constants already used across migrated seams
- reduces test-local duplication while keeping the config seam bounded

## Linked issue
Closes #25
