### PR TITLE
[Model Change] Migrate TOMATO tTHORP package-level legacy pipeline seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,4 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-032 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, and partitioning-package seams
+- Slices 025-033 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, and package-level legacy pipeline seams
+- Next blocked seam: TOMATO `tTHORP` shared IO helpers at `core/io.py`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` runner seam is migrated as slice 030.
 - TOMATO `tTHORP` partitioning core seam is migrated as slice 031.
 - TOMATO `tTHORP` THORP-derived partition-policy seam is migrated as slice 032.
+- TOMATO `tTHORP` package-level legacy pipeline seam is migrated as slice 033.
 
 ## Next validation
-- Audit the TOMATO package-level legacy pipeline seam at `pipelines/tomato_legacy.py`.
+- Audit the TOMATO shared IO seam at `core/io.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 032
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 032 approved for TOMATO
+- Gate C. Validation plan ready through slice 033
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 033 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -239,3 +239,9 @@ Slice 032:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/components/partitioning/`
 - scope: bounded TOMATO THORP-derived partitioning surface covering allocation wrappers, policy aliases, and `TomatoModel` THORP-policy execution
 - excluded: `pipelines/tomato_legacy.py`, `core/`, and `models/thorp_ref/`
+
+Slice 033:
+- source: `TOMATO/tTHORP/src/tthorp/pipelines/tomato_legacy.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/` and `tests/test_tomato_tthorp_pipeline.py`
+- scope: bounded TOMATO package-level legacy pipeline surface covering repo-root resolution, forcing-path resolution, filtered config payloads, default model construction, pipeline execution, and metrics summaries
+- excluded: `core/io.py`, `core/scheduler.py`, `pipelines/tomato_dayrun.py`, and broader repo-level CLI entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -282,7 +282,15 @@ The thirtieth slice opens the next bounded TOMATO seam:
 - move `TOMATO/tTHORP/src/tthorp/models/tomato_legacy/run.py` into the staged `domains/tomato/tthorp` package
 - preserve bounded argument parsing, forcing iteration, default adapter construction, and CSV result writing
 - keep the runner package-local instead of opening a repo-wide TOMATO CLI entrypoint yet
-- leave `pipelines/tomato_legacy.py` blocked as the next seam
+- leave `components/partitioning/policy.py` blocked as the next seam
+
+## Slice 031: TOMATO tTHORP Partitioning Core
+
+The thirty-first slice opens the next bounded TOMATO seam:
+- move `organ.py`, `fractions.py`, `policy.py`, and `sink_based.py` into the package-local TOMATO partitioning package
+- preserve organ enums, allocation-fraction validation, policy coercion, and the default sink-based tomato partition rule
+- replace inline default tomato allocation fallback inside `TomatoModel` with the migrated partitioning core
+- leave `thorp_opt.py` and `thorp_policies.py` blocked as the next seam
 
 ## Slice 032: TOMATO tTHORP THORP-Derived Partition Policies
 
@@ -292,8 +300,16 @@ The thirty-second slice closes the remaining TOMATO partitioning seam:
 - keep `TomatoModel` able to execute THORP-derived policies without breaking the bounded legacy surface
 - leave `pipelines/tomato_legacy.py` blocked as the next seam
 
+## Slice 033: TOMATO tTHORP Package-Level Legacy Pipeline
+
+The thirty-third slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/pipelines/tomato_legacy.py` into the staged `domains/tomato/tthorp` package
+- preserve repo-root and forcing-path resolution, filtered config payloads, default model construction, pipeline execution, and metrics summary behavior
+- keep the seam package-local instead of opening `core/io.py`, `core/scheduler.py`, or `pipelines/tomato_dayrun.py`
+- leave `core/io.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first eight TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first nine TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `pipelines/tomato_legacy.py`
+3. prepare the next TOMATO source audit for `core/io.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 032 completed and slice 033 planning
+- Current phase: slice 033 completed and slice 034 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO package-level legacy pipeline seam at `pipelines/tomato_legacy.py`
-2. decide how much of `pipelines/tomato_legacy.py` can land without pulling in `core/` helpers prematurely
+1. audit the TOMATO shared IO seam at `core/io.py`
+2. decide how much of `core/io.py` can land without pulling in `core/scheduler.py` or `pipelines/tomato_dayrun.py` prematurely
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-033-tomato-tthorp-legacy-pipeline.md
+++ b/docs/architecture/architecture/module_specs/module-033-tomato-tthorp-legacy-pipeline.md
@@ -1,0 +1,35 @@
+# Module Spec 033: TOMATO tTHORP Package-Level Legacy Pipeline
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the package-level legacy pipeline wrapper that resolves repo-relative paths, builds the default migrated tomato model, runs the tabular simulation, and summarizes output metrics.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/pipelines/tomato_legacy.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/`
+- `tests/test_tomato_tthorp_pipeline.py`
+
+## Responsibilities
+
+1. preserve repo-root and forcing-path resolution behavior for config-driven pipeline runs
+2. preserve the bounded execution order across `iter_forcing_csv()`, `make_tomato_legacy_model()`, and `simulate()`
+3. preserve package-local config payload filtering and summary-metric helpers without reopening the legacy `core/` layer
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/src/tthorp/core/io.py`
+- migrate `TOMATO/tTHORP/src/tthorp/core/scheduler.py`
+- migrate `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py`
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/core/io.py`

--- a/docs/architecture/executor/issue-033-model-change.md
+++ b/docs/architecture/executor/issue-033-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 032` closed the TOMATO partitioning package, so the next bounded seam is the package-level legacy pipeline wrapper at `pipelines/tomato_legacy.py`.
+- The migrated repo still lacks a config-driven surface that resolves repo-relative forcing paths, constructs the default tomato pipeline model, and summarizes output metrics without reopening `core/` helpers.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/`
+- related TOMATO pipeline integration tests and architecture slice records
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add path-resolution, pipeline-run, and metrics-summary coverage over the migrated `simulate`, `iter_forcing_csv`, and `make_tomato_legacy_model` seams
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/pipelines/tomato_legacy.py`
+- current migrated TOMATO `interface`, `forcing_csv`, adapter, runner, and partition-policy seams

