### PR TITLE
Migrate THORP _initial_allometry seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ poetry run ruff check .
 - THORP `load_forcing` seam is migrated as slice 018.
 - THORP `SimulationOutputs` seam is migrated as slice 019.
 - THORP `_Store` seam is migrated as slice 020.
+- THORP `_initial_allometry` seam is migrated as slice 021.
 
 ## Next validation
-- Migrate the next THORP seam, likely `_initial_allometry`, with behavior-preserving regression checks.
+- Migrate the next THORP seam, likely `run`, with behavior-preserving regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 020
-- Gate D. Bounded slices 001 through 020 approved for THORP
+- Gate C. Validation plan ready through slice 021
+- Gate D. Bounded slices 001 through 021 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -167,3 +167,9 @@ Slice 020:
 - target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
 - scope: bounded simulation-output buffering, cadence handling, and `SimulationOutputs` assembly
 - excluded: `_initial_allometry`, `run`, and MAT-file export implementation
+
+Slice 021:
+- source: `THORP/src/thorp/simulate.py` (`_initial_allometry`)
+- target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- scope: bounded initial geometry and carbon-pool helper for THORP startup state
+- excluded: `run`, CLI entrypoints, and simulation orchestration

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -204,8 +204,16 @@ The twentieth slice ports the next bounded simulation seam:
 - keep MAT export behind an injected callback instead of pulling the writer into the storage seam
 - leave `_initial_allometry` blocked as the next simulation seam
 
+## Slice 021: THORP Initial Allometry
+
+The twenty-first slice ports the next bounded simulation seam:
+- move `_initial_allometry` from `simulate.py` into the migrated THORP simulation module
+- preserve the legacy initial geometry and carbon-pool formulas
+- expose one explicit output structure so the later `run` seam can consume the helper without anonymous tuples
+- leave `run` blocked as the next simulation seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, simulation-output, and simulation-store seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, simulation-output, simulation-store, and initial-allometry seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `_initial_allometry` or another bounded simulation seam
+3. prepare the next THORP source audit for `run` or another bounded simulation seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 020 implementation and validation
+- Current phase: slice 021 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP simulation-store slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `_initial_allometry`
+1. validate the migrated THORP initial-allometry slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely `run`
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-020-thorp-simulation-store.md
+++ b/docs/architecture/architecture/module_specs/module-020-thorp-simulation-store.md
@@ -34,4 +34,4 @@ Migrate the bounded `_Store` seam so the new package can buffer THORP simulation
 
 ## Next Seam
 
-- `_initial_allometry` from `simulate.py`
+- `run` from `simulate.py`

--- a/docs/architecture/architecture/module_specs/module-021-thorp-initial-allometry.md
+++ b/docs/architecture/architecture/module_specs/module-021-thorp-initial-allometry.md
@@ -1,0 +1,36 @@
+# Module Spec 021: THORP Initial Allometry
+
+## Purpose
+
+Migrate the bounded `_initial_allometry` seam so the new package can reconstruct THORP initial geometry and carbon pools before porting the full simulation runner.
+
+## Source Inputs
+
+- `THORP/src/thorp/simulate.py` (`_initial_allometry`)
+- migrated `THORPParams` compatibility bundle in `src/stomatal_optimiaztion/domains/thorp/params.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- `tests/test_thorp_initial_allometry.py`
+
+## Responsibilities
+
+1. preserve the legacy initial geometry and carbon-pool formulas
+2. expose one explicit output structure for later simulation orchestration
+3. keep the helper isolated from `_Store` and `run`
+
+## Non-Goals
+
+- port `run` from `simulate.py`
+- port CLI entrypoints
+- change the legacy constants baked into the helper
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `run` from `simulate.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only twenty THORP runtime, reporting, helper, config-adapter, forcing, and simulation seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only twenty-one THORP runtime, reporting, helper, config-adapter, forcing, and simulation seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -57,7 +57,12 @@ from stomatal_optimiaztion.domains.thorp.soil_initialization import (
     SoilInitializationParams,
     initial_soil_and_roots,
 )
