### PR TITLE
[Model Change] Migrate TOMATO tTHORP partitioning core seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,4 +11,4 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-030 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, and runner seams
+- Slices 025-031 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, and partitioning-core seams

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` adapter seam is migrated as slice 028.
 - TOMATO `tTHORP` `TomatoModel` surface seam is migrated as slice 029.
 - TOMATO `tTHORP` runner seam is migrated as slice 030.
+- TOMATO `tTHORP` partitioning core seam is migrated as slice 031.
 
 ## Next validation
-- Audit the TOMATO partition-policy seam at `components/partitioning/policy.py` and decide how to stage sink-based versus THORP-derived policy slices.
+- Audit the TOMATO THORP-derived partitioning helper seam at `components/partitioning/thorp_opt.py` and decide how to stage `thorp_opt.py` versus `thorp_policies.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 030
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 030 approved for TOMATO
+- Gate C. Validation plan ready through slice 031
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 031 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -227,3 +227,9 @@ Slice 030:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/run.py`
 - scope: bounded TOMATO package-local runner over migrated forcing CSV, adapter, and tabular simulation seams
 - excluded: TOMATO partition-policy package migration, broader package entrypoints, and other legacy subprojects
+
+Slice 031:
+- source: `TOMATO/tTHORP/src/tthorp/components/partitioning/{organ.py,fractions.py,policy.py,sink_based.py}`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
+- scope: bounded TOMATO partitioning core covering organ enums, allocation-fraction validation, policy coercion, and default sink-based allocation
+- excluded: `thorp_opt.py`, `thorp_policies.py`, and broader cross-domain policy sharing

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -284,8 +284,16 @@ The thirtieth slice opens the next bounded TOMATO seam:
 - keep the runner package-local instead of opening a repo-wide TOMATO CLI entrypoint yet
 - leave `components/partitioning/policy.py` blocked as the next seam
 
+## Slice 031: TOMATO tTHORP Partitioning Core
+
+The thirty-first slice opens the next bounded TOMATO seam:
+- move `organ.py`, `fractions.py`, `policy.py`, and `sink_based.py` into a package-local TOMATO partitioning core
+- preserve allocation-fraction validation, scheme conversion, policy coercion, and default sink-based aliases
+- wire `TomatoModel` to the migrated sink-based policy instead of keeping default partitioning inline
+- leave `components/partitioning/thorp_opt.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first six TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first seven TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `components/partitioning/policy.py`
+3. prepare the next TOMATO source audit for `components/partitioning/thorp_opt.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 030 completed and slice 031 planning
+- Current phase: slice 031 completed and slice 032 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO partition-policy seam starting at `components/partitioning/policy.py`
-2. decide whether sink-based and THORP-derived partition policies should land as one bounded package migration or multiple slices
+1. audit the TOMATO THORP-derived partitioning helper seam at `components/partitioning/thorp_opt.py`
+2. decide whether `thorp_opt.py` and `thorp_policies.py` should land as one bounded slice or remain separate
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-031-tomato-tthorp-partitioning-core.md
+++ b/docs/architecture/architecture/module_specs/module-031-tomato-tthorp-partitioning-core.md
@@ -1,0 +1,39 @@
+# Module Spec 031: TOMATO tTHORP Partitioning Core
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the partitioning core that owns organ enums, allocation-fraction validation, policy coercion, and the default sink-based tomato partition rule.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/organ.py`
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/fractions.py`
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/policy.py`
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/sink_based.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/tomato_model.py`
+- `tests/test_tomato_tthorp_partitioning.py`
+
+## Responsibilities
+
+1. preserve `Organ` and `AllocationFractions` validation and scheme-conversion behavior
+2. preserve `PartitionPolicy`/`coerce_partition_policy()` and the default sink-based policy aliases
+3. replace inline default tomato allocation fallback with the migrated sink-based partitioning core
+
+## Non-Goals
+
+- port THORP-derived tomato partitioning helpers in `thorp_opt.py`
+- port THORP-derived tomato policies in `thorp_policies.py`
+- broaden into repo-wide shared utilities or non-TOMATO domains
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/thorp_opt.py`

