### PR TITLE
[Model Change] Migrate TOMATO tTHORP THORP-derived partition policies seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,4 +11,4 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-031 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, and partitioning-core seams
+- Slices 025-032 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, and partitioning-package seams

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` `TomatoModel` surface seam is migrated as slice 029.
 - TOMATO `tTHORP` runner seam is migrated as slice 030.
 - TOMATO `tTHORP` partitioning core seam is migrated as slice 031.
+- TOMATO `tTHORP` THORP-derived partition-policy seam is migrated as slice 032.
 
 ## Next validation
-- Audit the TOMATO THORP-derived partitioning helper seam at `components/partitioning/thorp_opt.py` and decide how to stage `thorp_opt.py` versus `thorp_policies.py`.
+- Audit the TOMATO package-level legacy pipeline seam at `pipelines/tomato_legacy.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 031
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 031 approved for TOMATO
+- Gate C. Validation plan ready through slice 032
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 032 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -233,3 +233,9 @@ Slice 031:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
 - scope: bounded TOMATO partitioning core covering organ enums, allocation-fraction validation, policy coercion, and default sink-based allocation
 - excluded: `thorp_opt.py`, `thorp_policies.py`, and broader cross-domain policy sharing
+
+Slice 032:
+- source: `TOMATO/tTHORP/src/tthorp/components/partitioning/{thorp_opt.py,thorp_policies.py}`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
+- scope: bounded TOMATO THORP-derived partitioning surface covering allocation wrappers, policy aliases, and `TomatoModel` THORP-policy execution
+- excluded: `pipelines/tomato_legacy.py`, `core/`, and `models/thorp_ref/`

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -282,18 +282,18 @@ The thirtieth slice opens the next bounded TOMATO seam:
 - move `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/run.py` into the staged `domains/tomato/tthorp` package
 - preserve bounded argument parsing, forcing iteration, default adapter construction, and CSV result writing
 - keep the runner package-local instead of opening a repo-wide TOMATO CLI entrypoint yet
-- leave `components/partitioning/policy.py` blocked as the next seam
+- leave `pipelines/tomato_legacy.py` blocked as the next seam
 
-## Slice 031: TOMATO tTHORP Partitioning Core
+## Slice 032: TOMATO tTHORP THORP-Derived Partition Policies
 
