### PR TITLE
Migrate THORP _Store seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ poetry run ruff check .
 - THORP `THORPParams` compatibility seam is migrated as slice 017.
 - THORP `load_forcing` seam is migrated as slice 018.
 - THORP `SimulationOutputs` seam is migrated as slice 019.
+- THORP `_Store` seam is migrated as slice 020.
 
 ## Next validation
-- Migrate the next THORP seam, likely `_Store`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `_initial_allometry`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 019
-- Gate D. Bounded slices 001 through 019 approved for THORP
+- Gate C. Validation plan ready through slice 020
+- Gate D. Bounded slices 001 through 020 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -161,3 +161,9 @@ Slice 019:
 - target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
 - scope: bounded simulation-result dataclass plus legacy MAT key mapping
 - excluded: `_Store`, `simulate`, and MAT-file export
+
+Slice 020:
+- source: `THORP/src/thorp/simulate.py` (`_Store`)
+- target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- scope: bounded simulation-output buffering, cadence handling, and `SimulationOutputs` assembly
+- excluded: `_initial_allometry`, `run`, and MAT-file export implementation

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -196,8 +196,16 @@ The nineteenth slice ports the next bounded simulation seam:
 - keep the boundary limited to result storage so reporting and export adapters can target one canonical output surface
 - leave `_Store` blocked as the next simulation seam
 
+## Slice 020: THORP Simulation Store
+
+The twentieth slice ports the next bounded simulation seam:
+- move `_Store` from `simulate.py` into the migrated THORP simulation module
+- preserve legacy buffering cadence and `SimulationOutputs` assembly behavior
+- keep MAT export behind an injected callback instead of pulling the writer into the storage seam
+- leave `_initial_allometry` blocked as the next simulation seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, and simulation-output seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, simulation-output, and simulation-store seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `_Store` or another bounded simulation seam
+3. prepare the next THORP source audit for `_initial_allometry` or another bounded simulation seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 019 implementation and validation
+- Current phase: slice 020 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP simulation-outputs slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `_Store`
+1. validate the migrated THORP simulation-store slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `_initial_allometry`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-019-thorp-simulation-outputs.md
+++ b/docs/architecture/architecture/module_specs/module-019-thorp-simulation-outputs.md
@@ -32,4 +32,4 @@ Migrate the bounded `SimulationOutputs` seam so the new package can expose one c
 
 ## Next Seam
 
-- `_Store` from `simulate.py`
+- `_initial_allometry` from `simulate.py`

