### PR TITLE
Migrate TOMATO tTHORP contracts seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ poetry run ruff check .
 - THORP `run` seam is migrated as slice 022.
 - THORP `matlab_io` seam is migrated as slice 023.
 - THORP CLI entrypoint seam is migrated as slice 024.
+- TOMATO `tTHORP` contracts seam is migrated as slice 025.
 
 ## Next validation
-- Run a representative package-local THORP CLI smoke and decide whether the next bounded slice should target THORP hardening or the first TOMATO seam.
+- Migrate the next TOMATO `tTHORP` seam, likely `interface.py`, with behavior-preserving contract checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 024
-- Gate D. Bounded slices 001 through 024 approved for THORP
+- Gate C. Validation plan ready through slice 025
+- Gate D. Bounded slices 001 through 024 approved for THORP and slice 025 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -191,3 +191,9 @@ Slice 024:
 - target: `src/stomatal_optimiaztion/domains/thorp/cli.py` and `src/stomatal_optimiaztion/domains/thorp/__main__.py`
 - scope: bounded package-local CLI wrapper over migrated `run` and `save_mat` seams
 - excluded: THORP numerical changes and broader workspace entrypoints
+
+Slice 025:
+- source: `TOMATO/tTHORP/src/tthorp/contracts.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/`
+- scope: bounded TOMATO forcing-step contracts, context protocol, and output coercion helpers
+- excluded: pandas-backed interface surfaces, adapters, pipelines, and CLI entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -236,8 +236,16 @@ The twenty-fourth slice ports the remaining bounded THORP execution seam:
 - wire the migrated `run` seam to the migrated `save_mat` callback without reintroducing legacy imports
 - leave representative end-to-end CLI smoke validation as the next hardening step
 
