### PR TITLE
Migrate THORPParams compatibility seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ poetry run ruff check .
 - THORP `rooting_depth` is migrated as slice 014.
 - THORP `soil_grid` helper is migrated as slice 015.
 - THORP `default_params` is migrated as a bounded defaults bundle in slice 016.
+- THORP `THORPParams` compatibility seam is migrated as slice 017.
 
 ## Next validation
-- Migrate the next THORP seam, likely `THORPParams`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `load_forcing`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 016
-- Gate D. Bounded slices 001 through 016 approved for THORP
+- Gate C. Validation plan ready through slice 017
+- Gate D. Bounded slices 001 through 017 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -143,3 +143,9 @@ Slice 016:
 - target: `src/stomatal_optimiaztion/domains/thorp/defaults.py`
 - scope: bounded default-parameter bundle for already migrated THORP seams
 - excluded: the legacy `THORPParams` dataclass, forcing-path setup, and simulation orchestration
+
+Slice 017:
+- source: `THORP/src/thorp/config.py` (`THORPParams`)
+- target: `src/stomatal_optimiaztion/domains/thorp/params.py`
+- scope: legacy-compatible flat parameter dataclass layered on top of migrated defaults
+- excluded: `load_forcing`, `netCDF4`-backed forcing I/O, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -172,8 +172,16 @@ The sixteenth slice ports the next bounded config seam:
 - keep the implementation bounded to migrated parameter dataclasses instead of reintroducing the full legacy `THORPParams` bundle
 - leave `THORPParams` blocked as the next config seam
 
+## Slice 017: THORP Params Compatibility
+
+The seventeenth slice ports the next bounded config seam:
+- move the legacy `THORPParams` dataclass into a dedicated compatibility module
+- reuse the migrated defaults bundle to expose a flat parameter surface for remaining adapters
+- keep forcing metadata passive instead of porting `load_forcing` or adding a new runtime dependency
+- leave `load_forcing` blocked as the next forcing seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, and defaults-bundle seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, and `THORPParams`-compatibility seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `THORPParams` or another bounded config seam
+3. prepare the next THORP source audit for `load_forcing` or another bounded forcing seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 016 implementation and validation
+- Current phase: slice 017 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP defaults-bundle slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `THORPParams`
+1. validate the migrated THORP params-compatibility slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `load_forcing`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-016-thorp-default-params-bundle.md
+++ b/docs/architecture/architecture/module_specs/module-016-thorp-default-params-bundle.md
@@ -33,4 +33,4 @@ Migrate the bounded `default_params` seam so the new package can expose canonica
 
 ## Next Seam
 
-- `THORPParams` from `config.py`
+- `load_forcing` from `forcing.py`

--- a/docs/architecture/architecture/module_specs/module-017-thorp-params-compatibility.md
+++ b/docs/architecture/architecture/module_specs/module-017-thorp-params-compatibility.md
@@ -1,0 +1,36 @@
+# Module Spec 017: THORP Params Compatibility
+
+## Purpose
+
+Migrate the bounded `THORPParams` seam so the new package can expose a legacy-compatible flat parameter dataclass without undoing the migrated defaults-bundle boundary.
+
+## Source Inputs
+
+- `THORP/src/thorp/config.py` (`THORPParams`)
+- migrated defaults bundle in `src/stomatal_optimiaztion/domains/thorp/defaults.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/params.py`
+- `tests/test_thorp_params.py`
+
+## Responsibilities
+
+1. preserve the legacy flat `THORPParams` field surface for remaining compatibility adapters
+2. reuse the migrated defaults bundle instead of duplicating already-migrated seam constants
+3. keep forcing metadata passive so the next forcing seam can migrate independently
+
+## Non-Goals
+
+- port `load_forcing` from `forcing.py`
+- add `netCDF4` as a runtime dependency
+- port simulation orchestration or the full forcing pipeline
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load_forcing` from `forcing.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only sixteen THORP runtime, reporting, helper, and config-adapter seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only seventeen THORP runtime, reporting, helper, and config-adapter seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -26,6 +26,10 @@ from stomatal_optimiaztion.domains.thorp.model_card import (
     model_card_document_names,
     require_equation_ids,
 )
