### PR TITLE
Migrate TOMATO tTHORP adapter seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` contracts seam is migrated as slice 025.
 - TOMATO `tTHORP` interface seam is migrated as slice 026.
 - TOMATO `tTHORP` forcing CSV seam is migrated as slice 027.
+- TOMATO `tTHORP` adapter seam is migrated as slice 028.
 
 ## Next validation
-- Migrate the next TOMATO `tTHORP` seam, likely `models/tomato_legacy/adapter.py`, with behavior-preserving adapter-state checks.
+- Migrate the next TOMATO `tTHORP` seam, likely `models/tomato_legacy/tomato_model.py`, with behavior-preserving legacy model-state checks.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 027
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 027 approved for TOMATO
+- Gate C. Validation plan ready through slice 028
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 028 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -209,3 +209,9 @@ Slice 027:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/forcing_csv.py`
 - scope: bounded TOMATO CSV forcing ingestion, alias normalization, and canonical `EnvStep` reconstruction
 - excluded: tomato legacy adapters, the full `TomatoModel`, pipelines, and CLI entrypoints
+
+Slice 028:
+- source: `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/adapter.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/adapter.py`
+- scope: bounded TOMATO step-adapter bridge and pipeline module wiring over injected legacy-model protocols
+- excluded: the full `TomatoModel`, partition-policy packages, pipelines, and CLI entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -260,8 +260,16 @@ The twenty-seventh slice opens the next bounded TOMATO seam:
 - keep the radiation-to-PAR conversion helper local to the seam instead of opening the broader TOMATO core utility layer
 - leave `models/tomato_legacy/adapter.py` blocked as the next seam
 
+## Slice 028: TOMATO tTHORP Adapter
+
+The twenty-eighth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/adapter.py` into the staged `domains/tomato/tthorp` package
+- preserve `TomatoLegacyAdapter`, `TomatoLegacyModule`, and `make_tomato_legacy_model()` behavior over the migrated `interface` and `forcing_csv` seams
+- use an injected tomato-model protocol so the adapter bridge lands today without forcing the full `tomato_model.py` import surface
+- leave `models/tomato_legacy/tomato_model.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first three TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first four TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `models/tomato_legacy/adapter.py`
+3. prepare the next TOMATO source audit for `models/tomato_legacy/tomato_model.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 027 implementation and validation
+- Current phase: slice 028 implementation and validation
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the migrated TOMATO `tTHORP` forcing CSV slice with `pytest` and `ruff`
-2. audit the next TOMATO seam, likely `models/tomato_legacy/adapter.py`
+1. validate the migrated TOMATO `tTHORP` adapter slice with `pytest` and `ruff`
+2. audit the next TOMATO seam, likely `models/tomato_legacy/tomato_model.py`
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-028-tomato-tthorp-adapter.md
+++ b/docs/architecture/architecture/module_specs/module-028-tomato-tthorp-adapter.md
@@ -1,0 +1,36 @@
+# Module Spec 028: TOMATO tTHORP Adapter
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the adapter bridge that maps migrated `EnvStep` forcing into the legacy tomato step-model contract without importing the full `tomato_model.py` implementation yet.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/adapter.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/adapter.py`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/__init__.py`
+- `tests/test_tomato_tthorp_adapter.py`
+
+## Responsibilities
+
+1. preserve legacy row mapping, timestep forwarding, and numeric-output extraction through `TomatoLegacyAdapter`
+2. preserve `TomatoLegacyModule` stress bookkeeping and pipeline wiring while using an injected tomato-model protocol to keep the seam bounded
+3. fail clearly when no migrated `tomato_model` or explicit `model_factory` is available yet
+
+## Non-Goals
+
+- port `models/tomato_legacy/tomato_model.py`
+- port partition-policy packages beyond pass-through adapter wiring
+- port TOMATO pipelines or CLI entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/tomato_model.py`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO and load-cell migration depth is still shallow beyond the first three `tTHORP` seams | Risks hidden coupling in nested adapters, pipelines, and cross-package interfaces | deeper domain audit note |
+| GAP-002 | TOMATO and load-cell migration depth is still shallow beyond the first four `tTHORP` seams | Risks hidden coupling in nested adapters, pipelines, and cross-package interfaces | deeper domain audit note |
 | GAP-008 | Only twenty-four THORP runtime, reporting, helper, config-adapter, forcing, simulation, IO, and CLI seams are migrated so far | Representative package-level smoke validation and next-domain planning are still incomplete | next THORP module spec |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
