### PR TITLE
[Model Change] Migrate TOMATO tTHORP dayrun pipeline seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-035 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, and shared scheduler seams
-- Next blocked seam: TOMATO `tTHORP` dayrun pipeline at `pipelines/tomato_dayrun.py`
+- Slices 025-036 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, and dayrun pipeline seams
+- Next blocked seam: TOMATO `tTHORP` repo-level pipeline script at `scripts/run_pipeline.py`

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` package-level legacy pipeline seam is migrated as slice 033.
 - TOMATO `tTHORP` shared IO seam is migrated as slice 034.
 - TOMATO `tTHORP` shared scheduler seam is migrated as slice 035.
+- TOMATO `tTHORP` dayrun pipeline seam is migrated as slice 036.
 
 ## Next validation
-- Audit the TOMATO dayrun pipeline seam at `pipelines/tomato_dayrun.py`.
+- Audit the TOMATO repo-level pipeline script seam at `scripts/run_pipeline.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 035
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 035 approved for TOMATO
+- Gate C. Validation plan ready through slice 036
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 036 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -257,3 +257,9 @@ Slice 035:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/core/` and `tests/test_tomato_tthorp_core_scheduler.py`
 - scope: bounded TOMATO shared scheduler surface covering deterministic experiment-key hashing, schedule dataclass construction, and forcing-derived run normalization
 - excluded: `pipelines/tomato_dayrun.py` and repo-level script entrypoints
+
+Slice 036:
+- source: `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/` and `tests/test_tomato_tthorp_dayrun.py`
+- scope: bounded TOMATO dayrun orchestration surface covering config-driven execution, deterministic output artifact paths, metadata emission, and package-level from-config entrypoints
+- excluded: repo-level `scripts/run_pipeline.py` and `scripts/make_features.py`

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -324,8 +324,16 @@ The thirty-fifth slice opens the next bounded TOMATO seam:
 - keep the seam package-local instead of opening `pipelines/tomato_dayrun.py` or repo-level script entrypoints
 - leave `pipelines/tomato_dayrun.py` blocked as the next seam
 
+## Slice 036: TOMATO tTHORP Dayrun Pipeline
+
+The thirty-sixth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py` into the staged `domains/tomato/tthorp` package
+- preserve config-driven execution, deterministic artifact writing, metadata JSON emission, and package-level from-config execution
+- keep the seam package-local instead of opening repo-level `scripts/run_pipeline.py` or `scripts/make_features.py`
+- leave `scripts/run_pipeline.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first eleven TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first twelve TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `pipelines/tomato_dayrun.py`
+3. prepare the next TOMATO source audit for `scripts/run_pipeline.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 035 completed and slice 036 planning
+- Current phase: slice 036 completed and slice 037 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO dayrun pipeline seam at `pipelines/tomato_dayrun.py`
-2. decide how much of `pipelines/tomato_dayrun.py` can land without pulling in repo-level script entrypoints prematurely
+1. audit the TOMATO repo-level pipeline script seam at `scripts/run_pipeline.py`
+2. decide how much of `scripts/run_pipeline.py` can land without pulling in `scripts/make_features.py` prematurely
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-036-tomato-tthorp-dayrun-pipeline.md
+++ b/docs/architecture/architecture/module_specs/module-036-tomato-tthorp-dayrun-pipeline.md
@@ -1,0 +1,35 @@
+# Module Spec 036: TOMATO tTHORP Dayrun Pipeline
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the dayrun pipeline wrapper that executes the migrated legacy pipeline against config payloads and writes deterministic run artifacts.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/`
+- `tests/test_tomato_tthorp_dayrun.py`
+
+## Responsibilities
+
+1. preserve config-driven execution over migrated `core/io`, `core/scheduler`, and `tomato_legacy` seams
+2. preserve deterministic `df.csv` and `meta.json` artifact writing with stable metadata fields
+3. preserve package-level from-config execution so repo-level scripts can target one migrated dayrun surface
+
+## Non-Goals
+
+- migrate repo-level `scripts/run_pipeline.py`
+- migrate repo-level `scripts/make_features.py`
+- broaden into workspace-wide CLI entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/scripts/run_pipeline.py`

