### PR TITLE
[Model Change] Migrate TOMATO tTHORP runner seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,4 +11,4 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-029 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, and `TomatoModel` surface seams
+- Slices 025-030 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, and runner seams

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` forcing CSV seam is migrated as slice 027.
 - TOMATO `tTHORP` adapter seam is migrated as slice 028.
 - TOMATO `tTHORP` `TomatoModel` surface seam is migrated as slice 029.
+- TOMATO `tTHORP` runner seam is migrated as slice 030.
 
 ## Next validation
-- Migrate the TOMATO `tTHORP` runner seam in `models/tomato_legacy/run.py` and decide whether partition-policy packages need dedicated slices before broader pipeline work.
+- Audit the TOMATO partition-policy seam at `components/partitioning/policy.py` and decide how to stage sink-based versus THORP-derived policy slices.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 029
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 029 approved for TOMATO
+- Gate C. Validation plan ready through slice 030
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 030 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -221,3 +221,9 @@ Slice 029:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/tomato_model.py`
 - scope: bounded TOMATO legacy-model surface covering reset-state defaults, forcing-row ingestion, output payload shape, density helpers, sample forcing generation, and default adapter execution
 - excluded: the full age-structured growth kernels, partition-policy package migration, and legacy runner or CLI entrypoints
+
+Slice 030:
+- source: `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/run.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/run.py`
+- scope: bounded TOMATO package-local runner over migrated forcing CSV, adapter, and tabular simulation seams
+- excluded: TOMATO partition-policy package migration, broader package entrypoints, and other legacy subprojects

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -276,8 +276,16 @@ The twenty-ninth slice opens the next bounded TOMATO seam:
 - wire the seam over the migrated `run_flux_step()` placeholder so default adapter execution works without opening the full partition-policy ecosystem or CLI yet
 - leave `models/tomato_legacy/run.py` blocked as the next seam
 
+## Slice 030: TOMATO tTHORP Runner Seam
+
+The thirtieth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/run.py` into the staged `domains/tomato/tthorp` package
+- preserve bounded argument parsing, forcing iteration, default adapter construction, and CSV result writing
+- keep the runner package-local instead of opening a repo-wide TOMATO CLI entrypoint yet
+- leave `components/partitioning/policy.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first five TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first six TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `models/tomato_legacy/run.py`
+3. prepare the next TOMATO source audit for `components/partitioning/policy.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 029 completed and slice 030 planning
+- Current phase: slice 030 completed and slice 031 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. validate the package-local TOMATO runner seam, likely `models/tomato_legacy/run.py`
-2. decide whether TOMATO partition-policy packages should stay internal fallback logic or open as dedicated slices before broader pipeline work
+1. audit the TOMATO partition-policy seam starting at `components/partitioning/policy.py`
+2. decide whether sink-based and THORP-derived partition policies should land as one bounded package migration or multiple slices
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-030-tomato-tthorp-runner-seam.md
+++ b/docs/architecture/architecture/module_specs/module-030-tomato-tthorp-runner-seam.md
@@ -1,0 +1,35 @@
+# Module Spec 030: TOMATO tTHORP Runner Seam
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the legacy `models/tomato_legacy/run.py` runner so the migrated package can bind forcing CSV ingestion, default adapter construction, argument parsing, and CSV result writing into one package-local execution surface.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/run.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/run.py`
+- `tests/test_tomato_tthorp_run.py`
+
+## Responsibilities
+
+1. preserve CLI argument parsing for forcing input, output path, timestep defaults, and optional fixed LAI
+2. preserve the bounded execution order across `iter_forcing_csv()`, `TomatoLegacyAdapter`, and `simulate()`
+3. preserve output-path creation and module execution behavior without opening broader package entrypoints
+
+## Non-Goals
+
+- create a repo-wide TOMATO CLI entrypoint outside the legacy runner seam
+- port TOMATO partition-policy packages as first-class modules
+- broaden into `tGOSM`, `tTDGM`, or cross-domain execution surfaces
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/policy.py`

--- a/docs/architecture/executor/issue-030-model-change.md
+++ b/docs/architecture/executor/issue-030-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 029` landed the bounded `TomatoModel` surface, so the next smallest blocked TOMATO seam is the legacy `models/tomato_legacy/run.py` runner.
+- The migrated package still lacks a package-local runner that binds forcing CSV ingestion, default adapter construction, argument parsing, and CSV result writing into one bounded execution surface.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/run.py`
+- related TOMATO `tTHORP` tests and architecture slice records
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add runner-focused checks for argument parsing, adapter invocation, output path creation, and module execution behavior
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/run.py`
+- current migrated `forcing_csv`, `adapter`, and `TomatoModel` seams