--- a/docs/architecture/executor/issue-031-model-change.md
+++ b/docs/architecture/executor/issue-031-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 030` landed the TOMATO runner seam, so the next smallest unresolved architecture gap is the partitioning core that should own organ enums, allocation-fraction validation, policy coercion, and the default sink-based partition rule.
+- The migrated `TomatoModel` currently falls back to inline allocation logic; this should be replaced by a bounded package-local partitioning seam before any THORP-derived tomato policies are considered.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
+- related TOMATO `TomatoModel` and adapter integration tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add partition-scheme conversion, sink-based invariant, and default policy wiring tests
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/components/partitioning/{organ.py,fractions.py,policy.py,sink_based.py}`
+- current migrated `TomatoModel` fallback allocation behavior

--- a/docs/architecture/executor/pr-055-tomato-partitioning-core.md
+++ b/docs/architecture/executor/pr-055-tomato-partitioning-core.md
@@ -1,0 +1,19 @@
+## Background
+- `slice 030` landed the TOMATO runner seam, but default tomato allocation still lived as inline fallback logic inside the migrated `TomatoModel`.
+- This PR lands `slice 031` by introducing a package-local partitioning core plus the default sink-based tomato policy, and moves the next blocked seam to the THORP-derived partitioning helpers.
+
+## Changes
+- add TOMATO partitioning core modules for `Organ`, `AllocationFractions`, `PartitionPolicy`, and `SinkBasedTomatoPolicy`
+- wire `TomatoModel` to the migrated sink-based policy via `coerce_partition_policy()`
+- add partitioning conversion and invariant tests, and update architecture artifacts to record `slice 031`
+
+## Validation
+- `.venv\Scripts\python.exe -m pytest`
+- `.venv\Scripts\ruff.exe check .`
+
+## Impact
+- default TOMATO partitioning now lives behind an explicit package-local seam instead of inline fallback logic
+- THORP-derived partitioning remains explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #55

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the package-local runner and bounded `TomatoModel` surface | Deeper partition-policy and wider pipeline coupling can still hide legacy assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the sink-based partitioning core, package-local runner, and bounded `TomatoModel` surface | THORP-derived partitioning and wider pipeline coupling can still hide legacy assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/__init__.py
@@ -1,0 +1,5 @@
+"""TOMATO tTHORP component seams."""
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components import partitioning
+
+__all__ = ["partitioning"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/__init__.py
@@ -1,0 +1,23 @@
+"""Migrated TOMATO partitioning core and default sink-based policy."""
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.fractions import (
+    AllocationFractions,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.organ import Organ
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.policy import (
+    PartitionPolicy,
+    build_partition_policy,
+    coerce_partition_policy,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.sink_based import (
+    SinkBasedTomatoPolicy,
+)
+
+__all__ = [
+    "AllocationFractions",
+    "Organ",
+    "PartitionPolicy",
+    "SinkBasedTomatoPolicy",
+    "build_partition_policy",
+    "coerce_partition_policy",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/fractions.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/fractions.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.organ import (
+    Organ,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationFractions:
+    """Allocation fractions for the requested partition scheme."""
+
+    values: dict[Organ, float]
+
+    def __post_init__(self) -> None:
+        normalized: dict[Organ, float] = {}
+        for organ, raw in self.values.items():
+            if not isinstance(organ, Organ):
+                raise TypeError(
+                    "AllocationFractions: keys must be Organ values, "
+                    f"got {type(organ).__name__}."
+                )
+            normalized[organ] = float(raw)
+        object.__setattr__(self, "values", normalized)
+        self.validate()
+
+    def validate(self, *, tol: float = 1e-9) -> None:
+        if tol < 0.0:
+            raise ValueError(f"AllocationFractions.validate: tol must be >= 0, got {tol!r}.")
+
+        total = 0.0
+        for organ, value in self.values.items():
+            if not math.isfinite(value):
+                raise ValueError(
+                    f"AllocationFractions.validate: {organ.value} must be finite, got {value!r}."
+                )
+            if value < -tol or value > 1.0 + tol:
+                raise ValueError(
+                    f"AllocationFractions.validate: {organ.value} must be in [0, 1], got {value!r}."
+                )
+            total += value
+
+        if abs(total - 1.0) > tol:
+            raise ValueError(
+                "AllocationFractions.validate: values must sum to 1.0 "
+                f"(within {tol}), got {total!r}."
+            )
+
+    @classmethod
+    def from_3pool_to_4pool(
+        cls,
+        fruit: float,
+        shoot: float,
+        root: float,
+        *,
+        leaf_stem_ratio: float = 0.7 / 0.3,
+    ) -> "AllocationFractions":
+        ratio = float(leaf_stem_ratio)
+        if not math.isfinite(ratio) or ratio <= 0.0:
+            raise ValueError(
+                "AllocationFractions.from_3pool_to_4pool: leaf_stem_ratio must be finite and > 0, "
+                f"got {leaf_stem_ratio!r}."
+            )
+        leaf_share = ratio / (1.0 + ratio)
+        stem_share = 1.0 / (1.0 + ratio)
+        return cls(
+            values={
+                Organ.FRUIT: float(fruit),
+                Organ.LEAF: float(shoot) * leaf_share,
+                Organ.STEM: float(shoot) * stem_share,
+                Organ.ROOT: float(root),
+            }
+        )
+
+    @classmethod
+    def from_4pool_to_3pool(
+        cls,
+        fruit: float,
+        leaf: float,
+        stem: float,
+        root: float,
+    ) -> "AllocationFractions":
+        shoot = float(leaf) + float(stem)
+        return cls(
+            values={
+                Organ.FRUIT: float(fruit),
+                Organ.SHOOT: shoot,
+                Organ.ROOT: float(root),
+            }
+        )

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/organ.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/organ.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Organ(str, Enum):
+    FRUIT = "fruit"
+    LEAF = "leaf"
+    STEM = "stem"
+    ROOT = "root"
+    SHOOT = "shoot"

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/policy.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.fractions import (
+    AllocationFractions,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
+
+
+@runtime_checkable
+class PartitionPolicy(Protocol):
+    name: str
+
+    def compute(
+        self,
+        *,
+        env: EnvStep,
+        state: object,
+        sinks: Mapping[str, float],
+        scheme: str,
+        params: Mapping[str, object] | None = None,
+    ) -> AllocationFractions:
+        """Compute allocation fractions for one step."""
+
+
+_SINK_BASED_ALIASES = {"sink_based", "sink-based", "sink", "legacy", "default"}
+_THORP_ALIASES = {
+    "thorp_veg",
+    "thorp_vegetative",
+    "thorp_fruit_veg",
+    "thorp_fruitveg",
+    "thorp_4pool",
+    "thorp-opt",
+    "thorp_opt",
+}
+
+
+def build_partition_policy(name: str) -> PartitionPolicy:
+    key = str(name).strip().lower()
+    if key in _SINK_BASED_ALIASES:
+        from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.sink_based import (
+            SinkBasedTomatoPolicy,
+        )
+
+        return SinkBasedTomatoPolicy()
+
+    if key in _THORP_ALIASES:
+        raise NotImplementedError(
+            f"Partition policy {name!r} is not migrated yet; the THORP-derived tomato policy seam remains blocked."
+        )
+
+    raise ValueError(f"Unknown partition policy name {name!r}.")
+
+
+def coerce_partition_policy(policy: PartitionPolicy | str | None) -> PartitionPolicy:
+    if policy is None:
+        return build_partition_policy("sink_based")
+    if isinstance(policy, str):
+        return build_partition_policy(policy)
+    if isinstance(policy, PartitionPolicy):
+        return policy
+
+    compute = getattr(policy, "compute", None)
+    name = getattr(policy, "name", None)
+    if callable(compute) and isinstance(name, str):
+        return policy  # type: ignore[return-value]
+
+    raise TypeError(
+        "partition_policy must be a policy instance, a known policy name string, or None."
+    )

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/sink_based.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/sink_based.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.fractions import (
+    AllocationFractions,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.organ import Organ
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
+
+
+def _sink_fraction(*, numerator: float, denominator: float) -> float:
+    if denominator > 1e-9:
+        return numerator / denominator
+    return 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class SinkBasedTomatoPolicy:
+    """Legacy tomato sink-based partitioning fractions."""
+
+    name: str = "sink_based"
+    leaf_fraction_of_shoot: float = 0.7
+    stem_fraction_of_shoot: float = 0.3
+
+    def compute(
+        self,
+        *,
+        env: EnvStep,
+        state: object,
+        sinks: Mapping[str, float],
+        scheme: str,
+        params: Mapping[str, object] | None = None,
+    ) -> AllocationFractions:
+        del env
+        del params
+
+        s_fr_g_d = float(sinks.get("S_fr_g_d", 0.0))
+        s_veg_g_d = float(sinks.get("S_veg_g_d", 0.0))
+
+        s_fr_g_d = max(0.0, s_fr_g_d)
+        s_veg_g_d = max(1e-9, s_veg_g_d)
+        s_total_g_d = s_fr_g_d + s_veg_g_d
+        f_fr_total = _sink_fraction(numerator=s_fr_g_d, denominator=s_total_g_d)
+        f_veg_total = 1.0 - f_fr_total
+
+        root_frac_of_total_veg = float(getattr(state, "root_frac_of_total_veg", 0.15 / 1.15))
+        f_rt = f_veg_total * root_frac_of_total_veg
+        f_shoot = f_veg_total - f_rt
+        f_lv = f_shoot * self.leaf_fraction_of_shoot
+        f_st = f_shoot * self.stem_fraction_of_shoot
+
+        scheme_key = str(scheme).strip().lower()
+        if scheme_key == "4pool":
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: f_fr_total,
+                    Organ.LEAF: f_lv,
+                    Organ.STEM: f_st,
+                    Organ.ROOT: f_rt,
+                }
+            )
+
+        if scheme_key == "3pool":
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: f_fr_total,
+                    Organ.SHOOT: f_shoot,
+                    Organ.ROOT: f_rt,
+                }
+            )
+
+        raise ValueError(f"Unsupported partition scheme {scheme!r}; expected '4pool' or '3pool'.")

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/tomato_model.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/tomato_model.py
@@ -9,6 +9,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning import (
+    PartitionPolicy,
+    coerce_partition_policy,
+)
 from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
 from stomatal_optimiaztion.domains.tomato.tthorp.interface import run_flux_step
 
@@ -49,18 +53,18 @@ class TomatoModel:
 
     This slice preserves the public state, CSV ingestion, output payload, and
     default adapter construction surface from the legacy `tomato_model.py`.
-    The deeper age-structured growth, full energy-balance solver, and broader
-    partition-policy ecosystem remain blocked for later slices.
+    The deeper age-structured growth, full energy-balance solver, and THORP-
+    derived partition-policy seams remain blocked for later slices.
     """
 
     def __init__(
         self,
         fixed_lai: float | None = None,
-        partition_policy: object | str | None = None,
+        partition_policy: PartitionPolicy | str | None = None,
         allocation_scheme: str = "4pool",
     ) -> None:
         self.fixed_lai = fixed_lai
-        self.partition_policy = partition_policy
+        self.partition_policy = coerce_partition_policy(partition_policy)
         self.allocation_scheme = str(allocation_scheme)
 
         self.lambda_v = 2.45e6

--- a/tests/test_tomato_tthorp_partitioning.py
+++ b/tests/test_tomato_tthorp_partitioning.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning import (
+    AllocationFractions,
+    Organ,
+    PartitionPolicy,
+    SinkBasedTomatoPolicy,
+    build_partition_policy,
+    coerce_partition_policy,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import TomatoModel
+
+
+@dataclass(frozen=True, slots=True)
+class _DummyState:
+    root_frac_of_total_veg: float = 0.15 / 1.15
+
+
+@dataclass(frozen=True, slots=True)
+class _CustomPolicy:
+    name: str = "custom"
+
+    def compute(
+        self,
+        *,
+        env: EnvStep,
+        state: object,
+        sinks: dict[str, float],
+        scheme: str,
+        params: dict[str, object] | None = None,
+    ) -> AllocationFractions:
+        del env
+        del state
+        del sinks
+        del scheme
+        del params
+        return AllocationFractions(
+            values={
+                Organ.FRUIT: 0.25,
+                Organ.LEAF: 0.35,
+                Organ.STEM: 0.25,
+                Organ.ROOT: 0.15,
+            }
+        )
+
+
+def _env() -> EnvStep:
+    return EnvStep(
+        t=datetime(2026, 1, 1, 0, 0, 0),
+        dt_s=3600.0,
+        T_air_C=25.0,
+        PAR_umol=400.0,
+        CO2_ppm=420.0,
+        RH_percent=60.0,
+        wind_speed_ms=1.0,
+    )
+
+
+def test_scheme_roundtrip_3pool_to_4pool_to_3pool() -> None:
+    original = AllocationFractions(values={Organ.FRUIT: 0.3, Organ.SHOOT: 0.5, Organ.ROOT: 0.2})
+    as_4pool = AllocationFractions.from_3pool_to_4pool(
+        fruit=original.values[Organ.FRUIT],
+        shoot=original.values[Organ.SHOOT],
+        root=original.values[Organ.ROOT],
+    )
+    back = AllocationFractions.from_4pool_to_3pool(
+        fruit=as_4pool.values[Organ.FRUIT],
+        leaf=as_4pool.values[Organ.LEAF],
+        stem=as_4pool.values[Organ.STEM],
+        root=as_4pool.values[Organ.ROOT],
+    )
+
+    assert back.values[Organ.FRUIT] == pytest.approx(original.values[Organ.FRUIT], abs=1e-12)
+    assert back.values[Organ.SHOOT] == pytest.approx(original.values[Organ.SHOOT], abs=1e-12)
+    assert back.values[Organ.ROOT] == pytest.approx(original.values[Organ.ROOT], abs=1e-12)
+
+
+def test_3pool_to_4pool_default_ratio_matches_legacy_split() -> None:
+    fractions = AllocationFractions.from_3pool_to_4pool(fruit=0.4, shoot=0.5, root=0.1)
+
+    assert fractions.values[Organ.FRUIT] == pytest.approx(0.4)
+    assert fractions.values[Organ.LEAF] == pytest.approx(0.35)
+    assert fractions.values[Organ.STEM] == pytest.approx(0.15)
+    assert fractions.values[Organ.ROOT] == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize("scheme", ["4pool", "3pool"])
+def test_sink_based_policy_invariants(scheme: str) -> None:
+    fracs = SinkBasedTomatoPolicy().compute(
+        env=_env(),
+        state=_DummyState(),
+        sinks={"S_fr_g_d": 12.0, "S_veg_g_d": 4.0},
+        scheme=scheme,
+        params=None,
+    )
+
+    values = list(fracs.values.values())
+    assert values
+    assert all(math.isfinite(value) for value in values)
+    assert all(0.0 <= value <= 1.0 for value in values)
+    assert sum(values) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_build_partition_policy_supports_sink_based_aliases_only() -> None:
+    assert build_partition_policy("sink_based").name == "sink_based"
+    assert build_partition_policy("sink-based").name == "sink_based"
+    assert build_partition_policy("default").name == "sink_based"
+
+    with pytest.raises(NotImplementedError, match="not migrated yet"):
+        build_partition_policy("thorp_veg")
+
+
+def test_coerce_partition_policy_accepts_protocol_instances() -> None:
+    policy = _CustomPolicy()
+
+    out = coerce_partition_policy(policy)
+
+    assert isinstance(out, PartitionPolicy)
+    assert out.name == "custom"
+
+
+def test_tomato_model_defaults_to_sink_based_policy() -> None:
+    model = TomatoModel()
+
+    assert model.partition_policy.name == "sink_based"
+
+    explicit = TomatoModel(partition_policy="sink-based")
+    assert explicit.partition_policy.name == "sink_based"


### PR DESCRIPTION
## Background
- `slice 030` landed the TOMATO runner seam, but default tomato allocation still lived as inline fallback logic inside the migrated `TomatoModel`.
- This PR lands `slice 031` by introducing a package-local partitioning core plus the default sink-based tomato policy, and moves the next blocked seam to the THORP-derived partitioning helpers.

## Changes
- add TOMATO partitioning core modules for `Organ`, `AllocationFractions`, `PartitionPolicy`, and `SinkBasedTomatoPolicy`
- wire `TomatoModel` to the migrated sink-based policy via `coerce_partition_policy()`
- add partitioning conversion and invariant tests, and update architecture artifacts to record `slice 031`

## Validation
- `.venv\Scripts\python.exe -m pytest`
- `.venv\Scripts\ruff.exe check .`

## Impact
- default TOMATO partitioning now lives behind an explicit package-local seam instead of inline fallback logic
- THORP-derived partitioning remains explicitly blocked and documented for the next slice

## Linked issue
Closes #55
