### PR TITLE
[Model Change] Migrate TOMATO tTHORP repo-level pipeline script seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-036 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, and dayrun pipeline seams
-- Next blocked seam: TOMATO `tTHORP` repo-level pipeline script at `scripts/run_pipeline.py`
+- Slices 025-037 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, and repo-level pipeline script seams
+- Next blocked seam: TOMATO `tTHORP` feature-builder script at `scripts/make_features.py`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` shared IO seam is migrated as slice 034.
 - TOMATO `tTHORP` shared scheduler seam is migrated as slice 035.
 - TOMATO `tTHORP` dayrun pipeline seam is migrated as slice 036.
+- TOMATO `tTHORP` repo-level pipeline script seam is migrated as slice 037.
 
 ## Next validation
-- Audit the TOMATO repo-level pipeline script seam at `scripts/run_pipeline.py`.
+- Audit the TOMATO feature-builder script seam at `scripts/make_features.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 036
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 036 approved for TOMATO
+- Gate C. Validation plan ready through slice 037
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 037 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -263,3 +263,9 @@ Slice 036:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/pipelines/` and `tests/test_tomato_tthorp_dayrun.py`
 - scope: bounded TOMATO dayrun orchestration surface covering config-driven execution, deterministic output artifact paths, metadata emission, and package-level from-config entrypoints
 - excluded: repo-level `scripts/run_pipeline.py` and `scripts/make_features.py`
+
+Slice 037:
+- source: `TOMATO/tTHORP/scripts/run_pipeline.py`
+- target: `scripts/run_pipeline.py` and `tests/test_tomato_tthorp_run_pipeline_script.py`
+- scope: bounded TOMATO repo-level pipeline script surface covering CLI argument parsing, config loading, output-dir resolution, deterministic result artifact naming, and printed JSON summaries
+- excluded: `scripts/make_features.py` and broader non-TOMATO entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -332,8 +332,16 @@ The thirty-sixth slice opens the next bounded TOMATO seam:
 - keep the seam package-local instead of opening repo-level `scripts/run_pipeline.py` or `scripts/make_features.py`
 - leave `scripts/run_pipeline.py` blocked as the next seam
 
+## Slice 037: TOMATO tTHORP Repo-Level Pipeline Script
+
+The thirty-seventh slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/scripts/run_pipeline.py` into the repo-local `scripts/` surface
+- preserve CLI argument parsing, config loading, output-dir resolution, deterministic artifact naming, and printed JSON summaries
+- keep the seam bounded to the pipeline-runner script instead of opening `scripts/make_features.py` or broader automation entrypoints
+- leave `scripts/make_features.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first twelve TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first thirteen TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `scripts/run_pipeline.py`
+3. prepare the next TOMATO source audit for `scripts/make_features.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 036 completed and slice 037 planning
+- Current phase: slice 037 completed and slice 038 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO repo-level pipeline script seam at `scripts/run_pipeline.py`
-2. decide how much of `scripts/run_pipeline.py` can land without pulling in `scripts/make_features.py` prematurely
+1. audit the TOMATO feature-builder script seam at `scripts/make_features.py`
+2. decide how much of `scripts/make_features.py` can land without opening broader non-TOMATO entrypoints prematurely
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-037-tomato-tthorp-run-pipeline-script.md
+++ b/docs/architecture/architecture/module_specs/module-037-tomato-tthorp-run-pipeline-script.md
@@ -1,0 +1,35 @@
+# Module Spec 037: TOMATO tTHORP Repo-Level Pipeline Script
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the repo-level pipeline runner script that executes YAML-configured runs, writes deterministic artifacts, and prints a stable JSON summary for automation.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/scripts/run_pipeline.py`
+
+## Target Outputs
+
+- `scripts/run_pipeline.py`
+- `tests/test_tomato_tthorp_run_pipeline_script.py`
+
+## Responsibilities
+
+1. preserve CLI argument parsing for config path, output-dir override, and explicit experiment-key override
+2. preserve deterministic CSV and metrics-JSON artifact naming over migrated package seams
+3. preserve printed JSON summary shape so shell automation can consume the runner output
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/scripts/make_features.py`
+- broaden into non-TOMATO repo-level automation entrypoints
+- rework the migrated package-level dayrun orchestration surface
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/scripts/make_features.py`

--- a/docs/architecture/executor/issue-037-model-change.md
+++ b/docs/architecture/executor/issue-037-model-change.md
@@ -1,0 +1,17 @@
+## Why
+- `slice 036` landed the TOMATO dayrun pipeline seam, so the next bounded orchestration surface is the repo-level script entrypoint at `scripts/run_pipeline.py`.
+- The migrated repo still lacks the CLI-style wrapper that loads YAML configs, resolves default output directories, emits deterministic result artifacts, and prints a stable JSON summary for automation.
+
+## Affected model
+- `TOMATO tTHORP`
+- `scripts/run_pipeline.py`
+- related TOMATO CLI-style pipeline smoke tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for config-path execution, output-dir overrides, exp-key overrides, and printed JSON summaries
+
+## Comparison target
+- legacy `TOMATO/tTHORP/scripts/run_pipeline.py`
+- current migrated TOMATO `core`, `tomato_legacy`, and `tomato_dayrun` seams

--- a/docs/architecture/executor/pr-069-tomato-run-pipeline-script.md
+++ b/docs/architecture/executor/pr-069-tomato-run-pipeline-script.md
@@ -1,0 +1,20 @@
+## Background
+- `slice 036` landed the TOMATO dayrun pipeline seam, but the migrated repo still lacked the repo-level runner script that shells and automation can call directly.
+- This PR lands `slice 037` by migrating `scripts/run_pipeline.py`, and moves the next TOMATO architectural uncertainty to the feature-builder script seam at `scripts/make_features.py`.
+
+## Changes
+- add the migrated repo-local `scripts/run_pipeline.py` runner over the already ported TOMATO package seams
+- preserve CLI arguments for config path, output-dir override, and explicit experiment-key override
+- add subprocess-based tests for printed JSON summaries and deterministic artifact outputs
+- update architecture artifacts and README so `slice 037` is recorded and `scripts/make_features.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- the migrated workspace now has a repo-level pipeline runner script over the TOMATO package seams
+- feature-building and remaining repo-level entrypoints stay explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #69

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the dayrun pipeline seam | repo-level script entrypoints can still hide legacy orchestration and artifact-layout assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the repo-level pipeline script seam | the feature-builder script and remaining repo-level entrypoints can still hide legacy data-shaping assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import (  # noqa: E402
+    build_exp_key,
+    ensure_dir,
+    load_config,
+    write_json,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (  # noqa: E402
+    config_payload_for_exp_key,
+    resolve_repo_root,
+    run_tomato_legacy_pipeline,
+    summarize_tomato_legacy_metrics,
+)
+
+
+def _as_dict(raw: object) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run YAML-configured tTHORP pipeline.")
+    parser.add_argument(
+        "--config",
+        default="configs/exp/tomato_dayrun.yaml",
+        help="Path to experiment YAML config.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Override output directory (default from config).",
+    )
+    parser.add_argument(
+        "--exp-key",
+        default=None,
+        help="Optional explicit experiment key; otherwise deterministic hash from config payload.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_output_dir(config: dict[str, Any], repo_root: Path, override: str | None) -> Path:
+    if override:
+        raw = Path(override)
+    else:
+        raw = Path(str(_as_dict(config.get("paths")).get("output_dir", "TOMATO/tTHORP/artifacts/runs")))
+
+    if raw.is_absolute():
+        return raw
+    return (repo_root / raw).resolve()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    config_path = Path(args.config).resolve()
+    config = load_config(config_path)
+    repo_root = resolve_repo_root(config, config_path=config_path)
+
+    exp_name = str(_as_dict(config.get("exp")).get("name", "exp"))
+    exp_key = args.exp_key or build_exp_key(config_payload_for_exp_key(config), prefix=exp_name)
+
+    output_dir = ensure_dir(_resolve_output_dir(config, repo_root, args.output_dir))
+    results = run_tomato_legacy_pipeline(config, repo_root=repo_root, config_path=config_path)
+    metrics = summarize_tomato_legacy_metrics(results)
+
+    csv_path = output_dir / f"{exp_key}.csv"
+    metrics_path = output_dir / f"{exp_key}.metrics.json"
+    results.to_csv(csv_path, index=False)
+    write_json(metrics_path, metrics)
+
+    summary = {
+        "exp_key": exp_key,
+        "rows": int(metrics.get("rows", 0)),
+        "output_csv": str(csv_path),
+        "metrics_json": str(metrics_path),
+    }
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tomato_tthorp_run_pipeline_script.py
+++ b/tests/test_tomato_tthorp_run_pipeline_script.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import build_exp_key, load_config
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import config_payload_for_exp_key
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src" / "stomatal_optimiaztion").mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text("[tool.poetry]\nname = 'demo'\n", encoding="utf-8")
+    return repo_root
+
+
+def _write_forcing_csv(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2026-01-01T00:00:00",
+                "2026-01-01T01:00:00",
+                "2026-01-01T02:00:00",
+            ],
+            "T_air_C": [21.0, 22.0, 23.0],
+            "PAR_umol": [150.0, 250.0, 350.0],
+            "CO2_ppm": [410.0, 420.0, 430.0],
+            "RH_percent": [70.0, 65.0, 60.0],
+            "wind_speed_ms": [0.8, 1.0, 1.2],
+        }
+    ).to_csv(path, index=False)
+
+
+def _write_config(repo_root: Path, *, include_output_dir: bool) -> Path:
+    configs_dir = repo_root / "configs"
+    exp_dir = configs_dir / "exp"
+    exp_dir.mkdir(parents=True)
+    (configs_dir / "base.yaml").write_text(
+        "\n".join(
+            [
+                "exp:",
+                "  name: tomato_dayrun",
+                "pipeline:",
+                "  model: tomato_legacy",
+                "  fixed_lai: 2.0",
+                "  theta_substrate: 0.33",
+                "  partition_policy: thorp_veg",
+                "  allocation_scheme: 4pool",
+                "forcing:",
+                "  csv_path: ../../data/forcing.csv",
+                "  default_dt_s: 3600.0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    lines = [
+        "extends: ../base.yaml",
+        "forcing:",
+        "  max_steps: 3",
+    ]
+    if include_output_dir:
+        lines.extend(
+            [
+                "paths:",
+                "  output_dir: artifacts/custom-runs",
+            ]
+        )
+    lines.append("")
+    config_path = exp_dir / "tomato_dayrun.yaml"
+    config_path.write_text("\n".join(lines), encoding="utf-8")
+    return config_path
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "run_pipeline.py"
+
+
+def test_run_pipeline_script_writes_summary_and_artifacts(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+    config_path = _write_config(repo_root, include_output_dir=False)
+    output_dir = tmp_path / "override-output"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--config",
+            str(config_path),
+            "--output-dir",
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout.strip())
+    config = load_config(config_path)
+    expected_exp_key = build_exp_key(
+        config_payload_for_exp_key(config),
+        prefix="tomato_dayrun",
+    )
+    output_csv = output_dir / f"{expected_exp_key}.csv"
+    metrics_json = output_dir / f"{expected_exp_key}.metrics.json"
+    assert summary == {
+        "exp_key": expected_exp_key,
+        "metrics_json": str(metrics_json),
+        "output_csv": str(output_csv),
+        "rows": 3,
+    }
+    assert output_csv.exists()
+    assert metrics_json.exists()
+
+    with metrics_json.open("r", encoding="utf-8") as handle:
+        metrics = json.load(handle)
+
+    assert metrics["rows"] == 3
+    assert "sum_a_n" in metrics
+
+
+def test_run_pipeline_script_respects_exp_key_override_and_config_output_dir(
+    tmp_path: Path,
+) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    _write_forcing_csv(forcing_path)
+    config_path = _write_config(repo_root, include_output_dir=True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--config",
+            str(config_path),
+            "--exp-key",
+            "manual-key",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout.strip())
+    output_dir = (repo_root / "artifacts" / "custom-runs").resolve()
+    output_csv = output_dir / "manual-key.csv"
+    metrics_json = output_dir / "manual-key.metrics.json"
+    assert summary == {
+        "exp_key": "manual-key",
+        "metrics_json": str(metrics_json),
+        "output_csv": str(output_csv),
+        "rows": 3,
+    }
+    assert output_csv.exists()
+    assert metrics_json.exists()


### PR DESCRIPTION
## Background
- `slice 036` landed the TOMATO dayrun pipeline seam, but the migrated repo still lacked the repo-level runner script that shells and automation can call directly.
- This PR lands `slice 037` by migrating `scripts/run_pipeline.py`, and moves the next TOMATO architectural uncertainty to the feature-builder script seam at `scripts/make_features.py`.

## Changes
- add the migrated repo-local `scripts/run_pipeline.py` runner over the already ported TOMATO package seams
- preserve CLI arguments for config path, output-dir override, and explicit experiment-key override
- add subprocess-based tests for printed JSON summaries and deterministic artifact outputs
- update architecture artifacts and README so `slice 037` is recorded and `scripts/make_features.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- the migrated workspace now has a repo-level pipeline runner script over the TOMATO package seams
- feature-building and remaining repo-level entrypoints stay explicitly blocked and documented for the next slice

## Linked issue
Closes #69