+from stomatal_optimiaztion.domains.thorp.params import (
+    THORPParams,
+    thorp_params_from_defaults,
+)
 from stomatal_optimiaztion.domains.thorp.metrics import (
     BiomassFractions,
     BiomassFractionSeries,
@@ -76,6 +80,7 @@ __all__ = [
     "SoilHydraulics",
     "SoilInitializationParams",
     "SoilMoistureParams",
+    "THORPParams",
     "ThorpDefaultParams",
     "WeibullVC",
     "allocation_fractions",
@@ -95,4 +100,5 @@ __all__ = [
     "soil_moisture",
     "soil_grid",
     "stomata",
+    "thorp_params_from_defaults",
 ]

--- a/src/stomatal_optimiaztion/domains/thorp/params.py
+++ b/src/stomatal_optimiaztion/domains/thorp/params.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.defaults import (
+    ThorpDefaultParams,
+    default_params as default_bundle_params,
+)
+from stomatal_optimiaztion.domains.thorp.soil_hydraulics import SoilHydraulics
+from stomatal_optimiaztion.domains.thorp.soil_initialization import BottomBoundaryCondition
+from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
+
+ResponseCurve = Callable[[NDArray[np.floating]], NDArray[np.floating]]
+TemperatureResponse = Callable[[float | NDArray[np.floating]], float | NDArray[np.floating]]
+
+DEFAULT_RUN_NAME = "0.6RH"
+DEFAULT_DT_SAV_FILE = 60 * 24 * 3600.0
+DEFAULT_DT_SAV_DATA = float((24 * 3600.0) * np.ceil((7 * 24 * 3600.0) / (24 * 3600.0)))
+DEFAULT_SIGMA = 5.67e-8
+DEFAULT_C_P = 29.3
+DEFAULT_EPSILON_SOIL = 0.95
+DEFAULT_KAPPA_L = 0.32
+DEFAULT_PHI = 3.34
+DEFAULT_H_N = 0.0
+DEFAULT_LAI_N = 3.0
+DEFAULT_FORCING_PATH = Path("data/forcing/Poblet_reserve_Prades_Mountains_NE_Spain_v2.nc")
+DEFAULT_FORCING_LAT_RAD = float(np.pi / 180.0 * (41 + 19 / 60 + 58.05 / 3600))
+DEFAULT_FORCING_REPEAT_Q = 15
+DEFAULT_FORCING_RH_SCALE = 0.6
+DEFAULT_FORCING_PRECIP_SCALE = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class THORPParams:
+    run_name: str
+
+    dt: float
+    dt_sav_file: float
+    dt_sav_data: float
+
+    sigma: float
+    r_gas: float
+    g: float
+
+    c_p: float
+    rho: float
+    m_h2o: float
+
+    epsilon_soil: float
+    g_wmin: float
+
+    sla: float
+    xi: float
+    rho_cw: float
+
+    kappa_l: float
+    phi: float
+    h_n: float
+    lai_n: float
+    kappa_n: float
+
+    c_prime1: float
+    c_prime2: float
+
+    d_ref: float
+    b0: float
+    c0: float
+    b1: float
+    c1: float
+
+    b2: float
+    c2: float
+    k_l: float
+
+    vc_sw: WeibullVC
+    vc_l: WeibullVC
+    vc_r: WeibullVC
+    beta_r_h: float
+    beta_r_v: float
+
+    v_cmax_func: ResponseCurve
+    j_max_func: ResponseCurve
+    gamma_star_func: ResponseCurve
+    k_c_func: ResponseCurve
+    k_o_func: ResponseCurve
+    r_d_func: ResponseCurve
+
+    var_kappa: float
+
+    f_c: float
+    r_m_sw_func: TemperatureResponse
+    r_m_r_func: TemperatureResponse
+
+    tau_l: float
+    tau_sw: float
+    tau_r: float
+
+    c_a: float
+    o_a: float
+
+    soil: SoilHydraulics
+
+    z_soil: float
+    n_soil: int
+    bc_bttm: BottomBoundaryCondition
+    z_wt: float
+    p_bttm: float
+
+    forcing_path: Path
+    forcing_lat_rad: float
+    forcing_repeat_q: int
+    forcing_rh_scale: float
+    forcing_precip_scale: float
+
+
+def thorp_params_from_defaults(
+    defaults_bundle: ThorpDefaultParams | None = None,
+    *,
+    run_name: str = DEFAULT_RUN_NAME,
+    forcing_path: Path | str = DEFAULT_FORCING_PATH,
+    forcing_lat_rad: float = DEFAULT_FORCING_LAT_RAD,
+    forcing_repeat_q: int = DEFAULT_FORCING_REPEAT_Q,
+    forcing_rh_scale: float = DEFAULT_FORCING_RH_SCALE,
+    forcing_precip_scale: float = DEFAULT_FORCING_PRECIP_SCALE,
+) -> THORPParams:
+    """Build a legacy-compatible THORP flat params bundle from migrated defaults."""
+
+    bundle = defaults_bundle if defaults_bundle is not None else default_bundle_params()
+
+    soil_initialization = bundle.soil_initialization
+    richards = bundle.richards
+    soil_moisture = bundle.soil_moisture
+    root_uptake = bundle.root_uptake
+    stomata = bundle.stomata
+    allocation = bundle.allocation
+    growth = bundle.growth
+
+    h_n = DEFAULT_H_N
+    lai_n = DEFAULT_LAI_N
+    kappa_n = DEFAULT_KAPPA_L * lai_n / h_n if h_n != 0 else 0.0
+
+    return THORPParams(
+        run_name=run_name,
+        dt=richards.dt,
+        dt_sav_file=DEFAULT_DT_SAV_FILE,
+        dt_sav_data=DEFAULT_DT_SAV_DATA,
+        sigma=DEFAULT_SIGMA,
+        r_gas=soil_moisture.r_gas,
+        g=soil_initialization.g,
+        c_p=DEFAULT_C_P,
+        rho=soil_initialization.rho,
+        m_h2o=soil_moisture.m_h2o,
+        epsilon_soil=DEFAULT_EPSILON_SOIL,
+        g_wmin=stomata.g_wmin,
+        sla=allocation.sla,
+        xi=growth.xi,
+        rho_cw=growth.rho_cw,
+        kappa_l=DEFAULT_KAPPA_L,
+        phi=DEFAULT_PHI,
+        h_n=h_n,
+        lai_n=lai_n,
+        kappa_n=kappa_n,
+        c_prime1=stomata.c_prime1,
+        c_prime2=stomata.c_prime2,
+        d_ref=stomata.d_ref,
+        b0=growth.b0,
+        c0=stomata.c0,
+        b1=growth.b1,
+        c1=stomata.c1,
+        b2=stomata.b2,
+        c2=stomata.c2,
+        k_l=stomata.k_l,
+        vc_sw=stomata.vc_sw,
+        vc_l=stomata.vc_l,
+        vc_r=root_uptake.vc_r,
+        beta_r_h=root_uptake.beta_r_h,
+        beta_r_v=root_uptake.beta_r_v,
+        v_cmax_func=stomata.v_cmax_func,
+        j_max_func=stomata.j_max_func,
+        gamma_star_func=stomata.gamma_star_func,
+        k_c_func=stomata.k_c_func,
+        k_o_func=stomata.k_o_func,
+        r_d_func=stomata.r_d_func,
+        var_kappa=stomata.var_kappa,
+        f_c=growth.f_c,
+        r_m_sw_func=allocation.r_m_sw_func,
+        r_m_r_func=allocation.r_m_r_func,
+        tau_l=allocation.tau_l,
+        tau_sw=allocation.tau_sw,
+        tau_r=allocation.tau_r,
+        c_a=stomata.c_a,
+        o_a=stomata.o_a,
+        soil=soil_initialization.soil,
+        z_soil=soil_initialization.z_soil,
+        n_soil=soil_initialization.n_soil,
+        bc_bttm=soil_initialization.bc_bttm,
+        z_wt=soil_initialization.z_wt,
+        p_bttm=richards.p_bttm,
+        forcing_path=Path(forcing_path),
+        forcing_lat_rad=float(forcing_lat_rad),
+        forcing_repeat_q=int(forcing_repeat_q),
+        forcing_rh_scale=float(forcing_rh_scale),
+        forcing_precip_scale=float(forcing_precip_scale),
+    )

--- a/tests/test_thorp_params.py
+++ b/tests/test_thorp_params.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.thorp.defaults import default_params
+from stomatal_optimiaztion.domains.thorp.params import THORPParams, thorp_params_from_defaults
+
+
+def test_thorp_params_from_defaults_returns_legacy_compatible_bundle() -> None:
+    params = thorp_params_from_defaults()
+
+    assert isinstance(params, THORPParams)
+    assert params.run_name == "0.6RH"
+    assert params.dt == 6 * 3600.0
+    assert params.dt_sav_file == 60 * 24 * 3600.0
+    assert params.dt_sav_data == 7 * 24 * 3600.0
+    assert params.sigma == 5.67e-8
+    assert params.r_gas == 8.314
+    assert params.g == 9.81
+    assert params.c_p == 29.3
+    assert params.rho == 998.0
+    assert params.m_h2o == 18.01528e-3
+    assert params.epsilon_soil == 0.95
+    assert params.g_wmin == 0.0
+    assert params.sla == 0.08
+    assert params.xi == 0.5
+    assert params.rho_cw == 1.4e4
+    assert params.kappa_l == 0.32
+    assert params.phi == 3.34
+    assert params.h_n == 0.0
+    assert params.lai_n == 3.0
+    assert params.kappa_n == 0.0
+    assert params.c_prime1 == 0.98
+    assert params.c_prime2 == 0.90
+    assert params.d_ref == 1.0
+    assert params.b0 == 64.6
+    assert params.c0 == 0.6411
+    assert params.b1 == 8.5
+    assert params.c1 == 0.625
+    assert params.b2 == 0.9253
+    assert params.c2 == 0.9296
+    assert params.k_l == 1.6e-2
+    assert params.beta_r_h == 3388.15038831676
+    assert params.beta_r_v == 941.1528856435444
+    assert params.var_kappa == 6.9e-7
+    assert params.f_c == 0.28
+    assert params.tau_l == 9.5e7
+    assert params.tau_sw == 1.2e9
+    assert params.tau_r == 9.6e7
+    assert params.c_a == 0.04154325
+    assert params.o_a == 21.0
+    assert params.z_soil == 30.0
+    assert params.n_soil == 15
+    assert params.bc_bttm == "FreeDrainage"
+    assert params.z_wt == 74.0
+    assert params.p_bttm == -0.43077672000000006
+    assert params.forcing_path == Path("data/forcing/Poblet_reserve_Prades_Mountains_NE_Spain_v2.nc")
+    assert params.forcing_repeat_q == 15
+    assert params.forcing_rh_scale == 0.6
+    assert params.forcing_precip_scale == 1.0
+    assert_allclose(params.forcing_lat_rad, 0.7213933036242081)
+
+
+def test_thorp_params_from_defaults_matches_legacy_function_outputs() -> None:
+    params = thorp_params_from_defaults()
+    t_l = np.array([15.0, 25.0], dtype=float)
+
+    assert_allclose(
+        params.v_cmax_func(t_l),
+        np.array([4.8488048999784482e-05, 1.4861206096092956e-04]),
+    )
+    assert_allclose(
+        params.j_max_func(t_l),
+        np.array([8.889475649960488e-05, 2.724554450950375e-04]),
+    )
+    assert_allclose(
+        params.gamma_star_func(t_l),
+        np.array([0.0036477, 0.0036477]),
+    )
+    assert_allclose(
+        params.k_c_func(t_l),
+        np.array([0.027864375, 0.027864375]),
+    )
+    assert_allclose(
+        params.k_o_func(t_l),
+        np.array([42.5565, 42.5565]),
+    )
+    assert_allclose(
+        params.r_d_func(t_l),
+        np.array([4.8488048999784479e-07, 1.4861206096092957e-06]),
+    )
+    assert_allclose(
+        params.r_m_sw_func(t_l),
+        np.array([2.20e-12, 3.96e-12]),
+    )
+    assert_allclose(
+        params.r_m_r_func(t_l),
+        np.array([7.000e-09, 1.386e-08]),
+    )
+
+
+def test_thorp_params_from_defaults_reuses_migrated_bundle_objects() -> None:
+    defaults_bundle = default_params()
+    params = thorp_params_from_defaults(defaults_bundle)
+
+    assert params.soil is defaults_bundle.soil_initialization.soil
+    assert params.vc_r is defaults_bundle.root_uptake.vc_r
+    assert params.vc_sw is defaults_bundle.stomata.vc_sw
+    assert params.vc_l is defaults_bundle.stomata.vc_l
+    assert params.v_cmax_func is defaults_bundle.stomata.v_cmax_func
+    assert params.r_m_sw_func is defaults_bundle.allocation.r_m_sw_func
+    assert params.dt == defaults_bundle.richards.dt
+    assert params.r_gas == defaults_bundle.soil_moisture.r_gas
+    assert params.g == defaults_bundle.soil_initialization.g
+    assert params.g_wmin == defaults_bundle.stomata.g_wmin
+    assert params.beta_r_h == defaults_bundle.root_uptake.beta_r_h
+    assert params.sla == defaults_bundle.allocation.sla
+    assert params.xi == defaults_bundle.growth.xi
+    assert params.p_bttm == defaults_bundle.richards.p_bttm


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `THORPParams` seam from legacy `config.py` as a legacy-compatible flat adapter.
- The scope stays limited to a compatibility dataclass layered on top of the migrated defaults bundle and does not pull in forcing I/O.

## Changes
- add a THORP params compatibility module with a flat `THORPParams` dataclass and `thorp_params_from_defaults()` builder
- add regression coverage for legacy scalar defaults, forcing metadata, callable outputs, and bundle reuse
- export the compatibility layer from the THORP package surface
- update architecture docs for slice 017 and point the next seam to `load_forcing`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- restores the legacy flat parameter surface needed by remaining adapters without undoing migrated seam boundaries
- keeps `load_forcing` and its `netCDF4` dependency isolated as the next bounded migration step

## Linked issue
Closes #27
