### PR TITLE
Migrate TOMATO tTHORP forcing csv seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ poetry run ruff check .
 - THORP CLI entrypoint seam is migrated as slice 024.
 - TOMATO `tTHORP` contracts seam is migrated as slice 025.
 - TOMATO `tTHORP` interface seam is migrated as slice 026.
+- TOMATO `tTHORP` forcing CSV seam is migrated as slice 027.
 
 ## Next validation
-- Migrate the next TOMATO `tTHORP` seam, likely `models/tomato_legacy/forcing_csv.py`, with behavior-preserving CSV forcing checks.
+- Migrate the next TOMATO `tTHORP` seam, likely `models/tomato_legacy/adapter.py`, with behavior-preserving adapter-state checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 026
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 026 approved for TOMATO
+- Gate C. Validation plan ready through slice 027
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 027 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -203,3 +203,9 @@ Slice 026:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/interface.py`
 - scope: bounded TOMATO pipeline interface, tabular simulation loop, and placeholder flux-step helper
 - excluded: tomato legacy models, CSV forcing loaders, pipelines, and CLI entrypoints
+
+Slice 027:
+- source: `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/forcing_csv.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/forcing_csv.py`
+- scope: bounded TOMATO CSV forcing ingestion, alias normalization, and canonical `EnvStep` reconstruction
+- excluded: tomato legacy adapters, the full `TomatoModel`, pipelines, and CLI entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -252,8 +252,16 @@ The twenty-sixth slice opens the next bounded TOMATO seam:
 - isolate the new `pandas` dependency to the tabular interface instead of pulling in tomato legacy models or pipelines
 - leave `models/tomato_legacy/forcing_csv.py` blocked as the next seam
 
+## Slice 027: TOMATO tTHORP Forcing CSV
+
+The twenty-seventh slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/forcing_csv.py` into the staged `domains/tomato/tthorp` package
+- preserve alias-column normalization, timestep reconstruction, and `EnvStep` emission behavior
+- keep the radiation-to-PAR conversion helper local to the seam instead of opening the broader TOMATO core utility layer
+- leave `models/tomato_legacy/adapter.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first two TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first three TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `models/tomato_legacy/forcing_csv.py`
+3. prepare the next TOMATO source audit for `models/tomato_legacy/adapter.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 026 implementation and validation
+- Current phase: slice 027 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated TOMATO `tTHORP` interface slice with `pytest` and `ruff`
-2. audit the next TOMATO seam, likely `models/tomato_legacy/forcing_csv.py`
+1. validate the migrated TOMATO `tTHORP` forcing CSV slice with `pytest` and `ruff`
+2. audit the next TOMATO seam, likely `models/tomato_legacy/adapter.py`
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-027-tomato-tthorp-forcing-csv.md
+++ b/docs/architecture/architecture/module_specs/module-027-tomato-tthorp-forcing-csv.md
@@ -1,0 +1,36 @@
+# Module Spec 027: TOMATO tTHORP Forcing CSV
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the CSV forcing loader that normalizes legacy column aliases and emits canonical `EnvStep` rows for the migrated interface.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/forcing_csv.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/forcing_csv.py`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/__init__.py`
+- `tests/test_tomato_tthorp_forcing_csv.py`
+
+## Responsibilities
+
+1. preserve legacy datetime sorting, timestep reconstruction, and required-column validation when yielding `EnvStep`
+2. preserve alias-column handling plus `SW_in_Wm2 -> PAR_umol` reconstruction without pulling in wider tomato legacy model code
+3. keep the seam bounded to forcing ingestion and package exports, leaving adapters and the full `TomatoModel` surface blocked
+
+## Non-Goals
+
+- port `models/tomato_legacy/adapter.py`
+- port `models/tomato_legacy/tomato_model.py`
+- port TOMATO pipelines or CLI entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/adapter.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO and load-cell migration depth is still shallow beyond the first two `tTHORP` seams | Risks hidden coupling in nested adapters, pipelines, and cross-package interfaces | deeper domain audit note |
+| GAP-002 | TOMATO and load-cell migration depth is still shallow beyond the first three `tTHORP` seams | Risks hidden coupling in nested adapters, pipelines, and cross-package interfaces | deeper domain audit note |
 | GAP-008 | Only twenty-four THORP runtime, reporting, helper, config-adapter, forcing, simulation, IO, and CLI seams are migrated so far | Representative package-level smoke validation and next-domain planning are still incomplete | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
