### PR TITLE
[Bug] Fix GitHub Project helper pagination for large boards

### DIFF
--- a/docs/architecture/executor/issue-059-bug-github-project-pagination.md
+++ b/docs/architecture/executor/issue-059-bug-github-project-pagination.md
@@ -1,0 +1,18 @@
+## repro
+- Run `scripts/New-GitHubIssueBranch.ps1` or `scripts/New-GitHubPullRequest.ps1` after the GitHub Project grows beyond 100 items.
+- The GitHub item is added successfully, but the helper prints `Failed to add project item: <url>`.
+
+## expected / actual
+- expected: project sync should detect the newly added item and continue to set `Status` / `Stage` fields without warning.
+- actual: `Ensure-ProjectItem()` only queries `items(first:100)`, misses items beyond the first page, and raises a false failure.
+
+## scope
+- repo-local helper scripts under `scripts/`
+- shared workspace helper source at `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\`
+
+## fix idea
+- add cursor-based GitHub Project item pagination and retry lookup after `gh project item-add`
+- keep the shared workspace script and repo-local copy aligned
+
+## test
+- run the updated helper against an existing `stomatal-optimiaztion` issue already on the Project board and confirm field sync works without the false warning

--- a/docs/architecture/executor/pr-059-fix-github-project-pagination.md
+++ b/docs/architecture/executor/pr-059-fix-github-project-pagination.md
@@ -1,0 +1,22 @@
+## Background
+- GitHub Project helper scripts started printing false `Failed to add project item` warnings once the shared Project board grew beyond 100 items.
+- The root cause was a first-page-only GraphQL lookup inside `Ensure-ProjectItem()`, so existing or newly added items beyond the first 100 could not be found even when `gh project item-add` succeeded.
+
+## Changes
+- add cursor-based Project item pagination helpers in `scripts/GitHubProject.Common.ps1`
+- make `Ensure-ProjectItem()` reuse paginated lookup both before and after `gh project item-add`
+- add a short retry window after `item-add` so field sync can absorb Project API propagation delay
+- mirror the same fix into the shared workspace helper at `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\GitHubProject.Common.ps1`
+
+## Validation
+- dot-source repo-local `scripts/GitHubProject.Common.ps1` and resolve the Project item id for `issue #57` with `AddIfMissing:$false`
+- dot-source shared `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\GitHubProject.Common.ps1` and resolve the same Project item id
+- run repo-local `scripts\Set-GitHubProjectStatus.ps1 -IssueNumber 57 -Status Done`
+- run shared `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\Set-GitHubProjectStatus.ps1 -IssueNumber 57 -Status Done`
+
+## Impact
+- Project status sync no longer depends on the target item appearing in the first 100 board entries
+- repo-local helpers and the shared workspace helper stay aligned for future repos
+
+## Linked issue
+Closes #59

--- a/scripts/GitHubProject.Common.ps1
+++ b/scripts/GitHubProject.Common.ps1
@@ -195,20 +195,17 @@ function Get-ProjectFieldInfo {
     return $field
 }
 