--- a/docs/architecture/architecture/module_specs/module-020-thorp-simulation-store.md
+++ b/docs/architecture/architecture/module_specs/module-020-thorp-simulation-store.md
@@ -1,0 +1,37 @@
+# Module Spec 020: THORP Simulation Store
+
+## Purpose
+
+Migrate the bounded `_Store` seam so the new package can buffer THORP simulation outputs and emit `SimulationOutputs` without porting the full simulation loop.
+
+## Source Inputs
+
+- `THORP/src/thorp/simulate.py` (`_Store`)
+- migrated `SimulationOutputs` in `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- migrated `THORPParams` compatibility bundle in `src/stomatal_optimiaztion/domains/thorp/params.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- `tests/test_thorp_simulation_store.py`
+
+## Responsibilities
+
+1. preserve legacy buffering and cadence rules for stored simulation checkpoints
+2. preserve the conversion from buffered lists into `SimulationOutputs`
+3. keep MAT export behind an injected callback so orchestration and export can migrate later
+
+## Non-Goals
+
+- port `_initial_allometry` from `simulate.py`
+- port `run` or CLI entrypoints
+- port the MATLAB writer itself
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `_initial_allometry` from `simulate.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only nineteen THORP runtime, reporting, helper, config-adapter, forcing, and simulation-output seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only twenty THORP runtime, reporting, helper, config-adapter, forcing, and simulation seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -57,7 +57,7 @@ from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.simulation import SimulationOutputs
+from stomatal_optimiaztion.domains.thorp.simulation import SimulationOutputs, _Store
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 __all__ = [
@@ -87,6 +87,7 @@ __all__ = [
     "THORPParams",
     "ThorpDefaultParams",
     "WeibullVC",
+    "_Store",
     "allocation_fractions",
     "biomass_fractions",
     "default_params",

--- a/src/stomatal_optimiaztion/domains/thorp/simulation.py
+++ b/src/stomatal_optimiaztion/domains/thorp/simulation.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
+import numpy as np
 from numpy.typing import NDArray
+
+from stomatal_optimiaztion.domains.thorp.params import THORPParams
+from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
+
+SaveMatCallback = Callable[[Path, dict[str, Any]], None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,3 +76,305 @@ class SimulationOutputs:
             "R_m_stor": self.r_m_ts,
             "U_stor": self.u_ts,
         }
+
+
+class _Store:
+    def __init__(
+        self,
+        *,
+        params: THORPParams,
+        grid: SoilGrid,
+        t_bgn: float,
+        t_end: float,
+        save_mat_callback: SaveMatCallback | None = None,
+    ) -> None:
+        self._params = params
+        self._grid = grid
+        self._t_bgn = float(t_bgn)
+        self._t_end = float(t_end)
+        self._save_mat_callback = save_mat_callback
+
+        self._t_sav_data: float | None = None
+        self._t_sav_file: float | None = None
+
+        self._t: list[float] = []
+        self._c_nsc: list[float] = []
+        self._c_l: list[float] = []
+        self._c_sw: list[float] = []
+        self._c_hw: list[float] = []
+        self._c_r_h: list[NDArray[float]] = []
+        self._c_r_v: list[NDArray[float]] = []
+
+        self._u_l: list[float] = []
+        self._u_sw: list[float] = []
+        self._u_r_h: list[float] = []
+        self._u_r_v: list[float] = []
+
+        self._d: list[float] = []
+        self._d_hw: list[float] = []
+        self._h: list[float] = []
+        self._w: list[float] = []
+
+        self._psi_l: list[float] = []
+        self._psi_s: list[float] = []
+        self._psi_rc: list[float] = []
+        self._psi_rc0: list[float] = []
+        self._psi_soil_by_layer: list[NDArray[float]] = []
+
+        self._r_abs: list[float] = []
+        self._e: list[float] = []
+        self._evap: list[float] = []
+        self._g_w: list[float] = []
+
+        self._a_n: list[float] = []
+        self._r_d: list[float] = []
+        self._r_m: list[float] = []
+        self._u: list[float] = []
+
+    def _append(
+        self,
+        *,
+        t: float,
+        c_nsc: float,
+        c_l: float,
+        c_sw: float,
+        c_hw: float,
+        c_r_h: NDArray[float],
+        c_r_v: NDArray[float],
+        u_l: float,
+        u_sw: float,
+        u_r_h: NDArray[float],
+        u_r_v: NDArray[float],
+        d: float,
+        d_hw: float,
+        h: float,
+        w: float,
+        psi_l: float,
+        psi_s: float,
+        psi_rc: float,
+        psi_rc0: float,
+        psi_soil_by_layer: NDArray[float],
+        r_abs: float,
+        e: float,
+        evap: float,
+        g_w: float,
+        a_n: float,
+        r_d: float,
+        r_m: float,
+        u: float,
+    ) -> None:
+        self._t.append(float(t))
+        self._c_nsc.append(float(c_nsc))
+        self._c_l.append(float(c_l))
+        self._c_sw.append(float(c_sw))
+        self._c_hw.append(float(c_hw))
+        self._c_r_h.append(np.asarray(c_r_h, dtype=float).copy())
+        self._c_r_v.append(np.asarray(c_r_v, dtype=float).copy())
+
+        self._u_l.append(float(u_l))
+        self._u_sw.append(float(u_sw))
+        self._u_r_h.append(float(np.sum(u_r_h)))
+        self._u_r_v.append(float(np.sum(u_r_v)))
+
+        self._d.append(float(d))
+        self._d_hw.append(float(d_hw))
+        self._h.append(float(h))
+        self._w.append(float(w))
+
+        self._psi_l.append(float(psi_l))
+        self._psi_s.append(float(psi_s))
+        self._psi_rc.append(float(psi_rc))
+        self._psi_rc0.append(float(psi_rc0))
+        self._psi_soil_by_layer.append(np.asarray(psi_soil_by_layer, dtype=float).copy())
+
+        self._r_abs.append(float(r_abs))
+        self._e.append(float(e))
+        self._evap.append(float(evap))
+        self._g_w.append(float(g_w))
+
+        self._a_n.append(float(a_n))
+        self._r_d.append(float(r_d))
+        self._r_m.append(float(r_m))
+        self._u.append(float(u))
+
+    def initialize(
+        self,
+        *,
+        t: float,
+        c_nsc: float,
+        c_l: float,
+        c_sw: float,
+        c_hw: float,
+        c_r_h: NDArray[float],
+        c_r_v: NDArray[float],
+        d: float,
+        d_hw: float,
+        h: float,
+        w: float,
+        psi_l: float,
+        psi_s: float,
+        psi_rc: float,
+        psi_rc0: float,
+        psi_soil_by_layer: NDArray[float],
+        r_abs: float,
+        e: float,
+        evap: float,
+        g_w: float,
+        a_n: float,
+        r_d: float,
+        r_m: float,
+        u: float,
+    ) -> None:
+        self._t_sav_data = self._t_bgn + 12 * 3600.0
+        self._t_sav_file = float(self._params.dt_sav_data)
+
+        self._append(
+            t=t,
+            c_nsc=c_nsc,
+            c_l=c_l,
+            c_sw=c_sw,
+            c_hw=c_hw,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+            u_l=0.0,
+            u_sw=0.0,
+            u_r_h=np.zeros_like(c_r_h, dtype=float),
+            u_r_v=np.zeros_like(c_r_v, dtype=float),
+            d=d,
+            d_hw=d_hw,
+            h=h,
+            w=w,
+            psi_l=psi_l,
+            psi_s=psi_s,
+            psi_rc=psi_rc,
+            psi_rc0=psi_rc0,
+            psi_soil_by_layer=psi_soil_by_layer,
+            r_abs=r_abs,
+            e=e,
+            evap=evap,
+            g_w=g_w,
+            a_n=a_n,
+            r_d=r_d,
+            r_m=r_m,
+            u=u,
+        )
+
+        self._t_sav_data = float(self._t_sav_data + self._params.dt_sav_data)
+
+    def maybe_store(
+        self,
+        *,
+        t: float,
+        c_nsc: float,
+        c_l: float,
+        c_sw: float,
+        c_hw: float,
+        c_r_h: NDArray[float],
+        c_r_v: NDArray[float],
+        u_l: float,
+        u_sw: float,
+        u_r_h: NDArray[float],
+        u_r_v: NDArray[float],
+        d: float,
+        d_hw: float,
+        h: float,
+        w: float,
+        psi_l: float,
+        psi_s: float,
+        psi_rc: float,
+        psi_rc0: float,
+        psi_soil_by_layer: NDArray[float],
+        r_abs: float,
+        e: float,
+        evap: float,
+        g_w: float,
+        a_n: float,
+        r_d: float,
+        r_m: float,
+        u: float,
+        save_mat_path: Path | str | None,
+    ) -> None:
+        if self._t_sav_data is None or self._t_sav_file is None:
+            raise RuntimeError("Store not initialized")
+
+        if (t == self._t_sav_data) or (abs(t - self._t_end) < self._params.dt):
+            if t == self._t_sav_data:
+                t_noon = (24 * 3600.0) * np.floor(t / (24 * 3600.0)) + 12 * 3600.0
+                if (t - t_noon) != 0:
+                    raise RuntimeError("Not noon")
+
+            self._append(
+                t=t,
+                c_nsc=c_nsc,
+                c_l=c_l,
+                c_sw=c_sw,
+                c_hw=c_hw,
+                c_r_h=c_r_h,
+                c_r_v=c_r_v,
+                u_l=u_l,
+                u_sw=u_sw,
+                u_r_h=u_r_h,
+                u_r_v=u_r_v,
+                d=d,
+                d_hw=d_hw,
+                h=h,
+                w=w,
+                psi_l=psi_l,
+                psi_s=psi_s,
+                psi_rc=psi_rc,
+                psi_rc0=psi_rc0,
+                psi_soil_by_layer=psi_soil_by_layer,
+                r_abs=r_abs,
+                e=e,
+                evap=evap,
+                g_w=g_w,
+                a_n=a_n,
+                r_d=r_d,
+                r_m=r_m,
+                u=u,
+            )
+
+            self._t_sav_data = float(self._t_sav_data + self._params.dt_sav_data)
+
+        if (t == self._t_sav_file) or (abs(t - self._t_end) < self._params.dt):
+            if save_mat_path is not None:
+                if self._save_mat_callback is None:
+                    raise RuntimeError("Store save callback not configured")
+                self._save_mat_callback(Path(save_mat_path), self.to_outputs().as_mat_dict())
+            self._t_sav_file = float(self._t_sav_file + self._params.dt_sav_file)
+
+    def to_outputs(self) -> SimulationOutputs:
+        c_r_h = np.stack(self._c_r_h, axis=1)
+        c_r_v = np.stack(self._c_r_v, axis=1)
+        psi_soil_by_layer = np.stack(self._psi_soil_by_layer, axis=1)
+
+        return SimulationOutputs(
+            t_ts=np.asarray(self._t, dtype=float),
+            c_nsc_ts=np.asarray(self._c_nsc, dtype=float),
+            c_l_ts=np.asarray(self._c_l, dtype=float),
+            c_sw_ts=np.asarray(self._c_sw, dtype=float),
+            c_hw_ts=np.asarray(self._c_hw, dtype=float),
+            c_r_h_by_layer_ts=c_r_h,
+            c_r_v_by_layer_ts=c_r_v,
+            u_l_ts=np.asarray(self._u_l, dtype=float),
+            u_sw_ts=np.asarray(self._u_sw, dtype=float),
+            u_r_h_ts=np.asarray(self._u_r_h, dtype=float),
+            u_r_v_ts=np.asarray(self._u_r_v, dtype=float),
+            d_ts=np.asarray(self._d, dtype=float),
+            d_hw_ts=np.asarray(self._d_hw, dtype=float),
+            h_ts=np.asarray(self._h, dtype=float),
+            w_ts=np.asarray(self._w, dtype=float),
+            psi_l_ts=np.asarray(self._psi_l, dtype=float),
+            psi_s_ts=np.asarray(self._psi_s, dtype=float),
+            psi_rc_ts=np.asarray(self._psi_rc, dtype=float),
+            psi_rc0_ts=np.asarray(self._psi_rc0, dtype=float),
+            psi_soil_by_layer_ts=psi_soil_by_layer,
+            r_abs_ts=np.asarray(self._r_abs, dtype=float),
+            e_ts=np.asarray(self._e, dtype=float),
+            evap_ts=np.asarray(self._evap, dtype=float),
+            g_w_ts=np.asarray(self._g_w, dtype=float),
+            a_n_ts=np.asarray(self._a_n, dtype=float),
+            r_d_ts=np.asarray(self._r_d, dtype=float),
+            r_m_ts=np.asarray(self._r_m, dtype=float),
+            u_ts=np.asarray(self._u, dtype=float),
+        )

--- a/tests/test_thorp_simulation_store.py
+++ b/tests/test_thorp_simulation_store.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.thorp.params import thorp_params_from_defaults
+from stomatal_optimiaztion.domains.thorp.simulation import _Store
+from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
+
+
+def _grid() -> SoilGrid:
+    return SoilGrid(
+        dz=np.array([0.2, 0.3], dtype=float),
+        z_bttm=np.array([0.2, 0.5], dtype=float),
+        z_mid=np.array([0.1, 0.35], dtype=float),
+        dz_c=np.array([0.1, 0.25, 0.15], dtype=float),
+    )
+
+
+def _base_state(*, t: float, offset: float = 0.0) -> dict[str, object]:
+    return {
+        "t": t,
+        "c_nsc": 10.0 + offset,
+        "c_l": 20.0 + offset,
+        "c_sw": 30.0 + offset,
+        "c_hw": 40.0 + offset,
+        "c_r_h": np.array([1.0 + offset, 2.0 + offset], dtype=float),
+        "c_r_v": np.array([0.5 + offset, 1.5 + offset], dtype=float),
+        "u_l": 50.0 + offset,
+        "u_sw": 60.0 + offset,
+        "u_r_h": np.array([3.0 + offset, 4.0 + offset], dtype=float),
+        "u_r_v": np.array([5.0 + offset, 6.0 + offset], dtype=float),
+        "d": 0.10 + offset,
+        "d_hw": 0.01 + offset,
+        "h": 1.0 + offset,
+        "w": 0.4 + offset,
+        "psi_l": -1.0 - offset,
+        "psi_s": -0.8 - offset,
+        "psi_rc": -0.6 - offset,
+        "psi_rc0": -0.5 - offset,
+        "psi_soil_by_layer": np.array([-0.3 - offset, -0.4 - offset], dtype=float),
+        "r_abs": 100.0 + offset,
+        "e": 0.001 + offset,
+        "evap": 0.01 + offset,
+        "g_w": 0.2 + offset,
+        "a_n": 5.0 + offset,
+        "r_d": 0.05 + offset,
+        "r_m": 0.15 + offset,
+        "u": 6.0 + offset,
+    }
+
+
+def _init_kwargs(*, t: float, offset: float = 0.0) -> dict[str, object]:
+    state = _base_state(t=t, offset=offset)
+    for key in ("u_l", "u_sw", "u_r_h", "u_r_v"):
+        state.pop(key)
+    return state
+
+
+def _store_kwargs(*, t: float, offset: float = 0.0) -> dict[str, object]:
+    state = _base_state(t=t, offset=offset)
+    state["save_mat_path"] = None
+    return state
+
+
+def test_store_requires_initialize_before_maybe_store() -> None:
+    params = thorp_params_from_defaults()
+    store = _Store(params=params, grid=_grid(), t_bgn=0.0, t_end=float(params.dt))
+
+    with pytest.raises(RuntimeError, match="Store not initialized"):
+        store.maybe_store(**_store_kwargs(t=float(params.dt)))
+
+
+def test_store_initialize_matches_legacy_zero_allocation_behavior() -> None:
+    params = thorp_params_from_defaults()
+    store = _Store(params=params, grid=_grid(), t_bgn=0.0, t_end=700000.0)
+
+    store.initialize(**_init_kwargs(t=0.0))
+    outputs = store.to_outputs()
+
+    assert_allclose(outputs.t_ts, np.array([0.0]))
+    assert_allclose(outputs.u_l_ts, np.array([0.0]))
+    assert_allclose(outputs.u_sw_ts, np.array([0.0]))
+    assert_allclose(outputs.u_r_h_ts, np.array([0.0]))
+    assert_allclose(outputs.u_r_v_ts, np.array([0.0]))
+    assert_allclose(outputs.c_r_h_by_layer_ts[:, 0], np.array([1.0, 2.0]))
+    assert_allclose(outputs.c_r_v_by_layer_ts[:, 0], np.array([0.5, 1.5]))
+    assert_allclose(outputs.psi_soil_by_layer_ts[:, 0], np.array([-0.3, -0.4]))
+
+
+def test_store_maybe_store_matches_legacy_data_schedule() -> None:
+    params = thorp_params_from_defaults()
+    scheduled_t = 12 * 3600.0 + params.dt_sav_data
+    store = _Store(params=params, grid=_grid(), t_bgn=0.0, t_end=scheduled_t + params.dt)
+
+    store.initialize(**_init_kwargs(t=0.0))
+    store.maybe_store(**_store_kwargs(t=scheduled_t, offset=1.0))
+    outputs = store.to_outputs()
+
+    assert_allclose(outputs.t_ts, np.array([0.0, scheduled_t]))
+    assert_allclose(outputs.u_l_ts, np.array([0.0, 51.0]))
+    assert_allclose(outputs.u_sw_ts, np.array([0.0, 61.0]))
+    assert_allclose(outputs.u_r_h_ts, np.array([0.0, 9.0]))
+    assert_allclose(outputs.u_r_v_ts, np.array([0.0, 13.0]))
+    assert_allclose(outputs.c_r_h_by_layer_ts[:, 1], np.array([2.0, 3.0]))
+    assert_allclose(outputs.psi_soil_by_layer_ts[:, 1], np.array([-1.3, -1.4]))
+
+
+def test_store_preserves_legacy_first_file_save_cadence() -> None:
+    params = thorp_params_from_defaults()
+    captures: list[tuple[Path, dict[str, object]]] = []
+    store = _Store(
+        params=params,
+        grid=_grid(),
+        t_bgn=0.0,
+        t_end=params.dt_sav_file + params.dt,
+        save_mat_callback=lambda path, data: captures.append((path, data)),
+    )
+
+    store.initialize(**_init_kwargs(t=0.0))
+    store.maybe_store(
+        **{
+            **_store_kwargs(t=params.dt_sav_data, offset=2.0),
+            "save_mat_path": Path("out.mat"),
+        }
+    )
+    outputs = store.to_outputs()
+
+    assert outputs.t_ts.size == 1
+    assert len(captures) == 1
+    assert captures[0][0] == Path("out.mat")
+    assert "t_stor" in captures[0][1]
+    assert_allclose(captures[0][1]["t_stor"], np.array([0.0]))
+
+
+def test_store_requires_noon_for_scheduled_data_store() -> None:
+    params = thorp_params_from_defaults()
+    t_bgn = 3600.0
+    scheduled_t = t_bgn + 12 * 3600.0 + params.dt_sav_data
+    store = _Store(params=params, grid=_grid(), t_bgn=t_bgn, t_end=scheduled_t + params.dt)
+
+    store.initialize(**_init_kwargs(t=t_bgn))
+
+    with pytest.raises(RuntimeError, match="Not noon"):
+        store.maybe_store(**_store_kwargs(t=scheduled_t))
+
+
+def test_store_requires_save_callback_when_path_is_provided() -> None:
+    params = thorp_params_from_defaults()
+    store = _Store(params=params, grid=_grid(), t_bgn=0.0, t_end=params.dt_sav_file + params.dt)
+
+    store.initialize(**_init_kwargs(t=0.0))
+
+    with pytest.raises(RuntimeError, match="save callback"):
+        store.maybe_store(
+            **{
+                **_store_kwargs(t=params.dt_sav_data, offset=1.0),
+                "save_mat_path": Path("out.mat"),
+            }
+        )


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `_Store` seam from legacy `simulate.py`.
- The scope stays limited to simulation buffering, cadence rules, and `SimulationOutputs` assembly, while MAT export remains behind an injected callback.

## Changes
- extend the THORP simulation module with the migrated `_Store` buffering seam
- add regression coverage for initialization behavior, scheduled data storage, scheduled file-save cadence, noon guards, and callback-based save handoff
- export the migrated storage seam from the THORP package
- update architecture docs for slice 020 and point the next seam to `_initial_allometry`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- restores legacy simulation checkpoint buffering without pulling the full `run` orchestration into the migrated package
- isolates MAT export behind a boundary that can be wired later by the orchestration seam

## Linked issue
Closes #33