--- a/docs/architecture/executor/pr-053-tomato-runner-seam.md
+++ b/docs/architecture/executor/pr-053-tomato-runner-seam.md
@@ -1,0 +1,19 @@
+## Background
+- `slice 029` landed the bounded `TomatoModel` surface, but the migrated TOMATO package still lacked the legacy runner seam that turns forcing CSV input into a written results table.
+- This PR lands `slice 030` by adding the package-local runner and moving the next architectural uncertainty to the TOMATO partition-policy package.
+
+## Changes
+- add the migrated `models/tomato_legacy/run.py` runner over `iter_forcing_csv()`, `TomatoLegacyAdapter`, and `simulate()`
+- add runner integration tests for argument parsing, CSV output writing, and module execution
+- update architecture artifacts and README so `slice 030` is recorded and `components/partitioning/policy.py` becomes the next blocked seam
+
+## Validation
+- `.venv\Scripts\python.exe -m pytest`
+- `.venv\Scripts\ruff.exe check .`
+
+## Impact
+- the migrated TOMATO `tTHORP` package now has a package-local legacy runner surface
+- deeper partition-policy migration remains explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #53

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the bounded `TomatoModel` surface | Deeper partition-policy, runner, and wider pipeline coupling can still hide legacy assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the package-local runner and bounded `TomatoModel` surface | Deeper partition-policy and wider pipeline coupling can still hide legacy assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/run.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/run.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tthorp.interface import simulate
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.adapter import (
+    TomatoLegacyAdapter,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.forcing_csv import (
+    iter_forcing_csv,
+)
+
+
+def _parse_datetime(raw: str) -> datetime:
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"Invalid datetime {raw!r}; expected ISO-8601 like '2025-01-01T00:00:00'."
+        ) from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Tomato legacy adapter on forcing CSV.")
+    parser.add_argument("--input", required=True, help="Input forcing CSV path.")
+    parser.add_argument("--output", required=True, help="Output CSV path for model results.")
+    parser.add_argument("--max-steps", type=int, default=None, help="Optional max number of forcing rows.")
+    parser.add_argument("--fixed-lai", type=float, default=None, help="Optional fixed LAI for single-day runs.")
+    parser.add_argument("--default-dt-s", type=float, default=6.0 * 3600.0, help="Fallback timestep seconds.")
+    parser.add_argument("--default-co2-ppm", type=float, default=420.0, help="Default CO2 when column is absent.")
+    parser.add_argument(
+        "--default-n-fruits-per-truss",
+        type=int,
+        default=4,
+        help="Default fruit count when column is absent.",
+    )
+    parser.add_argument(
+        "--start-datetime",
+        type=_parse_datetime,
+        default=None,
+        help="Fallback start datetime when forcing CSV has no datetime column.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+
+    forcing = iter_forcing_csv(
+        args.input,
+        max_steps=args.max_steps,
+        start_datetime=args.start_datetime,
+        default_dt_s=args.default_dt_s,
+        default_co2_ppm=args.default_co2_ppm,
+        default_n_fruits_per_truss=args.default_n_fruits_per_truss,
+    )
+    adapter = TomatoLegacyAdapter(fixed_lai=args.fixed_lai)
+    output = simulate(model=adapter, forcing=forcing, max_steps=args.max_steps)
+
+    output_path = Path(args.output).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output.to_csv(output_path, index=False)
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tomato_tthorp_run.py
+++ b/tests/test_tomato_tthorp_run.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import runpy
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.run as legacy_run
+
+
+def _write_forcing_csv(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2026-01-01T00:00:00",
+                "2026-01-01T01:00:00",
+                "2026-01-01T02:00:00",
+            ],
+            "T_air_C": [21.0, 22.0, 23.0],
+            "PAR_umol": [150.0, 250.0, 350.0],
+            "CO2_ppm": [410.0, 420.0, 430.0],
+            "RH_percent": [70.0, 65.0, 60.0],
+            "wind_speed_ms": [0.8, 1.0, 1.2],
+        }
+    ).to_csv(path, index=False)
+
+
+def test_parse_datetime_rejects_invalid_value() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="Invalid datetime"):
+        legacy_run._parse_datetime("2026/01/01 00:00:00")
+
+
+def test_runner_main_writes_csv_and_prints_output_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    input_path = tmp_path / "forcing.csv"
+    output_path = tmp_path / "out" / "results.csv"
+    _write_forcing_csv(input_path)
+
+    result = legacy_run.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--max-steps",
+            "2",
+            "--fixed-lai",
+            "2.1",
+        ]
+    )
+
+    assert result == 0
+    assert output_path.exists()
+
+    out = pd.read_csv(output_path)
+    assert len(out) == 2
+    assert out["LAI"].tolist() == pytest.approx([2.1, 2.1])
+    assert "co2_flux_g_m2_s" in out.columns
+    assert str(output_path.resolve()) in capsys.readouterr().out
+
+
+def test_runner_module_execution_delegates_to_main(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_path = tmp_path / "forcing.csv"
+    output_path = tmp_path / "module-out" / "results.csv"
+    _write_forcing_csv(input_path)
+    module_name = "stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy.run"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--max-steps",
+            "1",
+        ],
+    )
+    sys.modules.pop(module_name, None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module(module_name, run_name="__main__")
+
+    assert exc_info.value.code == 0
+    assert output_path.exists()
+    out = pd.read_csv(output_path)
+    assert len(out) == 1


### PR DESCRIPTION
## Background
- `slice 029` landed the bounded `TomatoModel` surface, but the migrated TOMATO package still lacked the legacy runner seam that turns forcing CSV input into a written results table.
- This PR lands `slice 030` by adding the package-local runner and moving the next architectural uncertainty to the TOMATO partition-policy package.

## Changes
- add the migrated `models/tomato_legacy/run.py` runner over `iter_forcing_csv()`, `TomatoLegacyAdapter`, and `simulate()`
- add runner integration tests for argument parsing, CSV output writing, and module execution
- update architecture artifacts and README so `slice 030` is recorded and `components/partitioning/policy.py` becomes the next blocked seam

## Validation
- `.venv\Scripts\python.exe -m pytest`
- `.venv\Scripts\ruff.exe check .`

## Impact
- the migrated TOMATO `tTHORP` package now has a package-local legacy runner surface
- deeper partition-policy migration remains explicitly blocked and documented for the next slice

## Linked issue
Closes #53