@@ -7,7 +7,12 @@ from stomatal_optimiaztion.domains.tomato.tthorp.interface import (
     run_flux_step,
     simulate,
 )
-from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import iter_forcing_csv
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import (
+    TomatoLegacyAdapter,
+    TomatoLegacyModule,
+    iter_forcing_csv,
+    make_tomato_legacy_model,
+)
 
 MODEL_NAME = "tTHORP"
 
@@ -21,4 +26,7 @@ __all__ = [
     "run_flux_step",
     "simulate",
     "iter_forcing_csv",
+    "TomatoLegacyAdapter",
+    "TomatoLegacyModule",
+    "make_tomato_legacy_model",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/__init__.py
@@ -1,5 +1,15 @@
 from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.forcing_csv import (
     iter_forcing_csv,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.adapter import (
+    TomatoLegacyAdapter,
+    TomatoLegacyModule,
+    make_tomato_legacy_model,
+)
 
-__all__ = ["iter_forcing_csv"]
+__all__ = [
+    "iter_forcing_csv",
+    "TomatoLegacyAdapter",
+    "TomatoLegacyModule",
+    "make_tomato_legacy_model",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/adapter.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/adapter.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Callable, Mapping, Protocol
+
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import (
+    Context,
+    EnvStep,
+    water_supply_stress_from_theta,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.interface import PipelineModel
+
+PartitionPolicyLike = object | str | None
+
+
+class TomatoLegacyModelProtocol(Protocol):
+    fixed_lai: float | None
+    partition_policy: PartitionPolicyLike
+    allocation_scheme: str
+    start_date: datetime
+    current_date: date
+    last_calc_time: datetime | None
+
+    def reset_state(self) -> None: ...
+
+    def update_inputs_from_row(self, row: dict[str, float]) -> None: ...
+
+    def run_timestep_calculations(self, dt_s: float, t: datetime) -> None: ...
+
+    def get_current_outputs(self, t: datetime) -> Mapping[str, object]: ...
+
+
+ModelFactory = Callable[..., TomatoLegacyModelProtocol]
+
+
+def _default_model_factory(
+    *,
+    fixed_lai: float | None,
+    partition_policy: PartitionPolicyLike,
+    allocation_scheme: str,
+) -> TomatoLegacyModelProtocol:
+    try:
+        from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.tomato_model import TomatoModel
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "TomatoLegacyAdapter requires a migrated tomato_model or an explicit model_factory."
+        ) from exc
+
+    return TomatoModel(
+        fixed_lai=fixed_lai,
+        partition_policy=partition_policy,
+        allocation_scheme=allocation_scheme,
+    )
+
+
+def _finite_float(raw: object, *, default: float) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(value):
+        return float(default)
+    return value
+
+
+def _default_moisture_response(theta_substrate: float) -> float:
+    return theta_substrate / 0.4
+
+
+def _write_numeric_legacy_outputs(legacy: Mapping[str, object], out: dict[str, float]) -> None:
+    for key, raw in legacy.items():
+        if key == "datetime":
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value):
+            out[key] = value
+
+
+def _env_to_legacy_row(env: EnvStep) -> dict[str, float]:
+    row: dict[str, float] = {
+        "T_air_C": float(env.T_air_C),
+        "PAR_umol": float(env.PAR_umol),
+        "CO2_ppm": float(env.CO2_ppm),
+        "RH_percent": float(env.RH_percent),
+        "wind_speed_ms": float(env.wind_speed_ms),
+        "n_fruits_per_truss": float(env.n_fruits_per_truss or 4),
+    }
+    if env.SW_in_Wm2 is not None:
+        row["SW_in_Wm2"] = float(env.SW_in_Wm2)
+    if env.T_rad_C is not None:
+        row["T_rad_C"] = float(env.T_rad_C)
+    return row
+
+
+def _build_model(
+    *,
+    model_factory: ModelFactory | None,
+    fixed_lai: float | None,
+    partition_policy: PartitionPolicyLike,
+    allocation_scheme: str,
+) -> TomatoLegacyModelProtocol:
+    factory = model_factory or _default_model_factory
+    return factory(
+        fixed_lai=fixed_lai,
+        partition_policy=partition_policy,
+        allocation_scheme=allocation_scheme,
+    )
+
+
+def _prime_model_clock(model: TomatoLegacyModelProtocol, env: EnvStep) -> None:
+    model.start_date = env.t
+    model.current_date = env.t.date()
+    model.last_calc_time = env.t
+
+
+@dataclass(slots=True)
+class TomatoLegacyAdapter:
+    """Stateful step adapter exposing the original TomatoModel step API."""
+
+    model: TomatoLegacyModelProtocol | None = None
+    fixed_lai: float | None = None
+    partition_policy: PartitionPolicyLike = None
+    allocation_scheme: str = "4pool"
+    model_factory: ModelFactory | None = None
+    _initialized: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        if self.model is None:
+            self.model = _build_model(
+                model_factory=self.model_factory,
+                fixed_lai=self.fixed_lai,
+                partition_policy=self.partition_policy,
+                allocation_scheme=self.allocation_scheme,
+            )
+        elif self.fixed_lai is not None:
+            self.model.fixed_lai = float(self.fixed_lai)
+        self.model.partition_policy = self.partition_policy
+        self.model.allocation_scheme = str(self.allocation_scheme)
+        self.reset_state()
+
+    def reset_state(self) -> None:
+        if self.model is None:  # pragma: no cover - defensive guard
+            self.model = _build_model(
+                model_factory=self.model_factory,
+                fixed_lai=self.fixed_lai,
+                partition_policy=self.partition_policy,
+                allocation_scheme=self.allocation_scheme,
+            )
+        self.model.reset_state()
+        self._initialized = False
+
+    def step(self, env: EnvStep) -> dict[str, object]:
+        if env.dt_s <= 0:
+            raise ValueError(f"TomatoLegacyAdapter.step: env.dt_s must be > 0, got {env.dt_s!r}.")
+
+        model = self.model
+        if model is None:  # pragma: no cover - defensive guard
+            model = _build_model(
+                model_factory=self.model_factory,
+                fixed_lai=self.fixed_lai,
+                partition_policy=self.partition_policy,
+                allocation_scheme=self.allocation_scheme,
+            )
+            self.model = model
+
+        if not self._initialized:
+            _prime_model_clock(model, env)
+            self._initialized = True
+
+        model.update_inputs_from_row(_env_to_legacy_row(env))
+        model.run_timestep_calculations(float(env.dt_s), env.t)
+        model.last_calc_time = env.t
+        return dict(model.get_current_outputs(env.t))
+
+
+@dataclass(slots=True)
+class TomatoLegacyModule:
+    """Bridge legacy tomato step logic into the migrated pipeline Module contract."""
+
+    model_state_key: str = "_tomato_legacy_model"
+    model_factory: ModelFactory | None = None
+
+    def __call__(self, ctx: Context) -> None:
+        model = self._get_or_create_model(ctx)
+        row = _env_to_legacy_row(ctx.env)
+
+        model.update_inputs_from_row(row)
+        model.run_timestep_calculations(float(ctx.env.dt_s), ctx.env.t)
+        legacy = dict(model.get_current_outputs(ctx.env.t))
+
+        theta = self._resolve_theta_substrate(ctx)
+        moisture_response_fn = self._resolve_moisture_response_fn(ctx)
+        stress = water_supply_stress_from_theta(theta, moisture_response_fn)
+
+        _write_numeric_legacy_outputs(legacy, ctx.out)
+
+        e = _finite_float(legacy.get("transpiration_rate_g_s_m2"), default=0.0)
+        g_w = max(e * 1.0e-3, 0.0)
+        a_n = _finite_float(legacy.get("co2_flux_g_m2_s"), default=0.0)
+        r_d = max(_finite_float(legacy.get("latent_heat_W_m2"), default=0.0) * 1.0e-4, 0.0)
+
+        ctx.out["theta_substrate"] = theta
+        ctx.out["water_supply_stress"] = stress
+        ctx.out["e"] = e
+        ctx.out["g_w"] = g_w
+        ctx.out["a_n"] = a_n
+        ctx.out["r_d"] = r_d
+
+    def _get_or_create_model(self, ctx: Context) -> TomatoLegacyModelProtocol:
+        cached = ctx.state.get(self.model_state_key)
+        if _looks_like_tomato_model(cached):
+            return cached
+
+        fixed_lai_raw = ctx.params.get("fixed_lai")
+        fixed_lai = _finite_float(fixed_lai_raw, default=float("nan")) if fixed_lai_raw is not None else None
+        if fixed_lai is not None and not math.isfinite(fixed_lai):
+            fixed_lai = None
+
+        model_factory = self.model_factory
+        ctx_factory = ctx.params.get("model_factory")
+        if callable(ctx_factory):
+            model_factory = ctx_factory
+        elif ctx_factory is not None:
+            raise TypeError("model_factory must be callable when provided in pipeline params.")
+
+        allocation_scheme = str(ctx.params.get("allocation_scheme", "4pool"))
+        model = _build_model(
+            model_factory=model_factory,
+            fixed_lai=fixed_lai,
+            partition_policy=ctx.params.get("partition_policy"),
+            allocation_scheme=allocation_scheme,
+        )
+        _prime_model_clock(model, ctx.env)
+        ctx.state[self.model_state_key] = model
+        return model
+
+    def _resolve_theta_substrate(self, ctx: Context) -> float:
+        raw = ctx.params.get("theta_substrate", ctx.state.get("theta_substrate", 0.33))
+        theta = _finite_float(raw, default=0.33)
+        theta = min(max(theta, 0.0), 1.0)
+        ctx.state["theta_substrate"] = theta
+        return theta
+
+    def _resolve_moisture_response_fn(self, ctx: Context) -> Callable[[float], float]:
+        candidate = ctx.params.get("moisture_response_fn")
+        if callable(candidate):
+            return candidate
+        return _default_moisture_response
+
+
+def _looks_like_tomato_model(candidate: object) -> bool:
+    required_attrs = ("fixed_lai", "partition_policy", "allocation_scheme", "start_date", "current_date", "last_calc_time")
+    required_methods = ("reset_state", "update_inputs_from_row", "run_timestep_calculations", "get_current_outputs")
+    if candidate is None:
+        return False
+    if not all(hasattr(candidate, name) for name in required_attrs):
+        return False
+    return all(callable(getattr(candidate, name, None)) for name in required_methods)
+
+
+def make_tomato_legacy_model(
+    *,
+    name: str = "tomato_legacy",
+    theta_substrate: float = 0.33,
+    fixed_lai: float | None = None,
+    partition_policy: PartitionPolicyLike = None,
+    allocation_scheme: str = "4pool",
+    moisture_response_fn: Callable[[float], float] | None = None,
+    model_factory: ModelFactory | None = None,
+) -> PipelineModel:
+    """Factory for a PipelineModel running the legacy tomato bridge module."""
+
+    params: dict[str, object] = {"theta_substrate": float(theta_substrate)}
+    if fixed_lai is not None:
+        params["fixed_lai"] = float(fixed_lai)
+    if partition_policy is not None:
+        params["partition_policy"] = partition_policy
+    params["allocation_scheme"] = str(allocation_scheme)
+    if moisture_response_fn is not None:
+        params["moisture_response_fn"] = moisture_response_fn
+    if model_factory is not None:
+        params["model_factory"] = model_factory
+
+    return PipelineModel(name=name, params=params, modules=(TomatoLegacyModule(model_factory=model_factory),))

--- a/tests/test_tomato_tthorp_adapter.py
+++ b/tests/test_tomato_tthorp_adapter.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp import simulate
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import Context, EnvStep
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import (
+    TomatoLegacyAdapter,
+    TomatoLegacyModule,
+    make_tomato_legacy_model,
+)
+
+
+@dataclass
+class _FakeTomatoModel:
+    fixed_lai: float | None = None
+    partition_policy: object | None = None
+    allocation_scheme: str = "4pool"
+    start_date: datetime = field(default_factory=lambda: datetime(2000, 1, 1, 0, 0, 0))
+    current_date: object = None
+    last_calc_time: datetime | None = None
+    reset_calls: int = 0
+    last_row: dict[str, float] | None = None
+    run_calls: list[tuple[float, datetime]] = field(default_factory=list)
+
+    def reset_state(self) -> None:
+        self.reset_calls += 1
+
+    def update_inputs_from_row(self, row: dict[str, float]) -> None:
+        self.last_row = dict(row)
+
+    def run_timestep_calculations(self, dt_s: float, t: datetime) -> None:
+        self.run_calls.append((dt_s, t))
+
+    def get_current_outputs(self, t: datetime) -> dict[str, object]:
+        return {
+            "datetime": t,
+            "LAI": 2.5,
+            "co2_flux_g_m2_s": 0.12,
+            "latent_heat_W_m2": 250.0,
+            "transpiration_rate_g_s_m2": 3.5,
+            "status_text": "ignore-me",
+        }
+
+
+def _make_env(*, t: datetime, dt_s: float, n_fruits_per_truss: int | None = None) -> EnvStep:
+    return EnvStep(
+        t=t,
+        dt_s=dt_s,
+        T_air_C=24.0,
+        PAR_umol=500.0,
+        CO2_ppm=420.0,
+        RH_percent=60.0,
+        wind_speed_ms=1.5,
+        SW_in_Wm2=120.0,
+        T_rad_C=26.0,
+        n_fruits_per_truss=n_fruits_per_truss,
+    )
+
+
+def test_tomato_legacy_adapter_primes_model_and_maps_rows() -> None:
+    model = _FakeTomatoModel()
+    adapter = TomatoLegacyAdapter(
+        model=model,
+        fixed_lai=1.8,
+        partition_policy="sink-based",
+        allocation_scheme="3pool",
+    )
+    env = _make_env(t=datetime(2026, 1, 1, 12, 0, 0), dt_s=3600.0, n_fruits_per_truss=None)
+
+    out = adapter.step(env)
+
+    assert model.reset_calls == 1
+    assert model.fixed_lai == 1.8
+    assert model.partition_policy == "sink-based"
+    assert model.allocation_scheme == "3pool"
+    assert model.start_date == env.t
+    assert model.current_date == env.t.date()
+    assert model.last_calc_time == env.t
+    assert model.last_row == {
+        "T_air_C": 24.0,
+        "PAR_umol": 500.0,
+        "CO2_ppm": 420.0,
+        "RH_percent": 60.0,
+        "wind_speed_ms": 1.5,
+        "n_fruits_per_truss": 4.0,
+        "SW_in_Wm2": 120.0,
+        "T_rad_C": 26.0,
+    }
+    assert model.run_calls == [(3600.0, env.t)]
+    assert out["LAI"] == 2.5
+
+
+def test_tomato_legacy_adapter_rejects_non_positive_timestep() -> None:
+    adapter = TomatoLegacyAdapter(model=_FakeTomatoModel())
+
+    with pytest.raises(ValueError, match="env.dt_s must be > 0"):
+        adapter.step(_make_env(t=datetime(2026, 1, 1, 0, 0, 0), dt_s=0.0))
+
+
+def test_tomato_legacy_module_writes_outputs_and_reuses_cached_model() -> None:
+    created: list[_FakeTomatoModel] = []
+
+    def factory(**kwargs: object) -> _FakeTomatoModel:
+        model = _FakeTomatoModel(
+            fixed_lai=kwargs.get("fixed_lai"),  # type: ignore[arg-type]
+            partition_policy=kwargs.get("partition_policy"),
+            allocation_scheme=str(kwargs.get("allocation_scheme", "4pool")),
+        )
+        created.append(model)
+        return model
+
+    module = TomatoLegacyModule(model_factory=factory)
+    env = _make_env(t=datetime(2026, 1, 1, 6, 0, 0), dt_s=1800.0)
+    ctx = Context(
+        env=env,
+        state={},
+        params={"theta_substrate": 0.2, "moisture_response_fn": lambda theta: theta / 0.5},
+        out={},
+    )
+
+    module(ctx)
+
+    assert len(created) == 1
+    assert ctx.state["_tomato_legacy_model"] is created[0]
+    assert ctx.state["theta_substrate"] == 0.2
+    assert ctx.out["LAI"] == 2.5
+    assert ctx.out["e"] == 3.5
+    assert ctx.out["g_w"] == pytest.approx(0.0035)
+    assert ctx.out["a_n"] == 0.12
+    assert ctx.out["r_d"] == pytest.approx(0.025)
+    assert ctx.out["water_supply_stress"] == pytest.approx(0.4)
+    assert "status_text" not in ctx.out
+
+    ctx.out = {}
+    ctx.env = _make_env(t=datetime(2026, 1, 1, 6, 30, 0), dt_s=1800.0)
+    module(ctx)
+    assert len(created) == 1
+    assert created[0].run_calls[-1] == (1800.0, ctx.env.t)
+
+
+def test_make_tomato_legacy_model_runs_with_injected_factory() -> None:
+    def factory(**kwargs: object) -> _FakeTomatoModel:
+        return _FakeTomatoModel(
+            fixed_lai=kwargs.get("fixed_lai"),  # type: ignore[arg-type]
+            partition_policy=kwargs.get("partition_policy"),
+            allocation_scheme=str(kwargs.get("allocation_scheme", "4pool")),
+        )
+
+    model = make_tomato_legacy_model(
+        fixed_lai=2.2,
+        partition_policy="thorp-opt",
+        allocation_scheme="3pool",
+        model_factory=factory,
+    )
+    forcing = [
+        _make_env(t=datetime(2026, 1, 1, 0, 0, 0), dt_s=3600.0),
+        _make_env(t=datetime(2026, 1, 1, 1, 0, 0), dt_s=3600.0),
+    ]
+
+    out = simulate(model=model, forcing=forcing)
+
+    assert isinstance(out, pd.DataFrame)
+    assert list(out.columns) == [
+        "datetime",
+        "LAI",
+        "co2_flux_g_m2_s",
+        "latent_heat_W_m2",
+        "transpiration_rate_g_s_m2",
+        "theta_substrate",
+        "water_supply_stress",
+        "e",
+        "g_w",
+        "a_n",
+        "r_d",
+    ]
+    assert out["theta_substrate"].tolist() == [0.33, 0.33]
+
+
+def test_make_tomato_legacy_model_fails_cleanly_without_model_factory() -> None:
+    model = make_tomato_legacy_model()
+
+    with pytest.raises(ModuleNotFoundError, match="model_factory"):
+        simulate(model=model, forcing=[_make_env(t=datetime(2026, 1, 1, 0, 0, 0), dt_s=3600.0)])


### PR DESCRIPTION
## Summary
- migrate the next TOMATO bounded seam by porting `tTHORP/models/tomato_legacy/adapter.py` into the staged package
- preserve adapter row mapping, pipeline-module output coercion, and factory wiring over the migrated `interface` and `forcing_csv` seams
- keep the slice bounded by using injected tomato-model doubles instead of importing the full legacy `tomato_model.py` implementation

## Validation
- `.venv\Scripts\python.exe -m pytest -q`
- `.venv\Scripts\python.exe -m ruff check .`

Closes #49