--- a/docs/architecture/executor/pr-061-tomato-legacy-pipeline.md
+++ b/docs/architecture/executor/pr-061-tomato-legacy-pipeline.md
@@ -1,0 +1,20 @@
+## Background
+- `slice 032` closed the TOMATO partitioning package, but the migrated repo still lacked the package-level legacy pipeline wrapper that turns config payloads and forcing CSV paths into a default tomato simulation run.
+- This PR lands `slice 033` by migrating `pipelines/tomato_legacy.py`, and moves the next TOMATO architectural uncertainty to the shared `core/io.py` seam.
+
+## Changes
+- add the migrated TOMATO pipeline package with repo-root resolution, forcing-path resolution, filtered config payload helpers, pipeline execution, and metrics summaries
+- export the new pipeline helpers through the package-local `tthorp` surface
+- add path-resolution, pipeline-run, and summary-metric tests for the migrated package-level legacy pipeline seam
+- update architecture artifacts and README so `slice 033` is recorded and `core/io.py` becomes the next blocked seam
+
+## Validation
+- `.venv\Scripts\python.exe -m pytest`
+- `.venv\Scripts\ruff.exe check .`
+
+## Impact
+- the migrated TOMATO `tTHORP` package now has a config-driven package-level legacy pipeline surface
+- deeper shared IO and dayrun orchestration remain explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #61

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the partitioning package, package-local runner, and bounded `TomatoModel` surface | package-level pipeline coupling and shared core helpers can still hide legacy assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the package-level legacy pipeline seam | shared `core/io.py`, `core/scheduler.py`, and `tomato_dayrun` helpers can still hide legacy assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
@@ -15,6 +15,13 @@ from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import (
     iter_forcing_csv,
     make_tomato_legacy_model,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (
+    config_payload_for_exp_key,
+    resolve_forcing_path,
+    resolve_repo_root,
+    run_tomato_legacy_pipeline,
+    summarize_tomato_legacy_metrics,
+)
 
 MODEL_NAME = "tTHORP"
 
@@ -33,4 +40,9 @@ __all__ = [
     "make_tomato_legacy_model",
     "TomatoModel",
     "create_sample_input_csv",
+    "resolve_repo_root",
+    "resolve_forcing_path",
+    "config_payload_for_exp_key",
+    "run_tomato_legacy_pipeline",
+    "summarize_tomato_legacy_metrics",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/__init__.py
@@ -1,0 +1,15 @@
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines.tomato_legacy import (
+    config_payload_for_exp_key,
+    resolve_forcing_path,
+    resolve_repo_root,
+    run_tomato_legacy_pipeline,
+    summarize_tomato_legacy_metrics,
+)
+
+__all__ = [
+    "config_payload_for_exp_key",
+    "resolve_forcing_path",
+    "resolve_repo_root",
+    "run_tomato_legacy_pipeline",
+    "summarize_tomato_legacy_metrics",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/tomato_legacy.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/tomato_legacy.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tthorp.interface import simulate
+from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import (
+    iter_forcing_csv,
+    make_tomato_legacy_model,
+)
+
+
+def _as_dict(raw: object) -> dict[str, Any]:
+    if isinstance(raw, Mapping):
+        return {str(key): value for key, value in raw.items()}
+    return {}
+
+
+def _resolve_existing_path(
+    path: str | Path,
+    *,
+    config_path: Path | None = None,
+    repo_root: Path | None = None,
+) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+
+    probes: list[Path] = []
+    if config_path is not None:
+        probes.append((config_path.parent / candidate).resolve())
+    if repo_root is not None:
+        probes.append((repo_root / candidate).resolve())
+    probes.append((Path.cwd() / candidate).resolve())
+
+    for probe in probes:
+        if probe.exists():
+            return probe
+    return probes[0]
+
+
+def _looks_like_repo_root(path: Path) -> bool:
+    staged_root = (path / "src" / "stomatal_optimiaztion").exists() and (
+        (path / "pyproject.toml").exists() or (path / ".git").exists()
+    )
+    legacy_root = (path / "THORP").exists() and (path / "TOMATO").exists()
+    return staged_root or legacy_root
+
+
+def _default_repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if _looks_like_repo_root(parent):
+            return parent
+    parents = Path(__file__).resolve().parents
+    return parents[min(6, len(parents) - 1)]
+
+
+def _infer_repo_root(config_path: Path | None) -> Path | None:
+    if config_path is None:
+        return None
+    for parent in config_path.resolve().parents:
+        if _looks_like_repo_root(parent):
+            return parent
+    return None
+
+
+def resolve_repo_root(config: Mapping[str, object], *, config_path: Path | None = None) -> Path:
+    paths_cfg = _as_dict(config.get("paths"))
+    repo_root_raw = paths_cfg.get("repo_root")
+    if repo_root_raw is not None:
+        configured = _resolve_existing_path(str(repo_root_raw), config_path=config_path)
+        if configured.exists():
+            return configured
+        raise FileNotFoundError(f"Configured repo_root does not exist: {configured}")
+
+    inferred = _infer_repo_root(config_path)
+    if inferred is not None:
+        return inferred
+    return _default_repo_root()
+
+
+def resolve_forcing_path(
+    config: Mapping[str, object],
+    *,
+    repo_root: Path,
+    config_path: Path | None = None,
+) -> Path:
+    forcing_cfg = _as_dict(config.get("forcing"))
+    forcing_raw = forcing_cfg.get("csv_path")
+    if forcing_raw is None:
+        raise KeyError("forcing.csv_path is required for tomato_legacy pipeline.")
+    return _resolve_existing_path(str(forcing_raw), config_path=config_path, repo_root=repo_root)
+
+
+def config_payload_for_exp_key(config: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "exp": _as_dict(config.get("exp")),
+        "pipeline": _as_dict(config.get("pipeline")),
+        "forcing": _as_dict(config.get("forcing")),
+    }
+
+
+def run_tomato_legacy_pipeline(
+    config: Mapping[str, object],
+    *,
+    repo_root: Path | None = None,
+    config_path: Path | None = None,
+) -> pd.DataFrame:
+    pipeline_cfg = _as_dict(config.get("pipeline"))
+    forcing_cfg = _as_dict(config.get("forcing"))
+
+    model_name = str(pipeline_cfg.get("model", "tomato_legacy"))
+    if model_name != "tomato_legacy":
+        raise ValueError(
+            f"Unsupported pipeline.model {model_name!r}; only 'tomato_legacy' is supported."
+        )
+
+    root = repo_root or resolve_repo_root(config, config_path=config_path)
+    forcing_path = resolve_forcing_path(config, repo_root=root, config_path=config_path)
+
+    max_steps_raw = forcing_cfg.get("max_steps")
+    max_steps = None if max_steps_raw is None else max(0, int(max_steps_raw))
+
+    fixed_lai_raw = pipeline_cfg.get("fixed_lai")
+    fixed_lai = None if fixed_lai_raw is None else float(fixed_lai_raw)
+    partition_policy_raw = pipeline_cfg.get("partition_policy")
+    partition_policy = None if partition_policy_raw is None else str(partition_policy_raw)
+    allocation_scheme = str(pipeline_cfg.get("allocation_scheme", "4pool"))
+
+    forcing = iter_forcing_csv(
+        forcing_path,
+        max_steps=max_steps,
+        default_dt_s=float(forcing_cfg.get("default_dt_s", 6.0 * 3600.0)),
+        default_co2_ppm=float(forcing_cfg.get("default_co2_ppm", 420.0)),
+        default_n_fruits_per_truss=int(forcing_cfg.get("default_n_fruits_per_truss", 4)),
+    )
+    model = make_tomato_legacy_model(
+        theta_substrate=float(pipeline_cfg.get("theta_substrate", 0.33)),
+        fixed_lai=fixed_lai,
+        partition_policy=partition_policy,
+        allocation_scheme=allocation_scheme,
+    )
+    return simulate(model=model, forcing=forcing, max_steps=max_steps)
+
+
+def summarize_tomato_legacy_metrics(df: pd.DataFrame) -> dict[str, float | int]:
+    metrics: dict[str, float | int] = {"rows": int(df.shape[0])}
+    if df.empty:
+        return metrics
+
+    for column in (
+        "theta_substrate",
+        "water_supply_stress",
+        "e",
+        "g_w",
+        "a_n",
+        "r_d",
+    ):
+        if column in df.columns:
+            metrics[f"mean_{column}"] = float(df[column].astype(float).mean())
+
+    if "a_n" in df.columns:
+        metrics["sum_a_n"] = float(df["a_n"].astype(float).sum())
+    if "LAI" in df.columns:
+        metrics["final_lai"] = float(df["LAI"].astype(float).iloc[-1])
+    if "total_dry_weight_g_m2" in df.columns:
+        metrics["final_total_dry_weight_g_m2"] = float(
+            df["total_dry_weight_g_m2"].astype(float).iloc[-1]
+        )
+    return metrics
+
+
+__all__ = [
+    "config_payload_for_exp_key",
+    "resolve_forcing_path",
+    "resolve_repo_root",
+    "run_tomato_legacy_pipeline",
+    "summarize_tomato_legacy_metrics",
+]

--- a/tests/test_tomato_tthorp_pipeline.py
+++ b/tests/test_tomato_tthorp_pipeline.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (
+    config_payload_for_exp_key,
+    resolve_forcing_path,
+    resolve_repo_root,
+    run_tomato_legacy_pipeline,
+    summarize_tomato_legacy_metrics,
+)
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src" / "stomatal_optimiaztion").mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text("[tool.poetry]\nname = 'demo'\n", encoding="utf-8")
+    return repo_root
+
+
+def _write_forcing_csv(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2026-01-01T00:00:00",
+                "2026-01-01T01:00:00",
+                "2026-01-01T02:00:00",
+            ],
+            "T_air_C": [21.0, 22.0, 23.0],
+            "PAR_umol": [150.0, 250.0, 350.0],
+            "CO2_ppm": [410.0, 420.0, 430.0],
+            "RH_percent": [70.0, 65.0, 60.0],
+            "wind_speed_ms": [0.8, 1.0, 1.2],
+        }
+    ).to_csv(path, index=False)
+
+
+def test_resolve_repo_root_prefers_configured_path_relative_to_config_path(
+    tmp_path: Path,
+) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    config_path = repo_root / "configs" / "exp" / "tomato_legacy.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("pipeline: {}\n", encoding="utf-8")
+
+    resolved = resolve_repo_root(
+        {"paths": {"repo_root": "../.."}},
+        config_path=config_path,
+    )
+
+    assert resolved == repo_root.resolve()
+
+
+def test_resolve_repo_root_infers_from_config_path_markers(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    config_path = repo_root / "configs" / "exp" / "tomato_legacy.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("pipeline: {}\n", encoding="utf-8")
+
+    resolved = resolve_repo_root({}, config_path=config_path)
+
+    assert resolved == repo_root.resolve()
+
+
+def test_resolve_forcing_path_uses_repo_root_and_config_path(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+    config_path = repo_root / "configs" / "exp" / "tomato_legacy.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("forcing: {}\n", encoding="utf-8")
+
+    resolved = resolve_forcing_path(
+        {"forcing": {"csv_path": "../../data/forcing.csv"}},
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+
+    assert resolved == forcing_path.resolve()
+
+
+def test_config_payload_for_exp_key_keeps_only_expected_sections() -> None:
+    payload = config_payload_for_exp_key(
+        {
+            "exp": {"name": "demo"},
+            "pipeline": {"model": "tomato_legacy"},
+            "forcing": {"max_steps": 2},
+            "paths": {"repo_root": "ignored"},
+        }
+    )
+
+    assert payload == {
+        "exp": {"name": "demo"},
+        "pipeline": {"model": "tomato_legacy"},
+        "forcing": {"max_steps": 2},
+    }
+
+
+def test_run_tomato_legacy_pipeline_runs_with_relative_paths(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+    config_path = repo_root / "configs" / "exp" / "tomato_legacy.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("exp: {}\n", encoding="utf-8")
+
+    config = {
+        "exp": {"name": "tomato_legacy"},
+        "pipeline": {
+            "model": "tomato_legacy",
+            "fixed_lai": 2.1,
+            "theta_substrate": 0.33,
+            "partition_policy": "thorp_veg",
+            "allocation_scheme": "4pool",
+        },
+        "forcing": {
+            "csv_path": "../../data/forcing.csv",
+            "max_steps": 2,
+            "default_dt_s": 3600.0,
+        },
+    }
+
+    out = run_tomato_legacy_pipeline(config, config_path=config_path)
+
+    expected_columns = {
+        "datetime",
+        "theta_substrate",
+        "water_supply_stress",
+        "e",
+        "g_w",
+        "a_n",
+        "r_d",
+        "LAI",
+        "total_dry_weight_g_m2",
+        "transpiration_rate_g_s_m2",
+    }
+    assert expected_columns.issubset(out.columns)
+    assert len(out) == 2
+    assert out["LAI"].tolist() == pytest.approx([2.1, 2.1])
+
+    numeric = out[list(expected_columns - {"datetime"})].to_numpy(dtype=float)
+    assert np.isfinite(numeric).all()
+
+
+def test_run_tomato_legacy_pipeline_rejects_unsupported_model(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+
+    with pytest.raises(ValueError, match="Unsupported pipeline.model"):
+        run_tomato_legacy_pipeline(
+            {
+                "pipeline": {"model": "other"},
+                "forcing": {"csv_path": str(forcing_path)},
+            },
+            repo_root=repo_root,
+        )
+
+
+def test_summarize_tomato_legacy_metrics_reports_rows_and_final_fields(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+
+    out = run_tomato_legacy_pipeline(
+        {
+            "pipeline": {
+                "model": "tomato_legacy",
+                "fixed_lai": 2.0,
+                "theta_substrate": 0.33,
+            },
+            "forcing": {
+                "csv_path": str(forcing_path),
+                "max_steps": 3,
+                "default_dt_s": 3600.0,
+            },
+        },
+        repo_root=repo_root,
+    )
+
+    metrics = summarize_tomato_legacy_metrics(out)
+
+    assert metrics["rows"] == 3
+    assert metrics["mean_theta_substrate"] == pytest.approx(0.33)
+    assert float(metrics["final_lai"]) == pytest.approx(2.0)
+    assert float(metrics["final_total_dry_weight_g_m2"]) >= 0.0
+
+
+def test_summarize_tomato_legacy_metrics_handles_empty_dataframe() -> None:
+    metrics = summarize_tomato_legacy_metrics(pd.DataFrame())
+
+    assert metrics == {"rows": 0}


### PR DESCRIPTION
## Background
- `slice 032` closed the TOMATO partitioning package, but the migrated repo still lacked the package-level legacy pipeline wrapper that turns config payloads and forcing CSV paths into a default tomato simulation run.
- This PR lands `slice 033` by migrating `pipelines/tomato_legacy.py`, and moves the next TOMATO architectural uncertainty to the shared `core/io.py` seam.

## Changes
- add the migrated TOMATO pipeline package with repo-root resolution, forcing-path resolution, filtered config payload helpers, pipeline execution, and metrics summaries
- export the new pipeline helpers through the package-local `tthorp` surface
- add path-resolution, pipeline-run, and summary-metric tests for the migrated package-level legacy pipeline seam
- update architecture artifacts and README so `slice 033` is recorded and `core/io.py` becomes the next blocked seam

## Validation
- `.venv\Scripts\python.exe -m pytest`
- `.venv\Scripts\ruff.exe check .`

## Impact
- the migrated TOMATO `tTHORP` package now has a config-driven package-level legacy pipeline surface
- deeper shared IO and dayrun orchestration remain explicitly blocked and documented for the next slice

## Linked issue
Closes #61