--- a/docs/architecture/executor/issue-036-model-change.md
+++ b/docs/architecture/executor/issue-036-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 035` landed the TOMATO shared scheduler seam, so the next bounded orchestration surface is the dayrun pipeline wrapper at `pipelines/tomato_dayrun.py`.
+- The migrated repo still lacks the package-level entry that combines config loading, repo-root resolution, legacy-pipeline execution, deterministic artifact paths, and metadata JSON emission before opening repo-level script entrypoints.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/`
+- related TOMATO dayrun artifact and config-loading integration tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for dayrun artifact writing, relative output-dir resolution, and config-path driven execution
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/pipelines/tomato_dayrun.py`
+- current migrated TOMATO `core/io.py`, `core/scheduler.py`, and `pipelines/tomato_legacy.py`

--- a/docs/architecture/executor/pr-067-tomato-dayrun-pipeline.md
+++ b/docs/architecture/executor/pr-067-tomato-dayrun-pipeline.md
@@ -1,0 +1,20 @@
+## Background
+- `slice 035` landed the TOMATO shared scheduler seam, but the migrated repo still lacked the package-level dayrun orchestration surface that writes deterministic artifacts from YAML-configured runs.
+- This PR lands `slice 036` by migrating `pipelines/tomato_dayrun.py`, and moves the next TOMATO architectural uncertainty to the repo-level pipeline script seam at `scripts/run_pipeline.py`.
+
+## Changes
+- add the migrated TOMATO dayrun pipeline surface with `TomatoDayrunArtifacts`, `run_tomato_dayrun()`, and `run_tomato_dayrun_from_config()`
+- export the new dayrun helpers through the package-local `pipelines` and root `tthorp` surfaces
+- add seam-level tests for relative and absolute output directories, artifact metadata, and config-path driven execution with inherited YAML configs
+- update architecture artifacts and README so `slice 036` is recorded and `scripts/run_pipeline.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- the migrated TOMATO `tTHORP` package now has a package-level dayrun orchestration surface over the already ported IO, scheduler, and legacy pipeline seams
+- repo-level script entrypoints remain explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #67

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the shared scheduler seam | `tomato_dayrun` and repo-level script entrypoints can still hide legacy orchestration assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the dayrun pipeline seam | repo-level script entrypoints can still hide legacy orchestration and artifact-layout assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
@@ -16,9 +16,12 @@ from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import (
     make_tomato_legacy_model,
 )
 from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (
+    TomatoDayrunArtifacts,
     config_payload_for_exp_key,
     resolve_forcing_path,
     resolve_repo_root,
+    run_tomato_dayrun,
+    run_tomato_dayrun_from_config,
     run_tomato_legacy_pipeline,
     summarize_tomato_legacy_metrics,
 )