-from stomatal_optimiaztion.domains.thorp.simulation import SimulationOutputs, _Store
+from stomatal_optimiaztion.domains.thorp.simulation import (
+    InitialAllometry,
+    SimulationOutputs,
+    _Store,
+    _initial_allometry,
+)
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
 __all__ = [
@@ -71,6 +76,7 @@ __all__ = [
     "GrowthState",
     "HuberValueParams",
     "HuberValueSeries",
+    "InitialAllometry",
     "InitialSoilAndRoots",
     "RootingDepthSeries",
     "RadiationResult",
@@ -107,4 +113,5 @@ __all__ = [
     "soil_grid",
     "stomata",
     "thorp_params_from_defaults",
+    "_initial_allometry",
 ]

--- a/src/stomatal_optimiaztion/domains/thorp/simulation.py
+++ b/src/stomatal_optimiaztion/domains/thorp/simulation.py
@@ -78,6 +78,49 @@ class SimulationOutputs:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class InitialAllometry:
+    d: float
+    h: float
+    w: float
+    z_i: float
+    c_l: float
+    c_sw: float
+    c_hw: float
+    d_hw: float
+    c_nsc: float
+    c_r_i: float
+
+
+def _initial_allometry(*, params: THORPParams) -> InitialAllometry:
+    d = 0.015
+    h = params.b0 * (d / params.d_ref) ** params.c0
+    w = params.b1 * (d / params.d_ref) ** params.c1
+    z_i = 3.0
+    la = 0.4 * params.phi * w**2
+    c_l = la / params.sla
+    c_w = params.rho_cw * params.xi * d**2 * h
+    rmf = 0.3
+    c_r_i = (c_l + c_w) * rmf / (1 - rmf)
+    c_sw = 0.94 * c_w
+    c_hw = c_w - c_sw
+    d_hw = (c_hw / (params.rho_cw * params.xi * h)) ** 0.5
+    c_nsc = (0.20 * c_l + 0.04 * c_w) / 0.8
+
+    return InitialAllometry(
+        d=float(d),
+        h=float(h),
+        w=float(w),
+        z_i=float(z_i),
+        c_l=float(c_l),
+        c_sw=float(c_sw),
+        c_hw=float(c_hw),
+        d_hw=float(d_hw),
+        c_nsc=float(c_nsc),
+        c_r_i=float(c_r_i),
+    )
+
+
 class _Store:
     def __init__(
         self,

--- a/tests/test_thorp_initial_allometry.py
+++ b/tests/test_thorp_initial_allometry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.thorp.params import thorp_params_from_defaults
+from stomatal_optimiaztion.domains.thorp.simulation import InitialAllometry, _initial_allometry
+
+
+def test_initial_allometry_matches_legacy_snapshot() -> None:
+    res = _initial_allometry(params=thorp_params_from_defaults())
+
+    assert isinstance(res, InitialAllometry)
+    assert_allclose(res.d, 0.015)
+    assert_allclose(res.h, 4.374461757393807)
+    assert_allclose(res.w, 0.6158514419627071)
+    assert_allclose(res.z_i, 3.0)
+    assert_allclose(res.c_l, 6.333859076078014)
+    assert_allclose(res.c_sw, 6.4763906318215305)
+    assert_allclose(res.c_hw, 0.4133866360737155)
+    assert_allclose(res.d_hw, 0.0036742346141747702)
+    assert_allclose(res.c_nsc, 1.9279536324142659)
+    assert_allclose(res.c_r_i, 5.667272718845683)
+
+
+def test_initial_allometry_respects_parameter_formulas() -> None:
+    params = replace(
+        thorp_params_from_defaults(),
+        d_ref=0.5,
+        b0=50.0,
+        c0=0.7,
+        b1=6.0,
+        c1=0.55,
+        phi=2.5,
+        sla=0.1,
+        rho_cw=10000.0,
+        xi=0.25,
+    )
+
+    res = _initial_allometry(params=params)
+
+    d = 0.015
+    h = params.b0 * (d / params.d_ref) ** params.c0
+    w = params.b1 * (d / params.d_ref) ** params.c1
+    la = 0.4 * params.phi * w**2
+    c_l = la / params.sla
+    c_w = params.rho_cw * params.xi * d**2 * h
+    c_r_i = (c_l + c_w) * 0.3 / 0.7
+    c_sw = 0.94 * c_w
+    c_hw = c_w - c_sw
+    d_hw = (c_hw / (params.rho_cw * params.xi * h)) ** 0.5
+    c_nsc = (0.20 * c_l + 0.04 * c_w) / 0.8
+
+    assert_allclose(res.d, d)
+    assert_allclose(res.h, h)
+    assert_allclose(res.w, w)
+    assert_allclose(res.z_i, 3.0)
+    assert_allclose(res.c_l, c_l)
+    assert_allclose(res.c_sw, c_sw)
+    assert_allclose(res.c_hw, c_hw)
+    assert_allclose(res.d_hw, d_hw)
+    assert_allclose(res.c_nsc, c_nsc)
+    assert_allclose(res.c_r_i, c_r_i)


### PR DESCRIPTION
## Background
- This PR migrates the bounded THORP `_initial_allometry` seam from legacy `simulate.py`.
- The scope stays limited to the helper and its explicit output structure, leaving `run` orchestration for the next slice.

## Changes
- extend the THORP simulation module with `InitialAllometry` and `_initial_allometry()`
- add regression coverage for the legacy snapshot and formula-driven parameter sensitivity
- export the migrated helper seam from the THORP package
- update architecture docs for slice 021 and point the next seam to `run`

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- restores the legacy initial geometry and carbon-pool helper inside the migrated package
- removes another simulation dependency from the future `run` slice by giving it a typed startup-state helper

## Linked issue
Closes #35
