### PR TITLE
Migrate THORP SimulationOutputs seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ poetry run ruff check .
 - THORP `default_params` is migrated as a bounded defaults bundle in slice 016.
 - THORP `THORPParams` compatibility seam is migrated as slice 017.
 - THORP `load_forcing` seam is migrated as slice 018.
+- THORP `SimulationOutputs` seam is migrated as slice 019.
 
 ## Next validation
-- Migrate the next THORP seam, likely `SimulationOutputs`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `_Store`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 018
-- Gate D. Bounded slices 001 through 018 approved for THORP
+- Gate C. Validation plan ready through slice 019
+- Gate D. Bounded slices 001 through 019 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -155,3 +155,9 @@ Slice 018:
 - target: `src/stomatal_optimiaztion/domains/thorp/forcing.py`
 - scope: bounded forcing netCDF ingestion, clipping, scaling, repetition, and solar-angle reconstruction
 - excluded: `SimulationOutputs`, simulation orchestration, and MAT-file export
+
+Slice 019:
+- source: `THORP/src/thorp/simulate.py` (`SimulationOutputs`)
+- target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- scope: bounded simulation-result dataclass plus legacy MAT key mapping
+- excluded: `_Store`, `simulate`, and MAT-file export

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -188,8 +188,16 @@ The eighteenth slice ports the next bounded forcing seam:
 - keep the `netCDF4` dependency isolated to this boundary and validate with temporary fixtures instead of workspace-global assets
 - leave `SimulationOutputs` blocked as the next simulation seam
 
+## Slice 019: THORP Simulation Outputs
+
+The nineteenth slice ports the next bounded simulation seam:
+- move `SimulationOutputs` from `simulate.py` into a dedicated THORP simulation module
+- preserve the legacy `as_mat_dict()` MAT key mapping without pulling in file export or time-stepping logic
+- keep the boundary limited to result storage so reporting and export adapters can target one canonical output surface
+- leave `_Store` blocked as the next simulation seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, and forcing seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, and simulation-output seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `SimulationOutputs` or another bounded simulation seam
+3. prepare the next THORP source audit for `_Store` or another bounded simulation seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 018 implementation and validation
+- Current phase: slice 019 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP forcing slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `SimulationOutputs`
+1. validate the migrated THORP simulation-outputs slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `_Store`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-018-thorp-load-forcing.md
+++ b/docs/architecture/architecture/module_specs/module-018-thorp-load-forcing.md
@@ -33,4 +33,4 @@ Migrate the bounded `load_forcing` seam so the new package can ingest THORP forc
 
 ## Next Seam
 
-- `SimulationOutputs` from `simulate.py`
+- `_Store` from `simulate.py`

