### PR TITLE
[Model Change] Migrate TOMATO tTHORP shared scheduler seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-034 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, and shared IO seams
-- Next blocked seam: TOMATO `tTHORP` shared scheduler helpers at `core/scheduler.py`
+- Slices 025-035 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, and shared scheduler seams
+- Next blocked seam: TOMATO `tTHORP` dayrun pipeline at `pipelines/tomato_dayrun.py`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` THORP-derived partition-policy seam is migrated as slice 032.
 - TOMATO `tTHORP` package-level legacy pipeline seam is migrated as slice 033.
 - TOMATO `tTHORP` shared IO seam is migrated as slice 034.
+- TOMATO `tTHORP` shared scheduler seam is migrated as slice 035.
 
 ## Next validation
-- Audit the TOMATO shared scheduler seam at `core/scheduler.py`.
+- Audit the TOMATO dayrun pipeline seam at `pipelines/tomato_dayrun.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 034
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 034 approved for TOMATO
+- Gate C. Validation plan ready through slice 035
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 035 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -251,3 +251,9 @@ Slice 034:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/core/`, `tests/test_tomato_tthorp_core_io.py`, `pyproject.toml`, and `poetry.lock`
 - scope: bounded TOMATO shared IO surface covering directory creation, JSON metadata writing, YAML config parsing, recursive config merge, and `extends`-chain loading
 - excluded: `core/scheduler.py`, `pipelines/tomato_dayrun.py`, and repo-level script entrypoints
+
+Slice 035:
+- source: `TOMATO/tTHORP/src/tthorp/core/scheduler.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/core/` and `tests/test_tomato_tthorp_core_scheduler.py`
+- scope: bounded TOMATO shared scheduler surface covering deterministic experiment-key hashing, schedule dataclass construction, and forcing-derived run normalization
+- excluded: `pipelines/tomato_dayrun.py` and repo-level script entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -316,8 +316,16 @@ The thirty-fourth slice opens the next bounded TOMATO seam:
 - declare `PyYAML` explicitly as a runtime dependency instead of relying on an undeclared local package
 - leave `core/scheduler.py` blocked as the next seam
 
+## Slice 035: TOMATO tTHORP Shared Scheduler
+
+The thirty-fifth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/core/scheduler.py` into the staged `domains/tomato/tthorp` package
+- preserve deterministic experiment-key hashing, `RunSchedule`, and forcing-derived schedule normalization
+- keep the seam package-local instead of opening `pipelines/tomato_dayrun.py` or repo-level script entrypoints
+- leave `pipelines/tomato_dayrun.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first ten TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first eleven TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `core/scheduler.py`
+3. prepare the next TOMATO source audit for `pipelines/tomato_dayrun.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 034 completed and slice 035 planning
+- Current phase: slice 035 completed and slice 036 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO shared scheduler seam at `core/scheduler.py`
-2. decide how much of `core/scheduler.py` can land without pulling in `pipelines/tomato_dayrun.py` or script entrypoints prematurely
+1. audit the TOMATO dayrun pipeline seam at `pipelines/tomato_dayrun.py`
+2. decide how much of `pipelines/tomato_dayrun.py` can land without pulling in repo-level script entrypoints prematurely
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-035-tomato-tthorp-shared-scheduler.md
+++ b/docs/architecture/architecture/module_specs/module-035-tomato-tthorp-shared-scheduler.md
@@ -1,0 +1,35 @@
+# Module Spec 035: TOMATO tTHORP Shared Scheduler
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the shared scheduler helper layer that derives deterministic experiment keys and normalized run schedules from config payloads.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/core/scheduler.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/core/`
+- `tests/test_tomato_tthorp_core_scheduler.py`
+
+## Responsibilities
+
+1. preserve deterministic canonical hashing for experiment-key generation
+2. preserve `RunSchedule` and config-derived `max_steps` / `default_dt_s` normalization
+3. keep the shared scheduler surface package-local so downstream dayrun and script entrypoints can consume one migrated contract
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py`
+- migrate repo-level `scripts/run_pipeline.py`
+- migrate repo-level `scripts/make_features.py`
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py`

--- a/docs/architecture/executor/issue-035-model-change.md
+++ b/docs/architecture/executor/issue-035-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 034` landed the TOMATO shared IO seam, so the next smallest unresolved dependency is the shared scheduling helper at `core/scheduler.py`.
+- The migrated repo still lacks a canonical way to derive deterministic experiment keys and normalized run schedules from config payloads before opening `pipelines/tomato_dayrun.py` or repo-level script entrypoints.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/core/`
+- related TOMATO scheduling and config-derived run-shape tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for experiment-key determinism, payload hashing options, default schedule behavior, and invalid `default_dt_s` rejection
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/core/scheduler.py`
+- current migrated TOMATO `core/io.py` and package-level legacy pipeline seams