-function Ensure-ProjectItem {
+function Get-ProjectItemsConnection {
     param(
-        [Parameter(Mandatory = $true)][string]$Owner,
-        [Parameter(Mandatory = $true)][int]$ProjectNumber,
         [Parameter(Mandatory = $true)][string]$ProjectId,
-        [Parameter(Mandatory = $true)][string]$ItemUrl,
-        [switch]$AddIfMissing = $true
+        [string]$After
     )
 
     $query = (
-        'query($project:ID!) {' ,
+        'query($project:ID!, $after:String) {' ,
         '  node(id:$project) {' ,
         '    ... on ProjectV2 {' ,
-        '      items(first:100) {' ,
+        '      items(first:100, after:$after) {' ,
         '        nodes {' ,
         '          id' ,
         '          content {' ,
@@ -218,17 +215,89 @@ function Ensure-ProjectItem {
         '            ... on DraftIssue { id }' ,
         '          }' ,
         '        }' ,
+        '        pageInfo {' ,
+        '          hasNextPage' ,
+        '          endCursor' ,
+        '        }' ,
         '      }' ,
         '    }' ,
         '  }' ,
         '}'
     ) -join "`n"
 
-    $raw = & gh api graphql -f query=$query -F project=$ProjectId
+    $args = @("api", "graphql", "-f", "query=$query", "-F", "project=$ProjectId")
+    if ($After) {
+        $args += @("-f", "after=$After")
+    }
+
+    $raw = & gh @args
     if (-not $raw) { throw "Could not query project items." }
     $data = $raw | ConvertFrom-Json
-    $existing = $data.data.node.items.nodes | Where-Object { $_.content.url -eq $ItemUrl } | Select-Object -First 1
-    if ($existing) { return $existing.id }
+    $items = $data.data.node.items
+    if (-not $items) { throw "Could not query project items." }
+    return $items
+}
+
+function Find-ProjectItemId {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectId,
+        [Parameter(Mandatory = $true)][string]$ItemUrl
+    )
+
+    $after = $null
+    while ($true) {
+        $items = Get-ProjectItemsConnection -ProjectId $ProjectId -After $after
+        $match = $items.nodes | Where-Object { $_.content.url -eq $ItemUrl } | Select-Object -First 1
+        if ($match) {
+            return $match.id
+        }
+
+        $pageInfo = $items.pageInfo
+        $hasNextPage = $false
+        if ($pageInfo) {
+            $hasNextPage = [bool]$pageInfo.hasNextPage
+        }
+        $after = ConvertTo-TrimmedString -Value $pageInfo.endCursor
+        if (-not $hasNextPage -or -not $after) {
+            break
+        }
+    }
+
+    return $null
+}
+
+function Wait-ProjectItemId {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectId,
+        [Parameter(Mandatory = $true)][string]$ItemUrl,
+        [int]$Attempts = 5,
+        [int]$DelaySeconds = 1
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        $itemId = Find-ProjectItemId -ProjectId $ProjectId -ItemUrl $ItemUrl
+        if ($itemId) {
+            return $itemId
+        }
+        if ($attempt -lt $Attempts) {
+            Start-Sleep -Seconds $DelaySeconds
+        }
+    }
+
+    return $null
+}
+
+function Ensure-ProjectItem {
+    param(
+        [Parameter(Mandatory = $true)][string]$Owner,
+        [Parameter(Mandatory = $true)][int]$ProjectNumber,
+        [Parameter(Mandatory = $true)][string]$ProjectId,
+        [Parameter(Mandatory = $true)][string]$ItemUrl,
+        [switch]$AddIfMissing = $true
+    )
+
+    $existingId = Find-ProjectItemId -ProjectId $ProjectId -ItemUrl $ItemUrl
+    if ($existingId) { return $existingId }
 
     if (-not $AddIfMissing) {
         throw "Item not found in project and -AddIfMissing was not specified: $ItemUrl"
@@ -236,13 +305,11 @@ function Ensure-ProjectItem {
 
     & gh project item-add $ProjectNumber --owner $Owner --url $ItemUrl | Out-Null
 
-    $raw2 = & gh api graphql -f query=$query -F project=$ProjectId
-    $data2 = $raw2 | ConvertFrom-Json
-    $added = $data2.data.node.items.nodes | Where-Object { $_.content.url -eq $ItemUrl } | Select-Object -First 1
-    if (-not $added) {
+    $addedId = Wait-ProjectItemId -ProjectId $ProjectId -ItemUrl $ItemUrl
+    if (-not $addedId) {
         throw "Failed to add project item: $ItemUrl"
     }
-    return $added.id
+    return $addedId
 }
 
 function Set-ProjectFieldValue {


### PR DESCRIPTION
## Background
- GitHub Project helper scripts started printing false `Failed to add project item` warnings once the shared Project board grew beyond 100 items.
- The root cause was a first-page-only GraphQL lookup inside `Ensure-ProjectItem()`, so existing or newly added items beyond the first 100 could not be found even when `gh project item-add` succeeded.

## Changes
- add cursor-based Project item pagination helpers in `scripts/GitHubProject.Common.ps1`
- make `Ensure-ProjectItem()` reuse paginated lookup both before and after `gh project item-add`
- add a short retry window after `item-add` so field sync can absorb Project API propagation delay
- mirror the same fix into the shared workspace helper at `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\GitHubProject.Common.ps1`

## Validation
- dot-source repo-local `scripts/GitHubProject.Common.ps1` and resolve the Project item id for `issue #57` with `AddIfMissing:$false`
- dot-source shared `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\GitHubProject.Common.ps1` and resolve the same Project item id
- run repo-local `scripts\Set-GitHubProjectStatus.ps1 -IssueNumber 57 -Status Done`
- run shared `C:\Users\yhmoo\OneDrive\Phytoritas\scripts\Set-GitHubProjectStatus.ps1 -IssueNumber 57 -Status Done`

## Impact
- Project status sync no longer depends on the target item appearing in the first 100 board entries
- repo-local helpers and the shared workspace helper stay aligned for future repos

## Linked issue
Closes #59