-The thirty-first slice opens the next bounded TOMATO seam:
-- move `organ.py`, `fractions.py`, `policy.py`, and `sink_based.py` into a package-local TOMATO partitioning core
-- preserve allocation-fraction validation, scheme conversion, policy coercion, and default sink-based aliases
-- wire `TomatoModel` to the migrated sink-based policy instead of keeping default partitioning inline
-- leave `components/partitioning/thorp_opt.py` blocked as the next seam
+The thirty-second slice closes the remaining TOMATO partitioning seam:
+- move `thorp_opt.py` and `thorp_policies.py` into the package-local TOMATO partitioning package
+- preserve THORP-backed tomato allocation wrappers, policy invariants, and `thorp_veg` / `thorp_fruit_veg` alias wiring
+- keep `TomatoModel` able to execute THORP-derived policies without breaking the bounded legacy surface
+- leave `pipelines/tomato_legacy.py` blocked as the next seam
 
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first seven TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first eight TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `components/partitioning/thorp_opt.py`
+3. prepare the next TOMATO source audit for `pipelines/tomato_legacy.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 031 completed and slice 032 planning
+- Current phase: slice 032 completed and slice 033 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO THORP-derived partitioning helper seam at `components/partitioning/thorp_opt.py`
-2. decide whether `thorp_opt.py` and `thorp_policies.py` should land as one bounded slice or remain separate
+1. audit the TOMATO package-level legacy pipeline seam at `pipelines/tomato_legacy.py`
+2. decide how much of `pipelines/tomato_legacy.py` can land without pulling in `core/` helpers prematurely
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-032-tomato-tthorp-thorp-partition-policies.md
+++ b/docs/architecture/architecture/module_specs/module-032-tomato-tthorp-thorp-partition-policies.md
@@ -1,0 +1,38 @@
+# Module Spec 032: TOMATO tTHORP THORP-Derived Partition Policies
+
+## Purpose
+
+Close the remaining TOMATO `tTHORP` partitioning seam by porting the THORP-backed tomato allocation adapter and policy layer that powers `thorp_veg` and `thorp_fruit_veg`.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/thorp_opt.py`
+- `TOMATO/tTHORP/src/tthorp/components/partitioning/thorp_policies.py`
+- `TOMATO/tTHORP/tests/test_thorp_opt_partitioning.py`
+- `TOMATO/tTHORP/tests/test_partition_policy_invariants.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
+- `tests/test_tomato_tthorp_partitioning.py`
+
+## Responsibilities
+
+1. provide `ThorpObjectiveParams`, THORP allocation wrappers, and collapsed tomato partition outputs behind a TOMATO-local surface
+2. reuse the migrated THORP allocation core while preserving the TOMATO adapter contract for ported versus external THORP backends
+3. expose `ThorpVegetativePolicy` and `ThorpFruitVegPolicy` through `build_partition_policy()` alias wiring and keep `TomatoModel` policy execution finite
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/src/tthorp/pipelines/tomato_legacy.py`
+- migrate `TOMATO/tTHORP/src/tthorp/core/`
+- broaden into shared cross-crop partition-policy abstractions
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/pipelines/tomato_legacy.py`

--- a/docs/architecture/executor/issue-032-model-change.md
+++ b/docs/architecture/executor/issue-032-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 031` landed the TOMATO partitioning core, but all THORP-derived tomato policy aliases still raise `NotImplementedError`.
+- The next bounded seam is the THORP-backed tomato partition adapter layer that owns `thorp_opt.py`, `thorp_policies.py`, and policy-builder wiring for `thorp_veg` / `thorp_fruit_veg`.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
+- related TOMATO `TomatoModel` and partition-policy integration tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add wrapper-equivalence, THORP-policy alias, and `TomatoModel(partition_policy="thorp_veg")` coverage
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/components/partitioning/{thorp_opt.py,thorp_policies.py}`
+- current migrated `domains/thorp/allocation.py` core behavior

--- a/docs/architecture/executor/pr-057-tomato-thorp-partition-policies.md
+++ b/docs/architecture/executor/pr-057-tomato-thorp-partition-policies.md
@@ -1,0 +1,20 @@
+## Background
+- `slice 031` landed the TOMATO partitioning core, but every THORP-derived tomato policy alias was still blocked behind `NotImplementedError`.
+- This PR lands `slice 032` by migrating the THORP-backed tomato allocation adapter and policy layer, and moves the next TOMATO seam to the package-level legacy pipeline wrapper.
+
+## Changes
+- add TOMATO partitioning adapters for `ThorpObjectiveParams`, THORP allocation fractions, and collapsed tomato partition outputs
+- add `ThorpVegetativePolicy` and `ThorpFruitVegPolicy`, then wire `build_partition_policy()` aliases to real policy instances
+- expand partitioning tests to cover wrapper behavior, THORP-policy invariants, and `TomatoModel(partition_policy=\"thorp_veg\")`
+- update architecture artifacts to record `slice 032`
+
+## Validation
+- `.venv\Scripts\python.exe -m pytest`
+- `.venv\Scripts\ruff.exe check .`
+
+## Impact
+- TOMATO partition-policy aliases now resolve to concrete migrated policies instead of runtime blockers
+- the next bounded TOMATO seam shifts from partitioning internals to `pipelines/tomato_legacy.py`
+
+## Linked issue
+Closes #57

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the sink-based partitioning core, package-local runner, and bounded `TomatoModel` surface | THORP-derived partitioning and wider pipeline coupling can still hide legacy assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the partitioning package, package-local runner, and bounded `TomatoModel` surface | package-level pipeline coupling and shared core helpers can still hide legacy assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/__init__.py
@@ -12,12 +12,32 @@ from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.policy 
 from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.sink_based import (
     SinkBasedTomatoPolicy,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.thorp_opt import (
+    ThorpAllocationFractions,
+    ThorpObjectiveParams,
+    TomatoPartitionFractions,
+    objective_params_from_thorp,
+    thorp_allocation_fractions,
+    tomato_partitioning,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.thorp_policies import (
+    ThorpFruitVegPolicy,
+    ThorpVegetativePolicy,
+)
 
 __all__ = [
     "AllocationFractions",
     "Organ",
     "PartitionPolicy",
     "SinkBasedTomatoPolicy",
+    "ThorpAllocationFractions",
+    "ThorpFruitVegPolicy",
+    "ThorpObjectiveParams",
+    "ThorpVegetativePolicy",
+    "TomatoPartitionFractions",
     "build_partition_policy",
     "coerce_partition_policy",
+    "objective_params_from_thorp",
+    "thorp_allocation_fractions",
+    "tomato_partitioning",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/policy.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/policy.py
@@ -26,17 +26,6 @@ class PartitionPolicy(Protocol):
 
 
 _SINK_BASED_ALIASES = {"sink_based", "sink-based", "sink", "legacy", "default"}
-_THORP_ALIASES = {
-    "thorp_veg",
-    "thorp_vegetative",
-    "thorp_fruit_veg",
-    "thorp_fruitveg",
-    "thorp_4pool",
-    "thorp-opt",
-    "thorp_opt",
-}
-
-
 def build_partition_policy(name: str) -> PartitionPolicy:
     key = str(name).strip().lower()
     if key in _SINK_BASED_ALIASES:
@@ -46,10 +35,19 @@ def build_partition_policy(name: str) -> PartitionPolicy:
 
         return SinkBasedTomatoPolicy()
 
-    if key in _THORP_ALIASES:
-        raise NotImplementedError(
-            f"Partition policy {name!r} is not migrated yet; the THORP-derived tomato policy seam remains blocked."
+    if key in {"thorp_veg", "thorp_vegetative", "thorp-opt", "thorp_opt"}:
+        from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.thorp_policies import (
+            ThorpVegetativePolicy,
         )
+
+        return ThorpVegetativePolicy()
+
+    if key in {"thorp_fruit_veg", "thorp_fruitveg", "thorp_4pool"}:
+        from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.thorp_policies import (
+            ThorpFruitVegPolicy,
+        )
+
+        return ThorpFruitVegPolicy()
 
     raise ValueError(f"Unknown partition policy name {name!r}.")
 

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/thorp_opt.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/thorp_opt.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from stomatal_optimiaztion.domains.thorp.allocation import (
+    AllocationParams as ThorpAllocationParams,
+)
+from stomatal_optimiaztion.domains.thorp.allocation import (
+    allocation_fractions as core_allocation_fractions,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ThorpObjectiveParams:
+    """Objective weights required by THORP allocation equations."""
+
+    sla: float
+    tau_l: float
+    tau_r: float
+    tau_sw: float
+    r_m_sw_func: Callable[[float], float]
+    r_m_r_func: Callable[[float], float]
+
+
+@dataclass(frozen=True, slots=True)
+class ThorpAllocationFractions:
+    """Full THORP allocation fractions."""
+
+    u_l: float
+    u_r_h: NDArray[np.floating]
+    u_r_v: NDArray[np.floating]
+    u_sw: float
+    backend: str = "ported"
+
+    @property
+    def u_root(self) -> float:
+        return float(np.sum(self.u_r_h + self.u_r_v))
+
+    @property
+    def u_stem(self) -> float:
+        return float(self.u_sw)
+
+
+@dataclass(frozen=True, slots=True)
+class TomatoPartitionFractions:
+    """Collapsed tomato fractions (leaf/stem/root)."""
+
+    u_leaf: float
+    u_stem: float
+    u_root: float
+    backend: str = "ported"
+
+    @property
+    def uL(self) -> float:  # noqa: N802 - preserve domain shorthand
+        return self.u_leaf
+
+    @property
+    def uS(self) -> float:  # noqa: N802 - preserve domain shorthand
+        return self.u_stem
+
+    @property
+    def uR(self) -> float:  # noqa: N802 - preserve domain shorthand
+        return self.u_root
+
+
+def objective_params_from_thorp(thorp_params: object) -> ThorpObjectiveParams:
+    """Extract minimum objective fields from a THORP params object."""
+
+    required = ("sla", "tau_l", "tau_r", "tau_sw", "r_m_sw_func", "r_m_r_func")
+    missing = [name for name in required if not hasattr(thorp_params, name)]
+    if missing:
+        raise AttributeError(
+            "THORP params missing required allocation fields: "
+            + ", ".join(sorted(missing))
+            + "."
+        )
+    return ThorpObjectiveParams(
+        sla=float(getattr(thorp_params, "sla")),
+        tau_l=float(getattr(thorp_params, "tau_l")),
+        tau_r=float(getattr(thorp_params, "tau_r")),
+        tau_sw=float(getattr(thorp_params, "tau_sw")),
+        r_m_sw_func=getattr(thorp_params, "r_m_sw_func"),
+        r_m_r_func=getattr(thorp_params, "r_m_r_func"),
+    )
+
+
+def _resolve_thorp_src() -> Path | None:
+    env_value = str(os.environ.get("TTHORP_THORP_SRC", "")).strip()
+    if env_value:
+        candidate = Path(env_value).expanduser().resolve()
+        if candidate.exists():
+            return candidate
+
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "THORP" / "src"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _import_thorp_allocation():
+    try:
+        from thorp.allocation import allocation_fractions
+
+        return allocation_fractions
+    except ModuleNotFoundError:
+        pass
+
+    thorp_src = _resolve_thorp_src()
+    if thorp_src is None:
+        return None
+
+    thorp_src_str = str(thorp_src)
+    if thorp_src_str not in sys.path:
+        sys.path.insert(0, thorp_src_str)
+
+    try:
+        from thorp.allocation import allocation_fractions
+
+        return allocation_fractions
+    except ModuleNotFoundError:
+        return None
+
+
+def _as_vector(name: str, values: ArrayLike) -> NDArray[np.floating]:
+    arr = np.asarray(values, dtype=float)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a 1D array, got shape {arr.shape}.")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must contain only finite values.")
+    return arr
+
+
+def _ported_allocation_fractions(
+    *,
+    objective_params: ThorpObjectiveParams,
+    a_n: float,
+    lambda_wue: float,
+    d_a_n_d_r_abs: float,
+    d_e_d_la: float,
+    d_e_d_d: float,
+    d_e_d_c_r_h: NDArray[np.floating],
+    d_e_d_c_r_v: NDArray[np.floating],
+    d_r_abs_d_h: float,
+    d_r_abs_d_w: float,
+    d_r_abs_d_la: float,
+    h: float,
+    w: float,
+    d: float,
+    c_w: float,
+    c_l: float,
+    c0: float,
+    c1: float,
+    t_a: float,
+    t_soil: float,
+) -> ThorpAllocationFractions:
+    if c_l == 0:
+        return ThorpAllocationFractions(
+            u_l=1.0,
+            u_r_h=np.zeros_like(d_e_d_c_r_h, dtype=float),
+            u_r_v=np.zeros_like(d_e_d_c_r_v, dtype=float),
+            u_sw=0.0,
+            backend="ported",
+        )
+
+    if d <= 0:
+        raise ValueError(f"d must be > 0, got {d!r}.")
+    if c_w <= 0:
+        raise ValueError(f"c_w must be > 0, got {c_w!r}.")
+
+    raw = core_allocation_fractions(
+        params=ThorpAllocationParams(
+            sla=objective_params.sla,
+            tau_l=objective_params.tau_l,
+            tau_r=objective_params.tau_r,
+            tau_sw=objective_params.tau_sw,
+            r_m_sw_func=objective_params.r_m_sw_func,
+            r_m_r_func=objective_params.r_m_r_func,
+        ),
+        a_n=float(a_n),
+        lambda_wue=float(lambda_wue),
+        d_a_n_d_r_abs=float(d_a_n_d_r_abs),
+        d_e_d_la=float(d_e_d_la),
+        d_e_d_d=float(d_e_d_d),
+        d_e_d_c_r_h=d_e_d_c_r_h,
+        d_e_d_c_r_v=d_e_d_c_r_v,
+        d_r_abs_d_h=float(d_r_abs_d_h),
+        d_r_abs_d_w=float(d_r_abs_d_w),
+        d_r_abs_d_la=float(d_r_abs_d_la),
+        h=float(h),
+        w=float(w),
+        d=float(d),
+        c_w=float(c_w),
+        c_l=float(c_l),
+        c0=float(c0),
+        c1=float(c1),
+        t_a=float(t_a),
+        t_soil=float(t_soil),
+    )
+    return ThorpAllocationFractions(
+        u_l=float(raw.u_l),
+        u_r_h=np.asarray(raw.u_r_h, dtype=float),
+        u_r_v=np.asarray(raw.u_r_v, dtype=float),
+        u_sw=float(raw.u_sw),
+        backend="ported",
+    )
+
+
+def thorp_allocation_fractions(
+    *,
+    a_n: float,
+    lambda_wue: float,
+    d_a_n_d_r_abs: float,
+    d_e_d_la: float,
+    d_e_d_d: float,
+    d_e_d_c_r_h: ArrayLike,
+    d_e_d_c_r_v: ArrayLike,
+    d_r_abs_d_h: float,
+    d_r_abs_d_w: float,
+    d_r_abs_d_la: float,
+    h: float,
+    w: float,
+    d: float,
+    c_w: float,
+    c_l: float,
+    c0: float,
+    c1: float,
+    t_a: float,
+    t_soil: float,
+    objective_params: ThorpObjectiveParams | None = None,
+    thorp_params: object | None = None,
+    prefer_thorp: bool = True,
+    allow_port_fallback: bool = True,
+) -> ThorpAllocationFractions:
+    """Compute THORP partitioning fractions, using external THORP when available."""
+
+    u_r_h_vec = _as_vector("d_e_d_c_r_h", d_e_d_c_r_h)
+    u_r_v_vec = _as_vector("d_e_d_c_r_v", d_e_d_c_r_v)
+    if u_r_h_vec.shape != u_r_v_vec.shape:
+        raise ValueError(
+            "d_e_d_c_r_h and d_e_d_c_r_v must have matching shapes, "
+            f"got {u_r_h_vec.shape} and {u_r_v_vec.shape}."
+        )
+
+    obj = objective_params
+    if obj is None and thorp_params is not None:
+        obj = objective_params_from_thorp(thorp_params)
+    if obj is None:
+        raise ValueError("Provide objective_params or thorp_params.")
+
+    if prefer_thorp and thorp_params is not None:
+        allocation_fn = _import_thorp_allocation()
+        if allocation_fn is not None:
+            raw = allocation_fn(
+                params=thorp_params,
+                a_n=float(a_n),
+                lambda_wue=float(lambda_wue),
+                d_a_n_d_r_abs=float(d_a_n_d_r_abs),
+                d_e_d_la=float(d_e_d_la),
+                d_e_d_d=float(d_e_d_d),
+                d_e_d_c_r_h=u_r_h_vec,
+                d_e_d_c_r_v=u_r_v_vec,
+                d_r_abs_d_h=float(d_r_abs_d_h),
+                d_r_abs_d_w=float(d_r_abs_d_w),
+                d_r_abs_d_la=float(d_r_abs_d_la),
+                h=float(h),
+                w=float(w),
+                d=float(d),
+                c_w=float(c_w),
+                c_l=float(c_l),
+                c0=float(c0),
+                c1=float(c1),
+                t_a=float(t_a),
+                t_soil=float(t_soil),
+            )
+            return ThorpAllocationFractions(
+                u_l=float(raw.u_l),
+                u_r_h=np.asarray(raw.u_r_h, dtype=float),
+                u_r_v=np.asarray(raw.u_r_v, dtype=float),
+                u_sw=float(raw.u_sw),
+                backend="thorp",
+            )
+        if not allow_port_fallback:
+            raise ModuleNotFoundError(
+                "THORP package not available. Install/import THORP or set allow_port_fallback=True."
+            )
+
+    return _ported_allocation_fractions(
+        objective_params=obj,
+        a_n=float(a_n),
+        lambda_wue=float(lambda_wue),
+        d_a_n_d_r_abs=float(d_a_n_d_r_abs),
+        d_e_d_la=float(d_e_d_la),
+        d_e_d_d=float(d_e_d_d),
+        d_e_d_c_r_h=u_r_h_vec,
+        d_e_d_c_r_v=u_r_v_vec,
+        d_r_abs_d_h=float(d_r_abs_d_h),
+        d_r_abs_d_w=float(d_r_abs_d_w),
+        d_r_abs_d_la=float(d_r_abs_d_la),
+        h=float(h),
+        w=float(w),
+        d=float(d),
+        c_w=float(c_w),
+        c_l=float(c_l),
+        c0=float(c0),
+        c1=float(c1),
+        t_a=float(t_a),
+        t_soil=float(t_soil),
+    )
+
+
+def tomato_partitioning(
+    *,
+    a_n: float,
+    lambda_wue: float,
+    d_a_n_d_r_abs: float,
+    d_e_d_la: float,
+    d_e_d_d: float,
+    d_e_d_c_r_h: ArrayLike,
+    d_e_d_c_r_v: ArrayLike,
+    d_r_abs_d_h: float,
+    d_r_abs_d_w: float,
+    d_r_abs_d_la: float,
+    h: float,
+    w: float,
+    d: float,
+    c_w: float,
+    c_l: float,
+    c0: float,
+    c1: float,
+    t_a: float,
+    t_soil: float,
+    objective_params: ThorpObjectiveParams | None = None,
+    thorp_params: object | None = None,
+    prefer_thorp: bool = True,
+    allow_port_fallback: bool = True,
+) -> TomatoPartitionFractions:
+    """Return collapsed leaf/stem/root fractions for tomato partitioning."""
+
+    alloc = thorp_allocation_fractions(
+        a_n=a_n,
+        lambda_wue=lambda_wue,
+        d_a_n_d_r_abs=d_a_n_d_r_abs,
+        d_e_d_la=d_e_d_la,
+        d_e_d_d=d_e_d_d,
+        d_e_d_c_r_h=d_e_d_c_r_h,
+        d_e_d_c_r_v=d_e_d_c_r_v,
+        d_r_abs_d_h=d_r_abs_d_h,
+        d_r_abs_d_w=d_r_abs_d_w,
+        d_r_abs_d_la=d_r_abs_d_la,
+        h=h,
+        w=w,
+        d=d,
+        c_w=c_w,
+        c_l=c_l,
+        c0=c0,
+        c1=c1,
+        t_a=t_a,
+        t_soil=t_soil,
+        objective_params=objective_params,
+        thorp_params=thorp_params,
+        prefer_thorp=prefer_thorp,
+        allow_port_fallback=allow_port_fallback,
+    )
+
+    return TomatoPartitionFractions(
+        u_leaf=float(alloc.u_l),
+        u_stem=float(alloc.u_sw),
+        u_root=float(np.sum(alloc.u_r_h + alloc.u_r_v)),
+        backend=alloc.backend,
+    )
+
+
+__all__ = [
+    "ThorpAllocationFractions",
+    "ThorpObjectiveParams",
+    "TomatoPartitionFractions",
+    "objective_params_from_thorp",
+    "thorp_allocation_fractions",
+    "tomato_partitioning",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/thorp_policies.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/thorp_policies.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.fractions import (
+    AllocationFractions,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.organ import Organ
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.policy import (
+    PartitionPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.thorp_opt import (
+    ThorpObjectiveParams,
+    tomato_partitioning,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
+
+
+def _constant(value: float):
+    def _fn(_t: float) -> float:
+        return float(value)
+
+    return _fn
+
+
+def _finite(value: object, *, default: float) -> float:
+    try:
+        x = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(x):
+        return float(default)
+    return float(x)
+
+
+def _default_objective_params() -> ThorpObjectiveParams:
+    return ThorpObjectiveParams(
+        sla=0.08,
+        tau_l=200.0,
+        tau_r=365.0,
+        tau_sw=400.0,
+        r_m_sw_func=_constant(0.01),
+        r_m_r_func=_constant(0.008),
+    )
+
+
+def _fruit_fraction_from_sinks(*, s_fr_g_d: float, s_veg_g_d: float) -> float:
+    s_fr = max(0.0, float(s_fr_g_d))
+    s_veg = max(1e-9, float(s_veg_g_d))
+    s_total = s_fr + s_veg
+    if s_total > 1e-9:
+        return s_fr / s_total
+    return 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ThorpVegetativePolicy(PartitionPolicy):
+    """Fruit from sinks, vegetative split from THORP allocation rule (ported)."""
+
+    name: str = "thorp_veg"
+
+    lambda_wue: float = 1.2
+    d_a_n_d_r_abs: float = 0.03
+    d_e_d_la: float = 0.015
+    d_e_d_d: float = 0.004
+    d_e_d_c_r_h: tuple[float, ...] = (0.006, 0.004)
+    d_e_d_c_r_v: tuple[float, ...] = (0.003, 0.002)
+    d_r_abs_d_h: float = 20.0
+    d_r_abs_d_w: float = 8.0
+    d_r_abs_d_la: float = 0.2
+    h: float = 1.5
+    w: float = 0.08
+    d: float = 0.02
+    c0: float = 0.6411
+    c1: float = 0.625
+    t_soil_c: float = 23.0
+
+    def compute(
+        self,
+        *,
+        env: EnvStep,
+        state: object,
+        sinks: Mapping[str, float],
+        scheme: str,
+        params: Mapping[str, object] | None = None,
+    ) -> AllocationFractions:
+        del params
+
+        s_fr_g_d = float(sinks.get("S_fr_g_d", 0.0))
+        s_veg_g_d = float(sinks.get("S_veg_g_d", 0.0))
+        f_fr = _fruit_fraction_from_sinks(s_fr_g_d=s_fr_g_d, s_veg_g_d=s_veg_g_d)
+        f_veg = 1.0 - f_fr
+
+        a_n = max(0.0, _finite(getattr(state, "co2_flux_g_m2_s", 0.0), default=0.0))
+
+        # Map tomato dry-matter pools to THORP carbon pools as a first-order proxy.
+        c_l = max(0.0, _finite(getattr(state, "W_lv", 0.0), default=0.0))
+        c_w = max(1e-6, _finite(getattr(state, "W_st", 1.0), default=1.0))
+
+        split = tomato_partitioning(
+            a_n=a_n,
+            lambda_wue=self.lambda_wue,
+            d_a_n_d_r_abs=self.d_a_n_d_r_abs,
+            d_e_d_la=self.d_e_d_la,
+            d_e_d_d=self.d_e_d_d,
+            d_e_d_c_r_h=np.asarray(self.d_e_d_c_r_h, dtype=float),
+            d_e_d_c_r_v=np.asarray(self.d_e_d_c_r_v, dtype=float),
+            d_r_abs_d_h=self.d_r_abs_d_h,
+            d_r_abs_d_w=self.d_r_abs_d_w,
+            d_r_abs_d_la=self.d_r_abs_d_la,
+            h=self.h,
+            w=self.w,
+            d=self.d,
+            c_w=c_w,
+            c_l=c_l,
+            c0=self.c0,
+            c1=self.c1,
+            t_a=float(env.T_air_C),
+            t_soil=float(self.t_soil_c),
+            objective_params=_default_objective_params(),
+            prefer_thorp=True,
+            allow_port_fallback=True,
+        )
+
+        u_leaf = max(0.0, float(split.u_leaf))
+        u_stem = max(0.0, float(split.u_stem))
+        u_root = max(0.0, float(split.u_root))
+        u_sum = u_leaf + u_stem + u_root
+        if (not math.isfinite(u_sum)) or u_sum <= 0.0:
+            u_leaf, u_stem, u_root = 0.7, 0.3, 0.0
+            u_sum = 1.0
+        u_leaf /= u_sum
+        u_stem /= u_sum
+        u_root /= u_sum
+
+        scheme_key = str(scheme).strip().lower()
+        if scheme_key == "4pool":
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: f_fr,
+                    Organ.LEAF: f_veg * u_leaf,
+                    Organ.STEM: f_veg * u_stem,
+                    Organ.ROOT: f_veg * u_root,
+                }
+            )
+
+        if scheme_key == "3pool":
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: f_fr,
+                    Organ.SHOOT: f_veg * (u_leaf + u_stem),
+                    Organ.ROOT: f_veg * u_root,
+                }
+            )
+
+        raise ValueError(f"Unsupported partition scheme {scheme!r}; expected '4pool' or '3pool'.")
+
+
+@dataclass(frozen=True, slots=True)
+class ThorpFruitVegPolicy(ThorpVegetativePolicy):
+    """THORP vegetative split, plus fruit-weighted sink fraction."""
+
+    name: str = "thorp_fruit_veg"
+    w_fruit: float = 0.0
+
+    def compute(
+        self,
+        *,
+        env: EnvStep,
+        state: object,
+        sinks: Mapping[str, float],
+        scheme: str,
+        params: Mapping[str, object] | None = None,
+    ) -> AllocationFractions:
+        s_fr_g_d = float(sinks.get("S_fr_g_d", 0.0))
+        s_veg_g_d = float(sinks.get("S_veg_g_d", 0.0))
+
+        w = max(0.0, _finite(self.w_fruit, default=0.0))
+        f_fr_base = _fruit_fraction_from_sinks(s_fr_g_d=s_fr_g_d, s_veg_g_d=s_veg_g_d)
+        if w <= 0.0:
+            f_fr = f_fr_base
+        else:
+            s_fr_eff = max(0.0, s_fr_g_d) * (1.0 + w)
+            f_fr = _fruit_fraction_from_sinks(s_fr_g_d=s_fr_eff, s_veg_g_d=s_veg_g_d)
+
+        base = super(ThorpFruitVegPolicy, self).compute(
+            env=env,
+            state=state,
+            sinks=sinks,
+            scheme=scheme,
+            params=params,
+        )
+        scheme_key = str(scheme).strip().lower()
+
+        if scheme_key == "4pool":
+            leaf = float(base.values[Organ.LEAF])
+            stem = float(base.values[Organ.STEM])
+            root = float(base.values[Organ.ROOT])
+            veg_sum = max(0.0, leaf + stem + root)
+            if veg_sum <= 0.0:
+                leaf, stem, root = 0.7, 0.3, 0.0
+                veg_sum = 1.0
+            leaf /= veg_sum
+            stem /= veg_sum
+            root /= veg_sum
+            f_veg = 1.0 - f_fr
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: f_fr,
+                    Organ.LEAF: f_veg * leaf,
+                    Organ.STEM: f_veg * stem,
+                    Organ.ROOT: f_veg * root,
+                }
+            )
+
+        if scheme_key == "3pool":
+            shoot = float(base.values[Organ.SHOOT])
+            root = float(base.values[Organ.ROOT])
+            veg_sum = max(0.0, shoot + root)
+            if veg_sum <= 0.0:
+                shoot, root = 1.0, 0.0
+                veg_sum = 1.0
+            shoot /= veg_sum
+            root /= veg_sum
+            f_veg = 1.0 - f_fr
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: f_fr,
+                    Organ.SHOOT: f_veg * shoot,
+                    Organ.ROOT: f_veg * root,
+                }
+            )
+
+        raise ValueError(f"Unsupported partition scheme {scheme!r}; expected '4pool' or '3pool'.")
+
+
+__all__ = ["ThorpFruitVegPolicy", "ThorpVegetativePolicy"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/tomato_model.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/tomato_legacy/tomato_model.py
@@ -52,9 +52,10 @@ class TomatoModel:
     """Bounded legacy-compatible tomato model surface for staged migration.
 
     This slice preserves the public state, CSV ingestion, output payload, and
-    default adapter construction surface from the legacy `tomato_model.py`.
-    The deeper age-structured growth, full energy-balance solver, and THORP-
-    derived partition-policy seams remain blocked for later slices.
+    default adapter construction surface from the legacy `tomato_model.py`,
+    including TOMATO-local partition-policy execution.
+    The deeper age-structured growth, full energy-balance solver, and wider
+    package-level pipeline seams remain blocked for later slices.
     """
 
     def __init__(

--- a/tests/test_tomato_tthorp_partitioning.py
+++ b/tests/test_tomato_tthorp_partitioning.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import dataclass
 from datetime import datetime
 
+import numpy as np
 import pytest
 
 from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning import (
@@ -11,8 +12,14 @@ from stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning import 
     Organ,
     PartitionPolicy,
     SinkBasedTomatoPolicy,
+    ThorpFruitVegPolicy,
+    ThorpObjectiveParams,
+    ThorpVegetativePolicy,
     build_partition_policy,
     coerce_partition_policy,
+    objective_params_from_thorp,
+    thorp_allocation_fractions,
+    tomato_partitioning,
 )
 from stomatal_optimiaztion.domains.tomato.tthorp.contracts import EnvStep
 from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import TomatoModel
@@ -21,6 +28,9 @@ from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import Tom
 @dataclass(frozen=True, slots=True)
 class _DummyState:
     root_frac_of_total_veg: float = 0.15 / 1.15
+    co2_flux_g_m2_s: float = 0.02
+    W_lv: float = 50.0
+    W_st: float = 20.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,6 +70,41 @@ def _env() -> EnvStep:
         CO2_ppm=420.0,
         RH_percent=60.0,
         wind_speed_ms=1.0,
+    )
+
+
+def _base_kwargs() -> dict[str, object]:
+    return {
+        "a_n": 6.0,
+        "lambda_wue": 1.2,
+        "d_a_n_d_r_abs": 0.03,
+        "d_e_d_la": 0.015,
+        "d_e_d_d": 0.004,
+        "d_e_d_c_r_h": np.array([0.006, 0.004], dtype=float),
+        "d_e_d_c_r_v": np.array([0.003, 0.002], dtype=float),
+        "d_r_abs_d_h": 20.0,
+        "d_r_abs_d_w": 8.0,
+        "d_r_abs_d_la": 0.2,
+        "h": 1.5,
+        "w": 0.08,
+        "d": 0.02,
+        "c_w": 4.0,
+        "c_l": 1.0,
+        "c0": 0.6411,
+        "c1": 0.625,
+        "t_a": 25.0,
+        "t_soil": 23.0,
+    }
+
+
+def _objective() -> ThorpObjectiveParams:
+    return ThorpObjectiveParams(
+        sla=0.08,
+        tau_l=200.0,
+        tau_r=365.0,
+        tau_sw=400.0,
+        r_m_sw_func=lambda _t: 0.01,
+        r_m_r_func=lambda _t: 0.008,
     )
 
 
@@ -112,9 +157,10 @@ def test_build_partition_policy_supports_sink_based_aliases_only() -> None:
     assert build_partition_policy("sink_based").name == "sink_based"
     assert build_partition_policy("sink-based").name == "sink_based"
     assert build_partition_policy("default").name == "sink_based"
-
-    with pytest.raises(NotImplementedError, match="not migrated yet"):
-        build_partition_policy("thorp_veg")
+    assert build_partition_policy("thorp_veg").name == "thorp_veg"
+    assert build_partition_policy("thorp_opt").name == "thorp_veg"
+    assert build_partition_policy("thorp_fruit_veg").name == "thorp_fruit_veg"
+    assert build_partition_policy("thorp_4pool").name == "thorp_fruit_veg"
 
 
 def test_coerce_partition_policy_accepts_protocol_instances() -> None:
@@ -133,3 +179,162 @@ def test_tomato_model_defaults_to_sink_based_policy() -> None:
 
     explicit = TomatoModel(partition_policy="sink-based")
     assert explicit.partition_policy.name == "sink_based"
+
+
+def test_ported_allocation_returns_unit_sum() -> None:
+    alloc = thorp_allocation_fractions(
+        **_base_kwargs(),
+        objective_params=_objective(),
+        prefer_thorp=False,
+    )
+    total = alloc.u_l + alloc.u_sw + float(np.sum(alloc.u_r_h + alloc.u_r_v))
+    assert alloc.backend == "ported"
+    assert np.isclose(total, 1.0, atol=1e-12)
+    assert alloc.u_l >= 0.0
+    assert alloc.u_sw >= 0.0
+    assert np.all(alloc.u_r_h >= 0.0)
+    assert np.all(alloc.u_r_v >= 0.0)
+
+
+def test_tomato_partitioning_collapses_root_components() -> None:
+    out = tomato_partitioning(
+        **_base_kwargs(),
+        objective_params=_objective(),
+        prefer_thorp=False,
+    )
+    assert np.isclose(out.u_leaf + out.u_stem + out.u_root, 1.0, atol=1e-12)
+    assert out.uL == out.u_leaf
+    assert out.uS == out.u_stem
+    assert out.uR == out.u_root
+
+
+def test_c_l_zero_forces_leaf_allocation() -> None:
+    kwargs = _base_kwargs()
+    kwargs["c_l"] = 0.0
+    alloc = thorp_allocation_fractions(
+        **kwargs,
+        objective_params=_objective(),
+        prefer_thorp=False,
+    )
+    assert alloc.u_l == 1.0
+    assert alloc.u_sw == 0.0
+    assert np.allclose(alloc.u_r_h, 0.0)
+    assert np.allclose(alloc.u_r_v, 0.0)
+
+
+@dataclass(frozen=True, slots=True)
+class _DummyThorpParams:
+    sla: float = 0.08
+    tau_l: float = 200.0
+    tau_r: float = 365.0
+    tau_sw: float = 400.0
+
+    @staticmethod
+    def r_m_sw_func(_t: float) -> float:
+        return 0.01
+
+    @staticmethod
+    def r_m_r_func(_t: float) -> float:
+        return 0.008
+
+
+def test_missing_thorp_import_falls_back_to_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    import stomatal_optimiaztion.domains.tomato.tthorp.components.partitioning.thorp_opt as thorp_opt
+
+    monkeypatch.setattr(thorp_opt, "_import_thorp_allocation", lambda: None)
+
+    alloc = thorp_allocation_fractions(
+        **_base_kwargs(),
+        thorp_params=_DummyThorpParams(),
+        prefer_thorp=True,
+        allow_port_fallback=True,
+    )
+    assert alloc.backend == "ported"
+
+
+def test_objective_params_from_thorp_extracts_required_fields() -> None:
+    params = objective_params_from_thorp(_DummyThorpParams())
+    assert params.sla == 0.08
+    assert params.tau_l == 200.0
+    assert params.tau_r == 365.0
+    assert params.tau_sw == 400.0
+
+
+@pytest.mark.parametrize("scheme", ["4pool", "3pool"])
+@pytest.mark.parametrize("policy", [SinkBasedTomatoPolicy(), ThorpVegetativePolicy()])
+def test_partition_policy_invariants(policy: PartitionPolicy, scheme: str) -> None:
+    fracs = policy.compute(
+        env=_env(),
+        state=_DummyState(co2_flux_g_m2_s=0.02),
+        sinks={"S_fr_g_d": 12.0, "S_veg_g_d": 4.0},
+        scheme=scheme,
+        params=None,
+    )
+
+    values = list(fracs.values.values())
+    assert values
+    assert all(math.isfinite(v) for v in values)
+    assert all(0.0 <= v <= 1.0 for v in values)
+    assert sum(values) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_fruit_fraction_is_zero_when_fruit_sink_is_zero() -> None:
+    env = _env()
+    state = _DummyState(co2_flux_g_m2_s=0.02)
+    sinks = {"S_fr_g_d": 0.0, "S_veg_g_d": 10.0}
+
+    out_sink = SinkBasedTomatoPolicy().compute(
+        env=env,
+        state=state,
+        sinks=sinks,
+        scheme="4pool",
+        params=None,
+    )
+    assert out_sink.values[Organ.FRUIT] == pytest.approx(0.0, abs=1e-15)
+
+    out_thorp = ThorpVegetativePolicy().compute(
+        env=env,
+        state=state,
+        sinks=sinks,
+        scheme="4pool",
+        params=None,
+    )
+    assert out_thorp.values[Organ.FRUIT] == pytest.approx(0.0, abs=1e-15)
+
+
+def test_thorp_fruit_veg_policy_preserves_fraction_sum() -> None:
+    fracs = ThorpFruitVegPolicy(w_fruit=0.4).compute(
+        env=_env(),
+        state=_DummyState(),
+        sinks={"S_fr_g_d": 6.0, "S_veg_g_d": 4.0},
+        scheme="4pool",
+        params=None,
+    )
+
+    assert sum(fracs.values.values()) == pytest.approx(1.0, abs=1e-9)
+    assert fracs.values[Organ.FRUIT] > 0.0
+
+
+def test_tomato_model_accepts_thorp_partition_policy() -> None:
+    model = TomatoModel(partition_policy="thorp_veg")
+    model.update_inputs_from_row(
+        {
+            "T_air_C": 25.0,
+            "PAR_umol": 500.0,
+            "CO2_ppm": 420.0,
+            "RH_percent": 60.0,
+            "wind_speed_ms": 1.0,
+            "n_fruits_per_truss": 4.0,
+        }
+    )
+
+    current_time = datetime(2026, 1, 1, 12, 0, 0)
+    model.run_timestep_calculations(3600.0, current_time)
+
+    assert model.partition_policy.name == "thorp_veg"
+    assert math.isfinite(model.part_leaf)
+    assert math.isfinite(model.part_stem)
+    assert math.isfinite(model.part_root)
+    assert model.part_leaf + model.part_stem + model.part_root + model.part_fruit == pytest.approx(
+        1.0, abs=1e-9
+    )


### PR DESCRIPTION
## Background
- `slice 031` landed the TOMATO partitioning core, but every THORP-derived tomato policy alias was still blocked behind `NotImplementedError`.
- This PR lands `slice 032` by migrating the THORP-backed tomato allocation adapter and policy layer, and moves the next TOMATO seam to the package-level legacy pipeline wrapper.

## Changes
- add TOMATO partitioning adapters for `ThorpObjectiveParams`, THORP allocation fractions, and collapsed tomato partition outputs
- add `ThorpVegetativePolicy` and `ThorpFruitVegPolicy`, then wire `build_partition_policy()` aliases to real policy instances
- expand partitioning tests to cover wrapper behavior, THORP-policy invariants, and `TomatoModel(partition_policy=\"thorp_veg\")`
- update architecture artifacts to record `slice 032`

## Validation
- `.venv\Scripts\python.exe -m pytest`
- `.venv\Scripts\ruff.exe check .`

## Impact
- TOMATO partition-policy aliases now resolve to concrete migrated policies instead of runtime blockers
- the next bounded TOMATO seam shifts from partitioning internals to `pipelines/tomato_legacy.py`

## Linked issue
Closes #57