+## Slice 025: TOMATO tTHORP Contracts
+
+The twenty-fifth slice opens the first bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/contracts.py` into the staged `domains/tomato/tthorp` package
+- preserve `EnvStep`, `Context`, `Module`, and output-coercion behavior
+- keep the first TOMATO slice stdlib-only so nested-workspace boundaries are explicit before interface and pipeline migration
+- leave `tTHORP/interface.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated model-card, radiation, hydraulic primitives, soil initialization, Richards-equation, soil-moisture, root-uptake, stomata, allocation, grow, biomass-fraction, Huber-value, rooting-depth, soil-grid, defaults-bundle, `THORPParams`-compatibility, forcing, simulation-output, simulation-store, initial-allometry, run, MATLAB-IO, and CLI seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first TOMATO `tTHORP` contract seam
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare representative package-local CLI smoke validation and the next non-THORP source audit
+3. prepare the next TOMATO source audit for `tTHORP/interface.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 024 implementation and validation
+- Current phase: slice 025 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated THORP CLI slice with `pytest` and `ruff`
-2. run a representative package-local THORP CLI smoke
-3. keep the TOMATO and load-cell domains blocked until their source audits are deeper
+1. validate the migrated TOMATO `tTHORP` contract slice with `pytest` and `ruff`
+2. audit the next TOMATO seam, likely `tTHORP/interface.py`
+3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-025-tomato-tthorp-contracts.md
+++ b/docs/architecture/architecture/module_specs/module-025-tomato-tthorp-contracts.md
@@ -1,0 +1,36 @@
+# Module Spec 025: TOMATO tTHORP Contracts
+
+## Purpose
+
+Start the TOMATO migration with the smallest explicit `tTHORP` seam: the step contracts and coercion helpers that define forcing rows, context mutation, and bounded output validation.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/contracts.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/contracts.py`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py`
+- `tests/test_tomato_tthorp_contracts.py`
+
+## Responsibilities
+
+1. preserve the legacy `EnvStep.from_row` parsing and timestep clipping behavior
+2. preserve the `Context` and `Module` step-contract surface for later pipeline slices
+3. keep the first TOMATO slice stdlib-only so the nested workspace boundary is explicit before adding pandas-backed interfaces
+
+## Non-Goals
+
+- port `interface.py`
+- port tomato adapters, pipelines, or CLI entrypoints
+- introduce shared abstractions between THORP and TOMATO
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/interface.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | Legacy source inventory is only top-level outside THORP slices 001-006 | Risks hidden coupling in TOMATO and load-cell migrations | deeper domain audit note |
+| GAP-002 | TOMATO and load-cell migration depth is still shallow beyond the first `tTHORP` contract seam | Risks hidden coupling in nested adapters, pipelines, and cross-package interfaces | deeper domain audit note |
 | GAP-008 | Only twenty-four THORP runtime, reporting, helper, config-adapter, forcing, simulation, IO, and CLI seams are migrated so far | Representative package-level smoke validation and next-domain planning are still incomplete | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/__init__.py
+++ b/src/stomatal_optimiaztion/domains/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["thorp"]
+__all__ = ["thorp", "tomato"]

--- a/src/stomatal_optimiaztion/domains/tomato/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/__init__.py
@@ -1,0 +1,3 @@
+from stomatal_optimiaztion.domains.tomato import tthorp
+
+__all__ = ["tthorp"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
@@ -1,0 +1,12 @@
+"""tTHORP package."""
+
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import Context, EnvStep, Module
+
+MODEL_NAME = "tTHORP"
+
+__all__ = [
+    "MODEL_NAME",
+    "Context",
+    "EnvStep",
+    "Module",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/contracts.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Mapping, MutableMapping, Protocol, runtime_checkable
+
+MoistureResponseFn = Callable[[float], float]
+Params = Mapping[str, object]
+StateStore = MutableMapping[str, object]
+StepOutputs = Mapping[str, float | int]
+_MAX_DEFAULT_DT_S = 6.0 * 3600.0
+
+
+def _read_required_value(row: Mapping[str, object], key: str) -> object:
+    if key not in row:
+        raise KeyError(f"EnvStep.from_row: missing required field '{key}'.")
+    return row[key]
+
+
+def _read_datetime(value: object, *, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+
+    to_pydatetime = getattr(value, "to_pydatetime", None)
+    if callable(to_pydatetime):
+        dt = to_pydatetime()
+        if isinstance(dt, datetime):
+            return dt
+
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"EnvStep.from_row: field '{field_name}' must be a datetime-like value, got {value!r}."
+            ) from exc
+
+    raise TypeError(
+        f"EnvStep.from_row: field '{field_name}' must be a datetime-like value, got {type(value).__name__}."
+    )
+
+
+def _read_required_float(row: Mapping[str, object], key: str) -> float:
+    raw = _read_required_value(row, key)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"EnvStep.from_row: required field '{key}' must be numeric.") from exc
+    if not math.isfinite(value):
+        raise ValueError(f"EnvStep.from_row: required field '{key}' must be finite, got {value!r}.")
+    return value
+
+
+def _read_optional_float(row: Mapping[str, object], key: str) -> float | None:
+    if key not in row:
+        return None
+
+    raw = row[key]
+    if raw is None:
+        return None
+
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def _read_optional_int(row: Mapping[str, object], key: str) -> int | None:
+    value = _read_optional_float(row, key)
+    if value is None:
+        return None
+    return int(round(value))
+
+
+@dataclass(frozen=True, slots=True)
+class EnvStep:
+    t: datetime
+    dt_s: float
+    T_air_C: float
+    PAR_umol: float
+    CO2_ppm: float
+    RH_percent: float
+    wind_speed_ms: float
+    SW_in_Wm2: float | None = None
+    T_rad_C: float | None = None
+    n_fruits_per_truss: int | None = None
+
+    @classmethod
+    def from_row(
+        cls,
+        row: Mapping[str, object],
+        prev_datetime: datetime | None,
+        dt_default: float,
+    ) -> "EnvStep":
+        t = _read_datetime(_read_required_value(row, "datetime"), field_name="datetime")
+
+        try:
+            dt_default_s = float(dt_default)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"EnvStep.from_row: dt_default must be numeric, got {dt_default!r}.") from exc
+        if not math.isfinite(dt_default_s):
+            raise ValueError(f"EnvStep.from_row: dt_default must be finite, got {dt_default_s!r}.")
+        dt_default_s = min(max(dt_default_s, 1.0), _MAX_DEFAULT_DT_S)
+
+        if prev_datetime is None:
+            dt_s = dt_default_s
+        else:
+            prev_t = _read_datetime(prev_datetime, field_name="prev_datetime")
+            dt_s = max(1.0, (t - prev_t).total_seconds())
+
+        return cls(
+            t=t,
+            dt_s=float(dt_s),
+            T_air_C=_read_required_float(row, "T_air_C"),
+            PAR_umol=_read_required_float(row, "PAR_umol"),
+            CO2_ppm=_read_required_float(row, "CO2_ppm"),
+            RH_percent=_read_required_float(row, "RH_percent"),
+            wind_speed_ms=_read_required_float(row, "wind_speed_ms"),
+            SW_in_Wm2=_read_optional_float(row, "SW_in_Wm2"),
+            T_rad_C=_read_optional_float(row, "T_rad_C"),
+            n_fruits_per_truss=_read_optional_int(row, "n_fruits_per_truss"),
+        )
+
+
+@dataclass(slots=True)
+class Context:
+    env: EnvStep
+    state: StateStore
+    params: Params
+    out: dict[str, float]
+
+
+@runtime_checkable
+class Module(Protocol):
+    def __call__(self, ctx: Context) -> None:
+        """Mutate context state/output for one simulation step."""
+
+
+def clamp_unit_interval(value: float) -> float:
+    if value < 0:
+        return 0.0
+    if value > 1:
+        return 1.0
+    return value
+
+
+def coerce_finite_outputs(outputs: StepOutputs, *, where: str) -> dict[str, float]:
+    """Validate run-step outputs and convert values to plain finite floats."""
+
+    out: dict[str, float] = {}
+    for key, raw in outputs.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{where}: output keys must be non-empty strings.")
+        try:
+            value = float(raw)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"{where}: output '{key}' must be numeric, got {type(raw).__name__}.") from exc
+        if not math.isfinite(value):
+            raise ValueError(f"{where}: output '{key}' must be finite, got {value!r}.")
+        out[key] = value
+    return out
+
+
+def water_supply_stress_from_theta(theta_substrate: float, moisture_response_fn: MoistureResponseFn) -> float:
+    return clamp_unit_interval(float(moisture_response_fn(theta_substrate)))

--- a/tests/test_tomato_tthorp_contracts.py
+++ b/tests/test_tomato_tthorp_contracts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp import MODEL_NAME
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import (
+    Context,
+    EnvStep,
+    clamp_unit_interval,
+    coerce_finite_outputs,
+    water_supply_stress_from_theta,
+)
+
+
+def _forcing_row(
+    *,
+    t: datetime,
+    t_air_c: float = 25.0,
+    par_umol: float = 400.0,
+    co2_ppm: float = 420.0,
+    rh_percent: float = 60.0,
+    wind_speed_ms: float = 1.0,
+) -> dict[str, object]:
+    return {
+        "datetime": t,
+        "T_air_C": t_air_c,
+        "PAR_umol": par_umol,
+        "CO2_ppm": co2_ppm,
+        "RH_percent": rh_percent,
+        "wind_speed_ms": wind_speed_ms,
+    }
+
+
+def test_tthorp_import_surface_exposes_model_name() -> None:
+    assert MODEL_NAME == "tTHORP"
+
+
+def test_envstep_from_row_uses_clipped_default_then_elapsed_seconds() -> None:
+    t0 = datetime(2026, 1, 1, 0, 0, 0)
+    first = EnvStep.from_row(_forcing_row(t=t0), prev_datetime=None, dt_default=10.0 * 3600.0)
+    assert first.dt_s == 6.0 * 3600.0
+
+    t1 = t0 + timedelta(minutes=30)
+    second = EnvStep.from_row(_forcing_row(t=t1), prev_datetime=t0, dt_default=5.0)
+    assert second.dt_s == 1800.0
+
+    earlier = EnvStep.from_row(_forcing_row(t=t0 - timedelta(minutes=5)), prev_datetime=t0, dt_default=5.0)
+    assert earlier.dt_s == 1.0
+
+
+def test_envstep_from_row_rejects_missing_required_field() -> None:
+    row = _forcing_row(t=datetime(2026, 1, 1, 0, 0, 0))
+    row.pop("PAR_umol")
+
+    with pytest.raises(KeyError, match="missing required field 'PAR_umol'"):
+        EnvStep.from_row(row, prev_datetime=None, dt_default=3600.0)
+
+
+def test_coerce_finite_outputs_rejects_non_finite_values() -> None:
+    with pytest.raises(ValueError):
+        coerce_finite_outputs({"e": float("nan")}, where="unit-test")
+
+
+def test_water_supply_stress_clamps_to_unit_interval() -> None:
+    assert clamp_unit_interval(-0.2) == 0.0
+    assert clamp_unit_interval(0.4) == 0.4
+    assert clamp_unit_interval(1.2) == 1.0
+    assert water_supply_stress_from_theta(0.2, lambda _: -0.1) == 0.0
+    assert water_supply_stress_from_theta(0.2, lambda _: 1.2) == 1.0
+
+
+def test_context_holds_env_state_and_outputs() -> None:
+    env = EnvStep.from_row(
+        _forcing_row(t=datetime(2026, 1, 1, 0, 0, 0)),
+        prev_datetime=None,
+        dt_default=3600.0,
+    )
+    ctx = Context(env=env, state={"signal": 1.0}, params={"gain": 2.0}, out={"e": 0.3})
+
+    assert ctx.env is env
+    assert ctx.state["signal"] == 1.0
+    assert ctx.params["gain"] == 2.0
+    assert ctx.out["e"] == 0.3


### PR DESCRIPTION
## Summary
- migrate the first TOMATO bounded seam by porting `tTHORP` step contracts into `domains/tomato/tthorp`
- keep the slice stdlib-only and limited to `EnvStep`, `Context`, `Module`, and coercion helpers
- add regression coverage for forcing-row parsing, finite-output validation, and moisture-stress helpers

## Validation
- `.venv\Scripts\python.exe -m pytest -q`
- `.venv\Scripts\python.exe -m ruff check .`

Closes #43
