### PR TITLE
Migrate THORP run seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ poetry run ruff check .
 - THORP `SimulationOutputs` seam is migrated as slice 019.
 - THORP `_Store` seam is migrated as slice 020.
 - THORP `_initial_allometry` seam is migrated as slice 021.
+- THORP `run` seam is migrated as slice 022.
 
 ## Next validation
-- Migrate the next THORP seam, likely `run`, with behavior-preserving regression checks.
+- Migrate the remaining `simulate.py` CLI entrypoint seam with bounded smoke and regression checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 021
-- Gate D. Bounded slices 001 through 021 approved for THORP
+- Gate C. Validation plan ready through slice 022
+- Gate D. Bounded slices 001 through 022 approved for THORP
 
 ## Migrated THORP Slices
 
@@ -173,3 +173,9 @@ Slice 021:
 - target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
 - scope: bounded initial geometry and carbon-pool helper for THORP startup state
 - excluded: `run`, CLI entrypoints, and simulation orchestration
+
+Slice 022:
+- source: `THORP/src/thorp/simulate.py` (`run`)
+- target: `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- scope: bounded THORP simulation orchestration across forcing, runtime seams, growth, and buffered storage
+- excluded: CLI entrypoints and concrete MAT-file writer implementation

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -212,8 +212,16 @@ The twenty-first slice ports the next bounded simulation seam:
 - expose one explicit output structure so the later `run` seam can consume the helper without anonymous tuples
 - leave `run` blocked as the next simulation seam
 
+## Slice 022: THORP Run Orchestration
+
+The twenty-second slice ports the next bounded simulation seam:
+- move `run` from `simulate.py` into the migrated THORP simulation module
+- preserve the legacy orchestration order across forcing, radiation, stomata, allocation, soil-moisture, growth, and storage seams
+- adapt flat `THORPParams` into the migrated dataclass seams without reintroducing legacy coupling
+- leave CLI entrypoints blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, simulation-output, simulation-store, and initial-allometry seams
+1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, simulation-output, simulation-store, initial-allometry, and run seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP source audit for `run` or another bounded simulation seam
+3. prepare the next THORP source audit for the remaining `simulate.py` CLI entrypoint seam

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 021 implementation and validation
+- Current phase: slice 022 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP initial-allometry slice with `pytest` and `ruff`
-2. audit the next THORP seam, likely `run`
+1. validate the migrated THORP run slice with `pytest` and `ruff`
+2. audit the next THORP seam, likely the remaining `simulate.py` CLI entrypoint
 3. keep the TOMATO and load-cell domains blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-022-thorp-run-orchestration.md
+++ b/docs/architecture/architecture/module_specs/module-022-thorp-run-orchestration.md
@@ -1,0 +1,36 @@
+# Module Spec 022: THORP Run Orchestration
+
+## Purpose
+
+Migrate the bounded `run` seam so the new package can execute the THORP simulation orchestration end to end by composing the already migrated forcing, hydraulics, allocation, growth, and storage seams.
+
+## Source Inputs
+
+- `THORP/src/thorp/simulate.py` (`run`)
+- migrated `THORPParams`, forcing, runtime, and simulation-storage seams in `src/stomatal_optimiaztion/domains/thorp/`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/simulation.py`
+- `tests/test_thorp_run.py`
+
+## Responsibilities
+
+1. preserve the legacy orchestration order across forcing, radiation, stomata, allocation, soil moisture, growth, and storage
+2. adapt flat `THORPParams` into migrated dataclass seams without reintroducing legacy module coupling
+3. keep MAT persistence behind an injected callback instead of pulling the writer into the runner
+
+## Non-Goals
+
+- port CLI entrypoints from `simulate.py`
+- port a concrete MAT-file writer implementation
+- retune or simplify THORP numerical behavior
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- CLI entrypoints from `simulate.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -3,5 +3,5 @@
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
 | GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
-| GAP-008 | Only twenty-one THORP runtime, reporting, helper, config-adapter, forcing, and simulation seams are migrated so far | Core simulation behavior is still mostly outside the new package | next THORP module spec |
+| GAP-008 | Only twenty-two THORP runtime, reporting, helper, config-adapter, forcing, and simulation seams are migrated so far | CLI parity and end-to-end runner packaging are still incomplete | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/__init__.py
@@ -62,6 +62,7 @@ from stomatal_optimiaztion.domains.thorp.simulation import (
     SimulationOutputs,
     _Store,
     _initial_allometry,
+    run,
 )
 from stomatal_optimiaztion.domains.thorp.vulnerability import WeibullVC
 
@@ -108,6 +109,7 @@ __all__ = [
     "radiation",
     "richards_equation",
     "rooting_depth",
+    "run",
     "require_equation_ids",
     "soil_moisture",
     "soil_grid",

--- a/src/stomatal_optimiaztion/domains/thorp/simulation.py
+++ b/src/stomatal_optimiaztion/domains/thorp/simulation.py
@@ -8,10 +8,129 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
-from stomatal_optimiaztion.domains.thorp.params import THORPParams
-from stomatal_optimiaztion.domains.thorp.soil_initialization import SoilGrid
+from stomatal_optimiaztion.domains.thorp.allocation import (
+    AllocationParams,
+    allocation_fractions,
+)
+from stomatal_optimiaztion.domains.thorp.forcing import Forcing, load_forcing
+from stomatal_optimiaztion.domains.thorp.growth import GrowthParams, grow
+from stomatal_optimiaztion.domains.thorp.hydraulics import (
+    RootUptakeParams,
+    StomataParams,
+    stomata,
+)
+from stomatal_optimiaztion.domains.thorp.params import (
+    THORPParams,
+    thorp_params_from_defaults,
+)
+from stomatal_optimiaztion.domains.thorp.radiation import radiation
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import (
+    RichardsEquationParams,
+    SoilMoistureParams,
+    soil_moisture,
+)
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    SoilGrid,
+    SoilInitializationParams,
+    initial_soil_and_roots,
+)
 
 SaveMatCallback = Callable[[Path, dict[str, Any]], None]
+
+
+@dataclass(frozen=True, slots=True)
+class _RunSeamParams:
+    soil_initialization: SoilInitializationParams
+    soil_moisture: SoilMoistureParams
+    stomata: StomataParams
+    allocation: AllocationParams
+    growth: GrowthParams
+
+
+def _run_seam_params(*, params: THORPParams) -> _RunSeamParams:
+    soil_initialization = SoilInitializationParams(
+        rho=params.rho,
+        g=params.g,
+        z_wt=params.z_wt,
+        z_soil=params.z_soil,
+        n_soil=params.n_soil,
+        bc_bttm=params.bc_bttm,
+        soil=params.soil,
+        vc_r=params.vc_r,
+        beta_r_h=params.beta_r_h,
+        beta_r_v=params.beta_r_v,
+    )
+    richards = RichardsEquationParams(
+        dt=params.dt,
+        rho=params.rho,
+        g=params.g,
+        bc_bttm=params.bc_bttm,
+        z_wt=params.z_wt,
+        p_bttm=params.p_bttm,
+        soil=params.soil,
+    )
+    soil_moisture_params = SoilMoistureParams(
+        richards=richards,
+        m_h2o=params.m_h2o,
+        r_gas=params.r_gas,
+    )
+    root_uptake = RootUptakeParams(
+        beta_r_h=params.beta_r_h,
+        beta_r_v=params.beta_r_v,
+        vc_r=params.vc_r,
+        rho=params.rho,
+        g=params.g,
+    )
+    stomata_params = StomataParams(
+        root_uptake=root_uptake,
+        g_wmin=params.g_wmin,
+        c_prime1=params.c_prime1,
+        c_prime2=params.c_prime2,
+        d_ref=params.d_ref,
+        c0=params.c0,
+        c1=params.c1,
+        b2=params.b2,
+        c2=params.c2,
+        k_l=params.k_l,
+        vc_sw=params.vc_sw,
+        vc_l=params.vc_l,
+        v_cmax_func=params.v_cmax_func,
+        j_max_func=params.j_max_func,
+        gamma_star_func=params.gamma_star_func,
+        k_c_func=params.k_c_func,
+        k_o_func=params.k_o_func,
+        r_d_func=params.r_d_func,
+        var_kappa=params.var_kappa,
+        c_a=params.c_a,
+        o_a=params.o_a,
+    )
+    allocation_params = AllocationParams(
+        sla=params.sla,
+        r_m_sw_func=params.r_m_sw_func,
+        r_m_r_func=params.r_m_r_func,
+        tau_l=params.tau_l,
+        tau_sw=params.tau_sw,
+        tau_r=params.tau_r,
+    )
+    growth_params = GrowthParams(
+        allocation=allocation_params,
+        dt=params.dt,
+        f_c=params.f_c,
+        rho_cw=params.rho_cw,
+        xi=params.xi,
+        b0=params.b0,
+        d_ref=params.d_ref,
+        c0=params.c0,
+        b1=params.b1,
+        c1=params.c1,
+    )
+    return _RunSeamParams(
+        soil_initialization=soil_initialization,
+        soil_moisture=soil_moisture_params,
+        stomata=stomata_params,
+        allocation=allocation_params,
+        growth=growth_params,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -421,3 +540,235 @@ class _Store:
             r_m_ts=np.asarray(self._r_m, dtype=float),
             u_ts=np.asarray(self._u, dtype=float),
         )
+
+
+def run(
+    params: THORPParams | None = None,
+    *,
+    forcing: Forcing | None = None,
+    max_steps: int | None = None,
+    save_mat_path: str | Path | None = None,
+    save_mat_callback: SaveMatCallback | None = None,
+) -> SimulationOutputs:
+    params = thorp_params_from_defaults() if params is None else params
+    forcing = load_forcing(params=params) if forcing is None else forcing
+    seam_params = _run_seam_params(params=params)
+
+    initial = _initial_allometry(params=params)
+    init = initial_soil_and_roots(
+        params=seam_params.soil_initialization,
+        c_r_i=initial.c_r_i,
+        z_i=initial.z_i,
+    )
+    grid = init.grid
+    n_soil = grid.n_soil
+
+    c_l = initial.c_l
+    c_sw = initial.c_sw
+    c_hw = initial.c_hw
+    c_nsc = initial.c_nsc
+    c_r_h = init.c_r_h
+    c_r_v = init.c_r_v
+    h = initial.h
+    w = initial.w
+    d = initial.d
+    d_hw = initial.d_hw
+    psi_soil_by_layer = init.psi_soil_by_layer
+
+    u_l = 0.0
+    u_r_h = np.zeros(n_soil, dtype=float)
+    u_r_v = np.zeros(n_soil, dtype=float)
+    u_sw = 0.0
+
+    t_allocate = 3600.0 * (24.0 * np.floor(0.0 / 3600.0 / 24.0) + 12.0)
+    store = _Store(
+        params=params,
+        grid=grid,
+        t_bgn=float(forcing.t[0]),
+        t_end=float(forcing.t_end),
+        save_mat_callback=save_mat_callback,
+    )
+    save_path = Path(save_mat_path) if save_mat_path is not None else None
+
+    n_steps = forcing.t.size - 1
+    if max_steps is not None:
+        n_steps = min(n_steps, int(max_steps))
+
+    for step in range(n_steps):
+        t = float(forcing.t[step])
+        t_a = float(forcing.t_a[step])
+        t_soil = float(forcing.t_soil[step])
+        rh = float(forcing.rh[step])
+        precip = float(forcing.precip[step])
+        u10 = float(forcing.u10[step])
+        r_incom = float(forcing.r_incom[step])
+        z_a = float(forcing.z_a[step])
+
+        la_area = float(params.sla * c_l)
+        rad = radiation(
+            r_incom=r_incom,
+            z_a=z_a,
+            la=la_area,
+            w=w,
+            h=h,
+            h_n=params.h_n,
+            kappa_l=params.kappa_l,
+            kappa_n=params.kappa_n,
+            phi=params.phi,
+        )
+        stom = stomata(
+            params=seam_params.stomata,
+            psi_soil_by_layer=psi_soil_by_layer,
+            n_soil=n_soil,
+            dz=grid.dz,
+            z_soil_mid=grid.z_mid,
+            t_a=t_a,
+            rh=rh,
+            r_abs=rad.r_abs,
+            la=la_area,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+            h=h,
+            w=w,
+            d=d,
+            d_hw=d_hw,
+            d_r_abs_d_h=rad.d_r_abs_dh,
+            d_r_abs_d_w=rad.d_r_abs_dw,
+            d_r_abs_d_la=rad.d_r_abs_dla,
+        )
+
+        if t >= t_allocate:
+            alloc = allocation_fractions(
+                params=seam_params.allocation,
+                a_n=stom.a_n,
+                lambda_wue=stom.lambda_wue,
+                d_a_n_d_r_abs=stom.d_a_n_d_r_abs,
+                d_e_d_la=stom.d_e_d_la,
+                d_e_d_d=stom.d_e_d_d,
+                d_e_d_c_r_h=stom.d_e_d_c_r_h,
+                d_e_d_c_r_v=stom.d_e_d_c_r_v,
+                d_r_abs_d_h=rad.d_r_abs_dh,
+                d_r_abs_d_w=rad.d_r_abs_dw,
+                d_r_abs_d_la=rad.d_r_abs_dla,
+                h=h,
+                w=w,
+                d=d,
+                c_w=float(c_sw + c_hw),
+                c_l=c_l,
+                c0=params.c0,
+                c1=params.c1,
+                t_a=t_a,
+                t_soil=t_soil,
+            )
+            u_l = alloc.u_l
+            u_r_h = alloc.u_r_h
+            u_r_v = alloc.u_r_v
+            u_sw = alloc.u_sw
+
+            if float(u_l + np.sum(u_r_h + u_r_v) + u_sw) == 0.0:
+                raise RuntimeError("Allocation fractions sum to zero")
+            t_allocate = float(t_allocate + 24 * 3600.0)
+
+        psi_soil_by_layer, evap = soil_moisture(
+            params=seam_params.soil_moisture,
+            grid=grid,
+            psi_soil_by_layer=psi_soil_by_layer,
+            t_a=t_a,
+            t_soil=t_soil,
+            rh=rh,
+            u10=u10,
+            precip=precip,
+            e_soil=stom.e_soil,
+            la=la_area,
+            w=w,
+        )
+        gstate = grow(
+            params=seam_params.growth,
+            u_l=u_l,
+            u_r_h=u_r_h,
+            u_r_v=u_r_v,
+            u_sw=u_sw,
+            a_n=stom.a_n,
+            r_d=stom.r_d,
+            c_l=c_l,
+            c_r_h=c_r_h,
+            c_r_v=c_r_v,
+            c_sw=c_sw,
+            c_hw=c_hw,
+            c_nsc=c_nsc,
+            t_a=t_a,
+            t_soil=t_soil,
+        )
+
+        c_l = gstate.c_l
+        c_r_h = gstate.c_r_h
+        c_r_v = gstate.c_r_v
+        c_sw = gstate.c_sw
+        c_hw = gstate.c_hw
+        c_nsc = gstate.c_nsc
+        h = gstate.h
+        w = gstate.w
+        d = gstate.d
+        d_hw = gstate.d_hw
+
+        if step == 0:
+            store.initialize(
+                t=t,
+                c_nsc=c_nsc,
+                c_l=c_l,
+                c_sw=c_sw,
+                c_hw=c_hw,
+                c_r_h=c_r_h,
+                c_r_v=c_r_v,
+                d=d,
+                d_hw=d_hw,
+                h=h,
+                w=w,
+                psi_l=stom.psi_l,
+                psi_s=stom.psi_s,
+                psi_rc=stom.psi_rc,
+                psi_rc0=stom.psi_rc0,
+                psi_soil_by_layer=psi_soil_by_layer,
+                r_abs=rad.r_abs,
+                e=stom.e,
+                evap=evap,
+                g_w=stom.g_w,
+                a_n=stom.a_n,
+                r_d=stom.r_d,
+                r_m=gstate.r_m,
+                u=gstate.u,
+            )
+        else:
+            store.maybe_store(
+                t=t,
+                c_nsc=c_nsc,
+                c_l=c_l,
+                c_sw=c_sw,
+                c_hw=c_hw,
+                c_r_h=c_r_h,
+                c_r_v=c_r_v,
+                u_l=u_l,
+                u_sw=u_sw,
+                u_r_h=u_r_h,
+                u_r_v=u_r_v,
+                d=d,
+                d_hw=d_hw,
+                h=h,
+                w=w,
+                psi_l=stom.psi_l,
+                psi_s=stom.psi_s,
+                psi_rc=stom.psi_rc,
+                psi_rc0=stom.psi_rc0,
+                psi_soil_by_layer=psi_soil_by_layer,
+                r_abs=rad.r_abs,
+                e=stom.e,
+                evap=evap,
+                g_w=stom.g_w,
+                a_n=stom.a_n,
+                r_d=stom.r_d,
+                r_m=gstate.r_m,
+                u=gstate.u,
+                save_mat_path=save_path,
+            )
+
+    return store.to_outputs()

--- a/tests/test_thorp_run.py
+++ b/tests/test_thorp_run.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import stomatal_optimiaztion.domains.thorp.simulation as simulation
+from stomatal_optimiaztion.domains.thorp.growth import GrowthParams
+from stomatal_optimiaztion.domains.thorp.hydraulics import StomataParams
+from stomatal_optimiaztion.domains.thorp.params import (
+    DEFAULT_RUN_NAME,
+    THORPParams,
+    thorp_params_from_defaults,
+)
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import SoilMoistureParams
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    InitialSoilAndRoots,
+    SoilGrid,
+    SoilInitializationParams,
+)
+
+
+def _grid() -> SoilGrid:
+    return SoilGrid(
+        dz=np.array([0.2, 0.3], dtype=float),
+        z_bttm=np.array([0.2, 0.5], dtype=float),
+        z_mid=np.array([0.1, 0.35], dtype=float),
+        dz_c=np.array([0.1, 0.25, 0.15], dtype=float),
+    )
+
+
+def _initialization_result() -> InitialSoilAndRoots:
+    return InitialSoilAndRoots(
+        grid=_grid(),
+        psi_soil_by_layer=np.array([-0.3, -0.4], dtype=float),
+        vwc=np.array([0.25, 0.20], dtype=float),
+        c_r_h=np.array([1.0, 2.0], dtype=float),
+        c_r_v=np.array([0.5, 1.5], dtype=float),
+    )
+
+
+def _forcing(t: np.ndarray) -> simulation.Forcing:
+    t = np.asarray(t, dtype=float)
+    return simulation.Forcing(
+        t=t,
+        t_a=np.full_like(t, 20.0, dtype=float),
+        t_soil=np.full_like(t, 18.0, dtype=float),
+        rh=np.full_like(t, 0.6, dtype=float),
+        precip=np.zeros_like(t, dtype=float),
+        u10=np.full_like(t, 1.5, dtype=float),
+        r_incom=np.full_like(t, 300.0, dtype=float),
+        z_a=np.zeros_like(t, dtype=float),
+    )
+
+
+def _install_stubbed_runtime(
+    monkeypatch,
+    *,
+    captures: dict[str, object] | None = None,
+) -> None:
+    init = _initialization_result()
+
+    def fake_initial_soil_and_roots(*, params, c_r_i, z_i):
+        if captures is not None:
+            captures.setdefault("soil_init_params", params)
+            captures.setdefault("c_r_i", c_r_i)
+            captures.setdefault("z_i", z_i)
+        return init
+
+    def fake_radiation(**kwargs):
+        return SimpleNamespace(
+            r_abs=100.0,
+            d_r_abs_dh=1.0,
+            d_r_abs_dw=2.0,
+            d_r_abs_dla=3.0,
+        )
+
+    def fake_stomata(*, params, **kwargs):
+        if captures is not None:
+            captures.setdefault("stomata_params", params)
+        return SimpleNamespace(
+            psi_l=-1.0,
+            psi_s=-0.8,
+            psi_rc=-0.6,
+            psi_rc0=-0.5,
+            e=0.01,
+            e_soil=np.array([0.001, 0.002], dtype=float),
+            a_n=5.0,
+            r_d=0.05,
+            g_w=0.2,
+            lambda_wue=0.1,
+            d_a_n_d_r_abs=0.2,
+            d_e_d_la=0.3,
+            d_e_d_d=0.4,
+            d_e_d_c_r_h=np.array([0.5, 0.6], dtype=float),
+            d_e_d_c_r_v=np.array([0.7, 0.8], dtype=float),
+        )
+
+    def fake_allocation_fractions(**kwargs):
+        return SimpleNamespace(
+            u_l=0.1,
+            u_r_h=np.array([0.1, 0.2], dtype=float),
+            u_r_v=np.array([0.3, 0.4], dtype=float),
+            u_sw=0.5,
+        )
+
+    def fake_soil_moisture(*, params, grid, psi_soil_by_layer, **kwargs):
+        if captures is not None:
+            captures.setdefault("soil_moisture_params", params)
+        return np.asarray(psi_soil_by_layer, dtype=float), 0.05
+
+    def fake_grow(*, params, **kwargs):
+        if captures is not None:
+            captures.setdefault("growth_params", params)
+        return SimpleNamespace(
+            c_l=11.0,
+            c_r_h=np.array([1.0, 2.0], dtype=float),
+            c_r_v=np.array([0.5, 1.5], dtype=float),
+            c_sw=12.0,
+            c_hw=13.0,
+            c_nsc=14.0,
+            h=2.0,
+            w=3.0,
+            d=0.4,
+            d_hw=0.2,
+            r_m=0.3,
+            u=0.4,
+        )
+
+    monkeypatch.setattr(simulation, "initial_soil_and_roots", fake_initial_soil_and_roots)
+    monkeypatch.setattr(simulation, "radiation", fake_radiation)
+    monkeypatch.setattr(simulation, "stomata", fake_stomata)
+    monkeypatch.setattr(simulation, "allocation_fractions", fake_allocation_fractions)
+    monkeypatch.setattr(simulation, "soil_moisture", fake_soil_moisture)
+    monkeypatch.setattr(simulation, "grow", fake_grow)
+
+
+def test_run_uses_default_params_and_loads_forcing_when_omitted(monkeypatch) -> None:
+    captures: dict[str, object] = {}
+
+    def fake_load_forcing(*, params):
+        captures["loaded_params"] = params
+        return _forcing(np.array([0.0, params.dt], dtype=float))
+
+    monkeypatch.setattr(simulation, "load_forcing", fake_load_forcing)
+    _install_stubbed_runtime(monkeypatch, captures=captures)
+
+    outputs = simulation.run(max_steps=1)
+
+    loaded_params = captures["loaded_params"]
+    assert isinstance(loaded_params, THORPParams)
+    assert loaded_params.run_name == DEFAULT_RUN_NAME
+
+    soil_init_params = captures["soil_init_params"]
+    stomata_params = captures["stomata_params"]
+    soil_moisture_params = captures["soil_moisture_params"]
+    growth_params = captures["growth_params"]
+
+    assert isinstance(soil_init_params, SoilInitializationParams)
+    assert soil_init_params.n_soil == loaded_params.n_soil
+    assert isinstance(stomata_params, StomataParams)
+    assert stomata_params.d_ref == loaded_params.d_ref
+    assert isinstance(soil_moisture_params, SoilMoistureParams)
+    assert soil_moisture_params.richards.dt == loaded_params.dt
+    assert isinstance(growth_params, GrowthParams)
+    assert growth_params.allocation.sla == loaded_params.sla
+
+    assert_allclose(outputs.t_ts, np.array([0.0]))
+    assert_allclose(outputs.a_n_ts, np.array([5.0]))
+    assert_allclose(outputs.evap_ts, np.array([0.05]))
+    assert_allclose(outputs.psi_soil_by_layer_ts[:, 0], np.array([-0.3, -0.4]))
+
+
+def test_run_matches_legacy_storage_schedule_with_stubbed_runtime_seams(monkeypatch) -> None:
+    params = thorp_params_from_defaults()
+    scheduled_t = 12 * 3600.0 + params.dt_sav_data
+    forcing = _forcing(np.arange(0.0, scheduled_t + 2 * params.dt, params.dt, dtype=float))
+
+    def fake_load_forcing(*, params):
+        raise AssertionError("load_forcing should not be called when forcing is provided")
+
+    monkeypatch.setattr(simulation, "load_forcing", fake_load_forcing)
+    _install_stubbed_runtime(monkeypatch)
+
+    outputs = simulation.run(params=params, forcing=forcing)
+
+    assert_allclose(outputs.t_ts, np.array([0.0, scheduled_t]))
+    assert_allclose(outputs.u_l_ts, np.array([0.0, 0.1]))
+    assert_allclose(outputs.u_sw_ts, np.array([0.0, 0.5]))
+    assert_allclose(outputs.u_r_h_ts, np.array([0.0, 0.3]))
+    assert_allclose(outputs.u_r_v_ts, np.array([0.0, 0.7]))
+    assert_allclose(outputs.r_m_ts, np.array([0.3, 0.3]))
+    assert_allclose(outputs.u_ts, np.array([0.4, 0.4]))
+
+
+def test_run_forwards_save_callback_to_store(monkeypatch) -> None:
+    params = thorp_params_from_defaults()
+    forcing = _forcing(np.arange(0.0, params.dt_sav_data + 2 * params.dt, params.dt, dtype=float))
+    captures: list[tuple[Path, dict[str, object]]] = []
+
+    _install_stubbed_runtime(monkeypatch)
+
+    outputs = simulation.run(
+        params=params,
+        forcing=forcing,
+        save_mat_path="out.mat",
+        save_mat_callback=lambda path, data: captures.append((path, data)),
+    )
+
+    assert outputs.t_ts.size == 1
+    assert len(captures) == 1
+    assert captures[0][0] == Path("out.mat")
+    assert "t_stor" in captures[0][1]
+    assert_allclose(captures[0][1]["t_stor"], np.array([0.0]))


### PR DESCRIPTION
## Summary
- migrate the bounded THORP `run` orchestration seam into `src/stomatal_optimiaztion/domains/thorp/simulation.py`
- adapt flat `THORPParams` into migrated runtime dataclasses without reintroducing legacy module coupling
- add bounded regression tests for default forcing loading, scheduled storage cadence, and save-callback wiring

## Validation
- `.venv\Scripts\python.exe -m pytest -q`
- `.venv\Scripts\python.exe -m ruff check .`

Closes #37