--- a/docs/architecture/architecture/module_specs/module-019-thorp-simulation-outputs.md
+++ b/docs/architecture/architecture/module_specs/module-019-thorp-simulation-outputs.md
@@ -1,0 +1,35 @@
+# Module Spec 019: THORP Simulation Outputs
+
+## Purpose
+
+Migrate the bounded `SimulationOutputs` seam so the new package can expose one canonical THORP result surface before porting storage and time-stepping orchestration.
+
+## Source Inputs
+
+- `THORP/src/thorp/simulate.py` (`SimulationOutputs`)
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- `tests/test_thorp_simulation_outputs.py`
+
+## Responsibilities
+
+1. preserve the legacy result field surface used by reporting and export adapters
+2. preserve the `as_mat_dict()` mapping to legacy MAT output keys
+3. keep the seam storage-only so the next simulation slice can port buffering logic independently
+
+## Non-Goals
+
+- port `_Store` from `simulate.py`
+- port `simulate` or MAT-file export
+- change result naming or output-key compatibility
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `_Store` from `simulate.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only eighteen THORP runtime, reporting, helper, config-adapter, and forcing seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only nineteen THORP runtime, reporting, helper, config-adapter, forcing, and simulation-output seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -57,6 +57,7 @@ from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
+from stomatal_optimiaztion.domains.thorp.simulation import SimulationOutputs
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 __all__ = [
@@ -82,6 +83,7 @@ __all__ = [
     "SoilHydraulics",
     "SoilInitializationParams",
     "SoilMoistureParams",
+    "SimulationOutputs",
     "THORPParams",
     "ThorpDefaultParams",
     "WeibullVC",

--- a/src/stomatal_optimiaztion/domains/thorp/simulation.py
+++ b/src/stomatal_optimiaztion/domains/thorp/simulation.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationOutputs:
+    t_ts: NDArray[float]
+    c_nsc_ts: NDArray[float]
+    c_l_ts: NDArray[float]
+    c_sw_ts: NDArray[float]
+    c_hw_ts: NDArray[float]
+    c_r_h_by_layer_ts: NDArray[float]
+    c_r_v_by_layer_ts: NDArray[float]
+    u_l_ts: NDArray[float]
+    u_sw_ts: NDArray[float]
+    u_r_h_ts: NDArray[float]
+    u_r_v_ts: NDArray[float]
+    d_ts: NDArray[float]
+    d_hw_ts: NDArray[float]
+    h_ts: NDArray[float]
+    w_ts: NDArray[float]
+    psi_l_ts: NDArray[float]
+    psi_s_ts: NDArray[float]
+    psi_rc_ts: NDArray[float]
+    psi_rc0_ts: NDArray[float]
+    psi_soil_by_layer_ts: NDArray[float]
+    r_abs_ts: NDArray[float]
+    e_ts: NDArray[float]
+    evap_ts: NDArray[float]
+    g_w_ts: NDArray[float]
+    a_n_ts: NDArray[float]
+    r_d_ts: NDArray[float]
+    r_m_ts: NDArray[float]
+    u_ts: NDArray[float]
+
+    def as_mat_dict(self) -> dict[str, Any]:
+        return {
+            "t_stor": self.t_ts,
+            "c_NSC_stor": self.c_nsc_ts,
+            "c_l_stor": self.c_l_ts,
+            "c_sw_stor": self.c_sw_ts,
+            "c_hw_stor": self.c_hw_ts,
+            "c_r_H_stor": self.c_r_h_by_layer_ts,
+            "c_r_V_stor": self.c_r_v_by_layer_ts,
+            "u_l_stor": self.u_l_ts,
+            "u_sw_stor": self.u_sw_ts,
+            "u_r_H_stor": self.u_r_h_ts,
+            "u_r_V_stor": self.u_r_v_ts,
+            "D_stor": self.d_ts,
+            "D_hw_stor": self.d_hw_ts,
+            "H_stor": self.h_ts,
+            "W_stor": self.w_ts,
+            "P_x_l_stor": self.psi_l_ts,
+            "P_x_s_stor": self.psi_s_ts,
+            "P_x_r_stor": self.psi_rc_ts,
+            "P_x_r0_stor": self.psi_rc0_ts,
+            "P_soil_stor": self.psi_soil_by_layer_ts,
+            "R_abs_stor": self.r_abs_ts,
+            "E_stor": self.e_ts,
+            "Evap_stor": self.evap_ts,
+            "G_w_stor": self.g_w_ts,
+            "A_n_stor": self.a_n_ts,
+            "R_d_stor": self.r_d_ts,
+            "R_m_stor": self.r_m_ts,
+            "U_stor": self.u_ts,
+        }

--- a/tests/test_thorp_simulation_outputs.py
+++ b/tests/test_thorp_simulation_outputs.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.thorp.simulation import SimulationOutputs
+
+
+def _outputs() -> SimulationOutputs:
+    t_ts = np.array([0.0, 1.0, 2.0], dtype=float)
+    c_nsc_ts = np.array([10.0, 11.0, 12.0], dtype=float)
+    c_l_ts = np.array([20.0, 21.0, 22.0], dtype=float)
+    c_sw_ts = np.array([30.0, 31.0, 32.0], dtype=float)
+    c_hw_ts = np.array([40.0, 41.0, 42.0], dtype=float)
+    c_r_h_by_layer_ts = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=float)
+    c_r_v_by_layer_ts = np.array([[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]], dtype=float)
+    u_l_ts = np.array([50.0, 51.0, 52.0], dtype=float)
+    u_sw_ts = np.array([60.0, 61.0, 62.0], dtype=float)
+    u_r_h_ts = np.array([70.0, 71.0, 72.0], dtype=float)
+    u_r_v_ts = np.array([80.0, 81.0, 82.0], dtype=float)
+    d_ts = np.array([0.10, 0.11, 0.12], dtype=float)
+    d_hw_ts = np.array([0.01, 0.02, 0.03], dtype=float)
+    h_ts = np.array([1.0, 1.1, 1.2], dtype=float)
+    w_ts = np.array([0.4, 0.5, 0.6], dtype=float)
+    psi_l_ts = np.array([-1.1, -1.2, -1.3], dtype=float)
+    psi_s_ts = np.array([-0.7, -0.8, -0.9], dtype=float)
+    psi_rc_ts = np.array([-0.5, -0.6, -0.7], dtype=float)
+    psi_rc0_ts = np.array([-0.4, -0.5, -0.6], dtype=float)
+    psi_soil_by_layer_ts = np.array(
+        [[-0.2, -0.3, -0.4], [-0.5, -0.6, -0.7]],
+        dtype=float,
+    )
+    r_abs_ts = np.array([100.0, 101.0, 102.0], dtype=float)
+    e_ts = np.array([0.001, 0.002, 0.003], dtype=float)
+    evap_ts = np.array([0.01, 0.02, 0.03], dtype=float)
+    g_w_ts = np.array([0.2, 0.3, 0.4], dtype=float)
+    a_n_ts = np.array([5.0, 5.1, 5.2], dtype=float)
+    r_d_ts = np.array([0.05, 0.06, 0.07], dtype=float)
+    r_m_ts = np.array([0.15, 0.16, 0.17], dtype=float)
+    u_ts = np.array([6.0, 6.1, 6.2], dtype=float)
+
+    return SimulationOutputs(
+        t_ts=t_ts,
+        c_nsc_ts=c_nsc_ts,
+        c_l_ts=c_l_ts,
+        c_sw_ts=c_sw_ts,
+        c_hw_ts=c_hw_ts,
+        c_r_h_by_layer_ts=c_r_h_by_layer_ts,
+        c_r_v_by_layer_ts=c_r_v_by_layer_ts,
+        u_l_ts=u_l_ts,
+        u_sw_ts=u_sw_ts,
+        u_r_h_ts=u_r_h_ts,
+        u_r_v_ts=u_r_v_ts,
+        d_ts=d_ts,
+        d_hw_ts=d_hw_ts,
+        h_ts=h_ts,
+        w_ts=w_ts,
+        psi_l_ts=psi_l_ts,
+        psi_s_ts=psi_s_ts,
+        psi_rc_ts=psi_rc_ts,
+        psi_rc0_ts=psi_rc0_ts,
+        psi_soil_by_layer_ts=psi_soil_by_layer_ts,
+        r_abs_ts=r_abs_ts,
+        e_ts=e_ts,
+        evap_ts=evap_ts,
+        g_w_ts=g_w_ts,
+        a_n_ts=a_n_ts,
+        r_d_ts=r_d_ts,
+        r_m_ts=r_m_ts,
+        u_ts=u_ts,
+    )
+
+
+def test_simulation_outputs_as_mat_dict_matches_legacy_key_order() -> None:
+    outputs = _outputs()
+    mat = outputs.as_mat_dict()
+
+    assert list(mat.keys()) == [
+        "t_stor",
+        "c_NSC_stor",
+        "c_l_stor",
+        "c_sw_stor",
+        "c_hw_stor",
+        "c_r_H_stor",
+        "c_r_V_stor",
+        "u_l_stor",
+        "u_sw_stor",
+        "u_r_H_stor",
+        "u_r_V_stor",
+        "D_stor",
+        "D_hw_stor",
+        "H_stor",
+        "W_stor",
+        "P_x_l_stor",
+        "P_x_s_stor",
+        "P_x_r_stor",
+        "P_x_r0_stor",
+        "P_soil_stor",
+        "R_abs_stor",
+        "E_stor",
+        "Evap_stor",
+        "G_w_stor",
+        "A_n_stor",
+        "R_d_stor",
+        "R_m_stor",
+        "U_stor",
+    ]
+
+
+def test_simulation_outputs_as_mat_dict_preserves_array_references() -> None:
+    outputs = _outputs()
+    mat = outputs.as_mat_dict()
+
+    assert mat["t_stor"] is outputs.t_ts
+    assert mat["c_r_H_stor"] is outputs.c_r_h_by_layer_ts
+    assert mat["c_r_V_stor"] is outputs.c_r_v_by_layer_ts
+    assert mat["P_soil_stor"] is outputs.psi_soil_by_layer_ts
+
+    assert_allclose(mat["A_n_stor"], outputs.a_n_ts)
+    assert_allclose(mat["R_abs_stor"], outputs.r_abs_ts)
+    assert_allclose(mat["P_x_r0_stor"], outputs.psi_rc0_ts)
+    assert_allclose(mat["U_stor"], outputs.u_ts)


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `SimulationOutputs` seam from legacy `simulate.py`.
- The scope stays limited to the result dataclass and legacy MAT key mapping, leaving `_Store` and `simulate()` for the next slice.

## Changes
- add a THORP simulation module with `SimulationOutputs` and `as_mat_dict()`
- add regression coverage for legacy MAT key order and direct array passthrough behavior
- export the new simulation result surface from the THORP package
- update architecture docs for slice 019 and point the next seam to `_Store`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- creates one canonical simulation output surface for later reporting and export adapters
- keeps simulation orchestration blocked while unblocking the next storage seam

## Linked issue
Closes #31