@@ -40,9 +43,12 @@ __all__ = [
     "make_tomato_legacy_model",
     "TomatoModel",
     "create_sample_input_csv",
+    "TomatoDayrunArtifacts",
     "resolve_repo_root",
     "resolve_forcing_path",
     "config_payload_for_exp_key",
+    "run_tomato_dayrun",
+    "run_tomato_dayrun_from_config",
     "run_tomato_legacy_pipeline",
     "summarize_tomato_legacy_metrics",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/__init__.py
@@ -1,3 +1,8 @@
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines.tomato_dayrun import (
+    TomatoDayrunArtifacts,
+    run_tomato_dayrun,
+    run_tomato_dayrun_from_config,
+)
 from stomatal_optimiaztion.domains.tomato.tthorp.pipelines.tomato_legacy import (
     config_payload_for_exp_key,
     resolve_forcing_path,
@@ -7,9 +12,12 @@ from stomatal_optimiaztion.domains.tomato.tthorp.pipelines.tomato_legacy import 
 )
 
 __all__ = [
+    "TomatoDayrunArtifacts",
     "config_payload_for_exp_key",
     "resolve_forcing_path",
     "resolve_repo_root",
+    "run_tomato_dayrun",
+    "run_tomato_dayrun_from_config",
     "run_tomato_legacy_pipeline",
     "summarize_tomato_legacy_metrics",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/tomato_dayrun.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/tomato_dayrun.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import (
+    build_exp_key,
+    ensure_dir,
+    load_config,
+    schedule_from_config,
+    write_json,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines.tomato_legacy import (
+    config_payload_for_exp_key,
+    resolve_repo_root,
+    run_tomato_legacy_pipeline,
+    summarize_tomato_legacy_metrics,
+)
+
+
+def _as_dict(raw: object) -> dict[str, Any]:
+    if isinstance(raw, Mapping):
+        return {str(key): value for key, value in raw.items()}
+    return {}
+
+
+def _resolve_output_dir(repo_root: Path, output_dir: str | Path) -> Path:
+    out_dir = Path(output_dir)
+    if out_dir.is_absolute():
+        return out_dir
+    return (repo_root / out_dir).resolve()
+
+
+@dataclass(frozen=True, slots=True)
+class TomatoDayrunArtifacts:
+    output_dir: Path
+    df_csv: Path
+    meta_json: Path
+
+
+def run_tomato_dayrun(
+    config: Mapping[str, Any],
+    *,
+    output_dir: str | Path,
+    repo_root: Path | None = None,
+    config_path: Path | None = None,
+) -> TomatoDayrunArtifacts:
+    """Run the migrated tomato dayrun and write deterministic artifacts."""
+
+    root = repo_root or resolve_repo_root(config, config_path=config_path)
+    out_dir = ensure_dir(_resolve_output_dir(root, output_dir))
+
+    df = run_tomato_legacy_pipeline(config, repo_root=root, config_path=config_path)
+    df_path = out_dir / "df.csv"
+    meta_path = out_dir / "meta.json"
+    df.to_csv(df_path, index=False)
+
+    metrics = summarize_tomato_legacy_metrics(df)
+    schedule = schedule_from_config(config)
+    exp_cfg = _as_dict(config.get("exp"))
+    exp_name = str(exp_cfg.get("name", "tomato_dayrun"))
+    exp_key = build_exp_key(config_payload_for_exp_key(config), prefix=exp_name)
+
+    meta: dict[str, Any] = {
+        "exp_key": exp_key,
+        "exp_name": exp_name,
+        "model": "tomato_legacy",
+        "rows": int(df.shape[0]),
+        "columns": [str(column) for column in df.columns],
+        "schedule": {
+            "max_steps": schedule.max_steps,
+            "default_dt_s": schedule.default_dt_s,
+        },
+        "metrics": dict(metrics),
+    }
+    write_json(meta_path, meta)
+    return TomatoDayrunArtifacts(output_dir=out_dir, df_csv=df_path, meta_json=meta_path)
+
+
+def run_tomato_dayrun_from_config(
+    config_path: str | Path,
+    *,
+    output_dir: str | Path,
+    repo_root: Path | None = None,
+) -> TomatoDayrunArtifacts:
+    resolved_config_path = Path(config_path).resolve()
+    config = load_config(resolved_config_path)
+    root = repo_root or resolve_repo_root(config, config_path=resolved_config_path)
+    return run_tomato_dayrun(
+        config,
+        output_dir=output_dir,
+        repo_root=root,
+        config_path=resolved_config_path,
+    )
+
+
+__all__ = [
+    "TomatoDayrunArtifacts",
+    "run_tomato_dayrun",
+    "run_tomato_dayrun_from_config",
+]

--- a/tests/test_tomato_tthorp_dayrun.py
+++ b/tests/test_tomato_tthorp_dayrun.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import build_exp_key, load_config
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (
+    config_payload_for_exp_key,
+    run_tomato_dayrun,
+    run_tomato_dayrun_from_config,
+)
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src" / "stomatal_optimiaztion").mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text("[tool.poetry]\nname = 'demo'\n", encoding="utf-8")
+    return repo_root
+
+
+def _write_forcing_csv(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2026-01-01T00:00:00",
+                "2026-01-01T01:00:00",
+                "2026-01-01T02:00:00",
+            ],
+            "T_air_C": [21.0, 22.0, 23.0],
+            "PAR_umol": [150.0, 250.0, 350.0],
+            "CO2_ppm": [410.0, 420.0, 430.0],
+            "RH_percent": [70.0, 65.0, 60.0],
+            "wind_speed_ms": [0.8, 1.0, 1.2],
+        }
+    ).to_csv(path, index=False)
+
+
+def _base_config() -> dict[str, object]:
+    return {
+        "exp": {"name": "tomato_dayrun"},
+        "pipeline": {
+            "model": "tomato_legacy",
+            "fixed_lai": 2.1,
+            "theta_substrate": 0.33,
+            "partition_policy": "thorp_veg",
+            "allocation_scheme": "4pool",
+        },
+        "forcing": {
+            "csv_path": "../../data/forcing.csv",
+            "max_steps": 2,
+            "default_dt_s": 3600.0,
+        },
+    }
+
+
+def test_run_tomato_dayrun_writes_relative_output_artifacts(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+    config_path = repo_root / "configs" / "exp" / "tomato_dayrun.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("exp: {}\n", encoding="utf-8")
+
+    config = _base_config()
+    artifacts = run_tomato_dayrun(
+        config,
+        output_dir="artifacts/runs/demo",
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+
+    assert artifacts.output_dir == (repo_root / "artifacts" / "runs" / "demo").resolve()
+    assert artifacts.df_csv == artifacts.output_dir / "df.csv"
+    assert artifacts.meta_json == artifacts.output_dir / "meta.json"
+    assert artifacts.df_csv.exists()
+    assert artifacts.meta_json.exists()
+
+    df = pd.read_csv(artifacts.df_csv)
+    with artifacts.meta_json.open("r", encoding="utf-8") as handle:
+        meta = json.load(handle)
+
+    assert len(df) == 2
+    assert meta["exp_name"] == "tomato_dayrun"
+    assert meta["model"] == "tomato_legacy"
+    assert meta["rows"] == 2
+    assert meta["schedule"] == {"max_steps": 2, "default_dt_s": 3600.0}
+    assert meta["exp_key"] == build_exp_key(
+        config_payload_for_exp_key(config),
+        prefix="tomato_dayrun",
+    )
+    assert "metrics" in meta
+    assert "created_at" not in meta
+
+
+def test_run_tomato_dayrun_from_config_loads_extends_and_infers_repo_root(
+    tmp_path: Path,
+) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+
+    configs_dir = repo_root / "configs"
+    exp_dir = configs_dir / "exp"
+    exp_dir.mkdir(parents=True)
+    (configs_dir / "base.yaml").write_text(
+        "\n".join(
+            [
+                "exp:",
+                "  name: tomato_dayrun",
+                "pipeline:",
+                "  model: tomato_legacy",
+                "  fixed_lai: 2.0",
+                "  theta_substrate: 0.33",
+                "forcing:",
+                "  csv_path: ../../data/forcing.csv",
+                "  default_dt_s: 3600.0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config_path = exp_dir / "tomato_dayrun.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "extends: ../base.yaml",
+                "pipeline:",
+                "  partition_policy: thorp_veg",
+                "  allocation_scheme: 4pool",
+                "forcing:",
+                "  max_steps: 3",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    artifacts = run_tomato_dayrun_from_config(
+        config_path,
+        output_dir="artifacts/runs/from-config",
+    )
+
+    with artifacts.meta_json.open("r", encoding="utf-8") as handle:
+        meta = json.load(handle)
+
+    config = load_config(config_path)
+    assert artifacts.output_dir == (repo_root / "artifacts" / "runs" / "from-config").resolve()
+    assert meta["rows"] == 3
+    assert meta["schedule"] == {"max_steps": 3, "default_dt_s": 3600.0}
+    assert meta["exp_key"] == build_exp_key(
+        config_payload_for_exp_key(config),
+        prefix="tomato_dayrun",
+    )
+
+
+def test_run_tomato_dayrun_supports_absolute_output_dir(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+    config = _base_config()
+    config["forcing"] = {
+        **dict(config["forcing"]),  # type: ignore[arg-type]
+        "csv_path": str(forcing_path),
+    }
+
+    artifacts = run_tomato_dayrun(
+        config,
+        output_dir=tmp_path / "absolute-output",
+        repo_root=repo_root,
+    )
+
+    assert artifacts.output_dir == (tmp_path / "absolute-output").resolve()
+    assert artifacts.df_csv.exists()
+    assert artifacts.meta_json.exists()


### PR DESCRIPTION
## Background
- `slice 035` landed the TOMATO shared scheduler seam, but the migrated repo still lacked the package-level dayrun orchestration surface that writes deterministic artifacts from YAML-configured runs.
- This PR lands `slice 036` by migrating `pipelines/tomato_dayrun.py`, and moves the next TOMATO architectural uncertainty to the repo-level pipeline script seam at `scripts/run_pipeline.py`.

## Changes
- add the migrated TOMATO dayrun pipeline surface with `TomatoDayrunArtifacts`, `run_tomato_dayrun()`, and `run_tomato_dayrun_from_config()`
- export the new dayrun helpers through the package-local `pipelines` and root `tthorp` surfaces
- add seam-level tests for relative and absolute output directories, artifact metadata, and config-path driven execution with inherited YAML configs
- update architecture artifacts and README so `slice 036` is recorded and `scripts/run_pipeline.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- the migrated TOMATO `tTHORP` package now has a package-level dayrun orchestration surface over the already ported IO, scheduler, and legacy pipeline seams
- repo-level script entrypoints remain explicitly blocked and documented for the next slice

## Linked issue
Closes #67