@@ -7,6 +7,7 @@ from stomatal_optimiaztion.domains.tomato.tthorp.interface import (
     run_flux_step,
     simulate,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import iter_forcing_csv
 
 MODEL_NAME = "tTHORP"
 
@@ -19,4 +20,5 @@ __all__ = [
     "PipelineModel",
     "run_flux_step",
     "simulate",
+    "iter_forcing_csv",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/__init__.py
@@ -1,0 +1,3 @@
+from stomatal_optimiaztion.domains.tomato.tthorp.models import tomato_legacy
+
+__all__ = ["tomato_legacy"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/__init__.py
@@ -1,0 +1,5 @@
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.forcing_csv import (
+    iter_forcing_csv,
+)
+
+__all__ = ["iter_forcing_csv"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/forcing_csv.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/forcing_csv.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
+
+PAR_UMOL_PER_W_M2 = 4.6
+_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "datetime",
+    "T_air_C",
+    "PAR_umol",
+    "CO2_ppm",
+    "RH_percent",
+    "wind_speed_ms",
+)
+_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
+    "datetime": ("Datetime", "timestamp", "time"),
+    "T_air_C": ("t_air_c", "t_a"),
+    "PAR_umol": ("par_umol",),
+    "CO2_ppm": ("co2_ppm",),
+    "RH_percent": ("rh_percent", "RH", "rh"),
+    "wind_speed_ms": ("u10",),
+    "SW_in_Wm2": ("r_incom_w_m2", "r_incom"),
+    "T_rad_C": ("t_rad_c",),
+    "n_fruits_per_truss": (),
+}
+
+
+def _validate_par_factor(par_umol_per_w_m2: float) -> float:
+    factor = float(par_umol_per_w_m2)
+    if not math.isfinite(factor) or factor <= 0:
+        raise ValueError(f"par_umol_per_w_m2 must be a positive finite value, got {par_umol_per_w_m2!r}.")
+    return factor
+
+
+def _w_m2_to_par_umol(w_m2: float, *, par_umol_per_w_m2: float = PAR_UMOL_PER_W_M2) -> float:
+    return float(w_m2) * _validate_par_factor(par_umol_per_w_m2)
+
+
+def _finite_float(raw: object, *, default: float) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(value):
+        return float(default)
+    return value
+
+
+def _read_float(row: pd.Series, names: tuple[str, ...], *, default: float) -> float:
+    for name in names:
+        if name in row.index:
+            return _finite_float(row[name], default=default)
+    return float(default)
+
+
+def _read_optional_float(row: pd.Series, names: tuple[str, ...]) -> float | None:
+    for name in names:
+        if name not in row.index:
+            continue
+        try:
+            value = float(row[name])
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value):
+            return value
+    return None
+
+
+def _coalesce_aliases(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    for canonical, aliases in _COLUMN_ALIASES.items():
+        if canonical in out.columns:
+            continue
+        for alias in aliases:
+            if alias in out.columns:
+                out[canonical] = out[alias]
+                break
+    return out
+
+
+def _prepare_forcing_dataframe(
+    forcing: pd.DataFrame,
+    *,
+    start_datetime: datetime | None,
+    default_dt_s: float,
+    default_co2_ppm: float,
+    default_n_fruits_per_truss: int,
+) -> pd.DataFrame:
+    prepared = _coalesce_aliases(forcing)
+
+    if "datetime" not in prepared.columns:
+        t0 = start_datetime or datetime(2025, 1, 1, 0, 0, 0)
+        prepared["datetime"] = [t0 + timedelta(seconds=default_dt_s * index) for index in range(prepared.shape[0])]
+
+    prepared["datetime"] = pd.to_datetime(prepared["datetime"], errors="coerce")
+    if prepared["datetime"].isna().any():
+        raise ValueError("Column 'datetime' contains unparsable values.")
+
+    prepared = prepared.sort_values("datetime").reset_index(drop=True)
+
+    if "PAR_umol" not in prepared.columns:
+        if "SW_in_Wm2" not in prepared.columns:
+            raise ValueError("Missing required columns: ['PAR_umol']")
+        sw_in = pd.to_numeric(prepared["SW_in_Wm2"], errors="coerce").fillna(0.0).astype(float)
+        prepared["PAR_umol"] = sw_in.map(_w_m2_to_par_umol)
+
+    if "CO2_ppm" not in prepared.columns:
+        prepared["CO2_ppm"] = float(default_co2_ppm)
+    if "n_fruits_per_truss" not in prepared.columns:
+        prepared["n_fruits_per_truss"] = int(default_n_fruits_per_truss)
+
+    missing = [column for column in _REQUIRED_COLUMNS if column not in prepared.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+
+    return prepared
+
+
+def _default_dt_seconds(forcing: pd.DataFrame) -> float:
+    if forcing.shape[0] < 2:
+        return 3600.0
+
+    dt0 = (forcing.loc[1, "datetime"] - forcing.loc[0, "datetime"]).total_seconds()
+    if not math.isfinite(dt0):
+        return 3600.0
+    return float(min(max(dt0, 1.0), 6.0 * 3600.0))
+
+
+def iter_forcing_csv(
+    csv_path: str | Path,
+    *,
+    max_steps: int | None = None,
+    start_datetime: datetime | None = None,
+    default_dt_s: float = 6.0 * 3600.0,
+    default_co2_ppm: float = 420.0,
+    default_n_fruits_per_truss: int = 4,
+) -> Iterator[EnvStep]:
+    """Load CSV forcing and yield canonical EnvStep rows for the pipeline."""
+
+    if default_dt_s <= 0:
+        raise ValueError(f"default_dt_s must be > 0, got {default_dt_s!r}.")
+
+    forcing = pd.read_csv(Path(csv_path))
+    if forcing.empty:
+        return
+
+    forcing = _prepare_forcing_dataframe(
+        forcing,
+        start_datetime=start_datetime,
+        default_dt_s=default_dt_s,
+        default_co2_ppm=default_co2_ppm,
+        default_n_fruits_per_truss=default_n_fruits_per_truss,
+    )
+
+    if max_steps is None:
+        limit = forcing.shape[0]
+    else:
+        limit = min(forcing.shape[0], max(0, int(max_steps)))
+    dt_default = _default_dt_seconds(forcing)
+    last_calc_time: datetime | None = None
+
+    for index in range(limit):
+        row = forcing.iloc[index]
+        t_step = pd.Timestamp(row["datetime"]).to_pydatetime()
+        if index == 0:
+            dt_s = dt_default
+        elif last_calc_time is None:
+            dt_s = dt_default
+        else:
+            dt_s = max(1.0, (t_step - last_calc_time).total_seconds())
+        last_calc_time = t_step
+
+        t_air_c = _read_float(row, ("T_air_C",), default=25.0)
+        sw_in = _read_optional_float(row, ("SW_in_Wm2",))
+        par_default = _w_m2_to_par_umol(sw_in) if sw_in is not None else 0.0
+        par_umol = _read_float(row, ("PAR_umol",), default=par_default)
+        co2_ppm = _read_float(row, ("CO2_ppm",), default=default_co2_ppm)
+
+        rh_percent = _read_float(row, ("RH_percent",), default=70.0)
+        if rh_percent <= 1.5:
+            rh_percent *= 100.0
+        rh_percent = min(max(rh_percent, 0.0), 100.0)
+
+        wind_speed_ms = _read_float(row, ("wind_speed_ms",), default=1.0)
+        t_rad_c = _read_optional_float(row, ("T_rad_C",))
+
+        n_fruits_raw = _read_float(
+            row,
+            ("n_fruits_per_truss",),
+            default=float(default_n_fruits_per_truss),
+        )
+        n_fruits = max(1, int(round(n_fruits_raw)))
+
+        yield EnvStep(
+            t=t_step,
+            dt_s=dt_s,
+            T_air_C=t_air_c,
+            PAR_umol=par_umol,
+            CO2_ppm=co2_ppm,
+            RH_percent=rh_percent,
+            wind_speed_ms=wind_speed_ms,
+            SW_in_Wm2=sw_in,
+            T_rad_C=t_rad_c,
+            n_fruits_per_truss=n_fruits,
+        )

--- a/tests/test_tomato_tthorp_forcing_csv.py
+++ b/tests/test_tomato_tthorp_forcing_csv.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import iter_forcing_csv
+
+
+def test_iter_forcing_csv_sorts_datetime_and_matches_legacy_dt_rules(tmp_path: Path) -> None:
+    forcing_path = tmp_path / "forcing.csv"
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2025-01-01T12:00:00",
+                "2025-01-01T00:00:00",
+                "2025-01-01T13:00:00",
+            ],
+            "T_air_C": [20.0, 19.0, 21.0],
+            "PAR_umol": [300.0, 200.0, 100.0],
+            "CO2_ppm": [420.0, 420.0, 420.0],
+            "RH_percent": [70.0, 70.0, 70.0],
+            "wind_speed_ms": [1.0, 1.0, 1.0],
+        }
+    ).to_csv(forcing_path, index=False)
+
+    steps = list(iter_forcing_csv(forcing_path, max_steps=10))
+
+    assert len(steps) == 3
+    assert steps[0].t.isoformat() == "2025-01-01T00:00:00"
+    assert steps[1].t.isoformat() == "2025-01-01T12:00:00"
+    assert steps[2].t.isoformat() == "2025-01-01T13:00:00"
+    assert steps[0].dt_s == 21600.0
+    assert steps[1].dt_s == 43200.0
+    assert steps[2].dt_s == 3600.0
+
+
+def test_iter_forcing_csv_raises_when_required_columns_missing(tmp_path: Path) -> None:
+    forcing_path = tmp_path / "forcing.csv"
+    pd.DataFrame(
+        {
+            "datetime": ["2025-01-01T00:00:00"],
+            "T_air_C": [20.0],
+            "PAR_umol": [250.0],
+            "CO2_ppm": [420.0],
+            "RH_percent": [65.0],
+        }
+    ).to_csv(forcing_path, index=False)
+
+    with pytest.raises(ValueError, match="Missing required columns"):
+        list(iter_forcing_csv(forcing_path))
+
+
+def test_iter_forcing_csv_reconstructs_alias_columns_and_defaults(tmp_path: Path) -> None:
+    forcing_path = tmp_path / "forcing_alias.csv"
+    pd.DataFrame(
+        {
+            "Datetime": ["2025-01-01T00:00:00"],
+            "t_a": [22.5],
+            "co2_ppm": [None],
+            "rh": [0.65],
+            "u10": [2.0],
+            "r_incom_w_m2": [100.0],
+            "t_rad_c": [24.0],
+        }
+    ).to_csv(forcing_path, index=False)
+
+    steps = list(
+        iter_forcing_csv(
+            forcing_path,
+            default_co2_ppm=415.0,
+            default_n_fruits_per_truss=5,
+        )
+    )
+
+    assert len(steps) == 1
+    step = steps[0]
+    assert step.t.isoformat() == "2025-01-01T00:00:00"
+    assert step.dt_s == 3600.0
+    assert step.T_air_C == 22.5
+    assert step.PAR_umol == pytest.approx(460.0)
+    assert step.CO2_ppm == 415.0
+    assert step.RH_percent == 65.0
+    assert step.wind_speed_ms == 2.0
+    assert step.SW_in_Wm2 == 100.0
+    assert step.T_rad_C == 24.0
+    assert step.n_fruits_per_truss == 5


### PR DESCRIPTION
## Summary
- migrate the next TOMATO bounded seam by porting `tTHORP/models/tomato_legacy/forcing_csv.py` into the staged package
- preserve datetime sorting, timestep reconstruction, alias normalization, and `EnvStep` emission over the migrated contracts
- add regression coverage for required-column failures and `SW_in_Wm2 -> PAR_umol` reconstruction without opening the full tomato model surface

## Validation
- `.venv\Scripts\python.exe -m pytest -q`
- `.venv\Scripts\python.exe -m ruff check .`

Closes #47