--- a/docs/architecture/executor/pr-065-tomato-shared-scheduler.md
+++ b/docs/architecture/executor/pr-065-tomato-shared-scheduler.md
@@ -1,0 +1,20 @@
+## Background
+- `slice 034` landed the TOMATO shared IO seam, but the migrated repo still lacked the shared scheduler helpers that derive experiment keys and normalized run schedules.
+- This PR lands `slice 035` by migrating `core/scheduler.py`, and moves the next TOMATO architectural uncertainty to the dayrun pipeline seam at `pipelines/tomato_dayrun.py`.
+
+## Changes
+- add the migrated TOMATO shared scheduler surface with `build_exp_key()`, `RunSchedule`, and `schedule_from_config()`
+- expose the scheduler helpers through the package-local `core` surface
+- add seam-level tests for canonical hashing, prefix and digest options, schedule defaults, normalization, and invalid timestep rejection
+- update architecture artifacts and README so `slice 035` is recorded and `pipelines/tomato_dayrun.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- the migrated TOMATO `tTHORP` package now has a deterministic shared scheduler surface for downstream orchestration seams
+- `tomato_dayrun` and script entrypoints remain explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #65

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the shared IO seam | shared `core/scheduler.py`, `tomato_dayrun`, and script entrypoints can still hide legacy assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the shared scheduler seam | `tomato_dayrun` and repo-level script entrypoints can still hide legacy orchestration assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/core/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/core/__init__.py
@@ -5,11 +5,19 @@ from stomatal_optimiaztion.domains.tomato.tthorp.core.io import (
     read_yaml,
     write_json,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.core.scheduler import (
+    RunSchedule,
+    build_exp_key,
+    schedule_from_config,
+)
 
 __all__ = [
+    "RunSchedule",
+    "build_exp_key",
     "deep_merge",
     "ensure_dir",
     "load_config",
     "read_yaml",
+    "schedule_from_config",
     "write_json",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/core/scheduler.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/core/scheduler.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any
+
+
+def build_exp_key(
+    payload: Mapping[str, Any],
+    *,
+    prefix: str = "exp",
+    digest_size: int = 10,
+) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:digest_size]
+    return f"{prefix}_{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class RunSchedule:
+    max_steps: int | None
+    default_dt_s: float
+
+
+def schedule_from_config(config: Mapping[str, Any]) -> RunSchedule:
+    forcing_raw = config.get("forcing", {})
+    forcing = forcing_raw if isinstance(forcing_raw, Mapping) else {}
+
+    max_steps_raw = forcing.get("max_steps")
+    if max_steps_raw is None:
+        max_steps: int | None = None
+    else:
+        max_steps = max(0, int(max_steps_raw))
+
+    default_dt_s = float(forcing.get("default_dt_s", 6.0 * 3600.0))
+    if default_dt_s <= 0:
+        raise ValueError(f"default_dt_s must be > 0, got {default_dt_s!r}.")
+    return RunSchedule(max_steps=max_steps, default_dt_s=default_dt_s)
+
+
+__all__ = [
+    "RunSchedule",
+    "build_exp_key",
+    "schedule_from_config",
+]

--- a/tests/test_tomato_tthorp_core_scheduler.py
+++ b/tests/test_tomato_tthorp_core_scheduler.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import (
+    RunSchedule,
+    build_exp_key,
+    schedule_from_config,
+)
+
+
+def test_build_exp_key_is_order_insensitive_and_deterministic() -> None:
+    payload_a = {
+        "pipeline": {"model": "tomato_legacy"},
+        "forcing": {"max_steps": 20},
+        "exp": {"name": "tomato_dayrun"},
+    }
+    payload_b = {
+        "exp": {"name": "tomato_dayrun"},
+        "forcing": {"max_steps": 20},
+        "pipeline": {"model": "tomato_legacy"},
+    }
+
+    assert build_exp_key(payload_a) == "exp_be493124a1"
+    assert build_exp_key(payload_a) == build_exp_key(payload_b)
+
+
+def test_build_exp_key_respects_prefix_and_digest_size() -> None:
+    payload = {"exp": {"name": "demo"}, "forcing": {"max_steps": 3}}
+
+    assert build_exp_key(payload, prefix="run", digest_size=6) == "run_5f28c9"
+
+
+def test_build_exp_key_supports_non_json_scalars_via_default_str() -> None:
+    payload = {"exp": {"name": "demo"}, "path": pytest}
+
+    exp_key = build_exp_key(payload)
+
+    assert exp_key.startswith("exp_")
+    assert len(exp_key) == 14
+
+
+def test_schedule_from_config_returns_defaults_when_forcing_missing() -> None:
+    schedule = schedule_from_config({"exp": {"name": "demo"}})
+
+    assert schedule == RunSchedule(max_steps=None, default_dt_s=21600.0)
+
+
+def test_schedule_from_config_normalizes_mapping_values() -> None:
+    schedule = schedule_from_config({"forcing": {"max_steps": "-4", "default_dt_s": "3600"}})
+
+    assert schedule == RunSchedule(max_steps=0, default_dt_s=3600.0)
+
+
+def test_schedule_from_config_ignores_non_mapping_forcing() -> None:
+    schedule = schedule_from_config({"forcing": ["unexpected"]})
+
+    assert schedule == RunSchedule(max_steps=None, default_dt_s=21600.0)
+
+
+def test_schedule_from_config_rejects_non_positive_default_dt_s() -> None:
+    with pytest.raises(ValueError, match="default_dt_s must be > 0"):
+        schedule_from_config({"forcing": {"default_dt_s": 0}})


### PR DESCRIPTION
## Background
- `slice 034` landed the TOMATO shared IO seam, but the migrated repo still lacked the shared scheduler helpers that derive experiment keys and normalized run schedules.
- This PR lands `slice 035` by migrating `core/scheduler.py`, and moves the next TOMATO architectural uncertainty to the dayrun pipeline seam at `pipelines/tomato_dayrun.py`.

## Changes
- add the migrated TOMATO shared scheduler surface with `build_exp_key()`, `RunSchedule`, and `schedule_from_config()`
- expose the scheduler helpers through the package-local `core` surface
- add seam-level tests for canonical hashing, prefix and digest options, schedule defaults, normalization, and invalid timestep rejection
- update architecture artifacts and README so `slice 035` is recorded and `pipelines/tomato_dayrun.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- the migrated TOMATO `tTHORP` package now has a deterministic shared scheduler surface for downstream orchestration seams
- `tomato_dayrun` and script entrypoints remain explicitly blocked and documented for the next slice

## Linked issue
Closes #65
