### PR TITLE
[Model Change] Migrate TOMATO tTHORP feature-builder script seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-037 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, and repo-level pipeline script seams
-- Next blocked seam: TOMATO `tTHORP` feature-builder script at `scripts/make_features.py`
+- Slices 025-038 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level pipeline script, and feature-builder script seams
+- Next blocked seam: TOMATO `tTHORP` THORP reference adapter at `models/thorp_ref/adapter.py`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` shared scheduler seam is migrated as slice 035.
 - TOMATO `tTHORP` dayrun pipeline seam is migrated as slice 036.
 - TOMATO `tTHORP` repo-level pipeline script seam is migrated as slice 037.
+- TOMATO `tTHORP` feature-builder script seam is migrated as slice 038.
 
 ## Next validation
-- Audit the TOMATO feature-builder script seam at `scripts/make_features.py`.
+- Audit the TOMATO THORP reference adapter seam at `models/thorp_ref/adapter.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 037
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 037 approved for TOMATO
+- Gate C. Validation plan ready through slice 038
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 038 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -269,3 +269,9 @@ Slice 037:
 - target: `scripts/run_pipeline.py` and `tests/test_tomato_tthorp_run_pipeline_script.py`
 - scope: bounded TOMATO repo-level pipeline script surface covering CLI argument parsing, config loading, output-dir resolution, deterministic result artifact naming, and printed JSON summaries
 - excluded: `scripts/make_features.py` and broader non-TOMATO entrypoints
+
+Slice 038:
+- source: `TOMATO/tTHORP/scripts/make_features.py` and `TOMATO/tTHORP/src/tthorp/core/util_units.py`
+- target: `scripts/make_features.py`, `src/stomatal_optimiaztion/domains/tomato/tthorp/core/util_units.py`, and feature/unit-conversion tests
+- scope: bounded TOMATO feature-building surface covering deterministic feature CSV output, SW-to-PAR derivation, forcing defaults, and shared PAR conversion helpers
+- excluded: `models/thorp_ref/adapter.py`, plotting scripts, and broader non-TOMATO entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -340,8 +340,16 @@ The thirty-seventh slice opens the next bounded TOMATO seam:
 - keep the seam bounded to the pipeline-runner script instead of opening `scripts/make_features.py` or broader automation entrypoints
 - leave `scripts/make_features.py` blocked as the next seam
 
+## Slice 038: TOMATO tTHORP Feature-Builder Script
+
+The thirty-eighth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/scripts/make_features.py` into the repo-local `scripts/` surface
+- port the shared `core.util_units` PAR conversion helper as a direct dependency instead of duplicating the conversion logic again
+- preserve deterministic feature CSV naming, SW-to-PAR derivation, forcing defaults, and printed output-path behavior
+- leave `models/thorp_ref/adapter.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first thirteen TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first fourteen TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `scripts/make_features.py`
+3. prepare the next TOMATO source audit for `models/thorp_ref/adapter.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 037 completed and slice 038 planning
+- Current phase: slice 038 completed and slice 039 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO feature-builder script seam at `scripts/make_features.py`
-2. decide how much of `scripts/make_features.py` can land without opening broader non-TOMATO entrypoints prematurely
+1. audit the TOMATO THORP reference adapter seam at `models/thorp_ref/adapter.py`
+2. decide how much of `models/thorp_ref/adapter.py` can land without reopening broader THORP workspace assumptions prematurely
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-038-tomato-tthorp-make-features-script.md
+++ b/docs/architecture/architecture/module_specs/module-038-tomato-tthorp-make-features-script.md
@@ -1,0 +1,38 @@
+# Module Spec 038: TOMATO tTHORP Feature-Builder Script
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the repo-level feature-builder script that converts forcing CSV inputs into deterministic feature CSV outputs for downstream runs.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/scripts/make_features.py`
+- `TOMATO/tTHORP/src/tthorp/core/util_units.py`
+
+## Target Outputs
+
+- `scripts/make_features.py`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/core/util_units.py`
+- `tests/test_tomato_tthorp_make_features_script.py`
+- `tests/test_tomato_tthorp_util_units.py`
+
+## Responsibilities
+
+1. preserve CLI argument parsing for config path and output-path override
+2. preserve deterministic feature CSV output naming, SW-to-PAR conversion, and forcing default injection
+3. expose shared PAR conversion helpers through the migrated `core` surface
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/src/tthorp/models/thorp_ref/adapter.py`
+- migrate plotting scripts under `TOMATO/tTHORP/scripts/`
+- broaden into non-TOMATO repo-level automation entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/src/tthorp/models/thorp_ref/adapter.py`

--- a/docs/architecture/executor/issue-038-model-change.md
+++ b/docs/architecture/executor/issue-038-model-change.md
@@ -1,0 +1,20 @@
+## Why
+- `slice 037` landed the TOMATO repo-level pipeline runner, so the next bounded repo-level seam is the deterministic forcing feature builder at `scripts/make_features.py`.
+- The migrated repo still lacks the CLI-style wrapper that loads YAML configs, resolves forcing CSV paths, injects derived `PAR_umol` and default forcing columns, and writes a deterministic feature CSV for downstream runs.
+- This seam depends on the shared PAR conversion helper from `core.util_units`, so that helper should land as a direct supporting dependency instead of duplicating conversion logic again.
+
+## Affected model
+- `TOMATO tTHORP`
+- `scripts/make_features.py`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/core/`
+- related TOMATO feature-building tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for deterministic feature output paths, SW-to-PAR derivation, forcing defaults, and direct unit-conversion helper behavior
+
+## Comparison target
+- legacy `TOMATO/tTHORP/scripts/make_features.py`
+- legacy `TOMATO/tTHORP/src/tthorp/core/util_units.py`
+- current migrated TOMATO `core`, `forcing_csv`, and repo-level pipeline runner seams

--- a/docs/architecture/executor/pr-071-tomato-make-features-script.md
+++ b/docs/architecture/executor/pr-071-tomato-make-features-script.md
@@ -1,0 +1,20 @@
+## Background
+- `slice 037` landed the TOMATO repo-level pipeline runner, but the migrated repo still lacked the deterministic feature-builder script used to prepare forcing CSVs for downstream runs.
+- This PR lands `slice 038` by migrating `scripts/make_features.py` plus the direct `core.util_units` dependency, and moves the next TOMATO architectural uncertainty to the THORP reference adapter seam at `models/thorp_ref/adapter.py`.
+
+## Changes
+- add the migrated repo-local `scripts/make_features.py` feature-builder over the already ported TOMATO package seams
+- add the shared `core.util_units` PAR conversion helper and expose it through the `core` surface
+- add subprocess-based script tests and direct unit-conversion tests
+- update architecture artifacts and README so `slice 038` is recorded and `models/thorp_ref/adapter.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- the migrated workspace now has a repo-level feature-builder script and shared PAR conversion helpers for TOMATO forcing preparation
+- THORP reference bridging and remaining plotting scripts stay explicitly blocked and documented for the next slice
+
+## Linked issue
+Closes #71

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the repo-level pipeline script seam | the feature-builder script and remaining repo-level entrypoints can still hide legacy data-shaping assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the feature-builder script seam | the THORP reference adapter and remaining plotting/utility entrypoints can still hide legacy coupling assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/scripts/make_features.py
+++ b/scripts/make_features.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Any
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import (  # noqa: E402
+    build_exp_key,
+    ensure_dir,
+    load_config,
+    w_m2_to_par_umol,
+)
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (  # noqa: E402
+    config_payload_for_exp_key,
+    resolve_forcing_path,
+    resolve_repo_root,
+)
+
+
+def _as_dict(raw: object) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build deterministic forcing features from YAML config.")
+    parser.add_argument(
+        "--config",
+        default="configs/exp/tomato_dayrun.yaml",
+        help="Path to experiment YAML config.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output feature CSV path (default from config and deterministic exp_key).",
+    )
+    return parser.parse_args()
+
+
+def _find_sw_column(df: pd.DataFrame) -> str | None:
+    for name in ("SW_in_Wm2", "r_incom_w_m2", "r_incom"):
+        if name in df.columns:
+            return name
+    return None
+
+
+def _resolve_default_output(config: dict[str, Any], repo_root: Path, exp_key: str) -> Path:
+    paths_cfg = _as_dict(config.get("paths"))
+    features_dir_raw = Path(str(paths_cfg.get("features_dir", "TOMATO/tTHORP/artifacts/features")))
+    features_dir = (
+        features_dir_raw if features_dir_raw.is_absolute() else (repo_root / features_dir_raw).resolve()
+    )
+    return features_dir / f"{exp_key}.features.csv"
+
+
+def main() -> int:
+    args = _parse_args()
+
+    config_path = Path(args.config).resolve()
+    config = load_config(config_path)
+    repo_root = resolve_repo_root(config, config_path=config_path)
+    forcing_path = resolve_forcing_path(config, repo_root=repo_root, config_path=config_path)
+    forcing_cfg = _as_dict(config.get("forcing"))
+
+    df = pd.read_csv(forcing_path)
+    max_steps_raw = forcing_cfg.get("max_steps")
+    if max_steps_raw is not None:
+        df = df.head(max(0, int(max_steps_raw))).copy()
+    else:
+        df = df.copy()
+
+    sw_col = _find_sw_column(df)
+    if "PAR_umol" not in df.columns:
+        if sw_col is None:
+            df["PAR_umol"] = 0.0
+        else:
+            sw_series = df[sw_col].astype(float).clip(lower=0.0)
+            df["PAR_umol"] = sw_series.map(lambda value: w_m2_to_par_umol(float(value)))
+
+    if "CO2_ppm" not in df.columns:
+        df["CO2_ppm"] = float(forcing_cfg.get("default_co2_ppm", 420.0))
+    if "n_fruits_per_truss" not in df.columns:
+        df["n_fruits_per_truss"] = int(forcing_cfg.get("default_n_fruits_per_truss", 4))
+
+    exp_name = str(_as_dict(config.get("exp")).get("name", "exp"))
+    exp_key = build_exp_key(config_payload_for_exp_key(config), prefix=exp_name)
+    output_path = Path(args.output) if args.output else _resolve_default_output(config, repo_root, exp_key)
+    if not output_path.is_absolute():
+        output_path = (repo_root / output_path).resolve()
+    ensure_dir(output_path.parent)
+    df.to_csv(output_path, index=False)
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/core/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/core/__init__.py
@@ -10,14 +10,24 @@ from stomatal_optimiaztion.domains.tomato.tthorp.core.scheduler import (
     build_exp_key,
     schedule_from_config,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.core.util_units import (
+    PAR_UMOL_PER_W_M2,
+    PAR_UMOL_PER_WM2,
+    par_umol_to_w_m2,
+    w_m2_to_par_umol,
+)
 
 __all__ = [
+    "PAR_UMOL_PER_W_M2",
+    "PAR_UMOL_PER_WM2",
     "RunSchedule",
     "build_exp_key",
     "deep_merge",
     "ensure_dir",
     "load_config",
+    "par_umol_to_w_m2",
     "read_yaml",
     "schedule_from_config",
+    "w_m2_to_par_umol",
     "write_json",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/core/util_units.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/core/util_units.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import math
+
+PAR_UMOL_PER_WM2 = 4.6
+PAR_UMOL_PER_W_M2 = PAR_UMOL_PER_WM2
+
+
+def _validate_factor(par_umol_per_w_m2: float) -> float:
+    factor = float(par_umol_per_w_m2)
+    if not math.isfinite(factor) or factor <= 0:
+        raise ValueError(f"par_umol_per_w_m2 must be a positive finite value, got {par_umol_per_w_m2!r}.")
+    return factor
+
+
+def par_umol_to_w_m2(
+    par_umol: float,
+    *,
+    par_umol_per_w_m2: float = PAR_UMOL_PER_WM2,
+) -> float:
+    factor = _validate_factor(par_umol_per_w_m2)
+    return float(par_umol) / factor
+
+
+def w_m2_to_par_umol(
+    w_m2: float,
+    *,
+    par_umol_per_w_m2: float = PAR_UMOL_PER_WM2,
+) -> float:
+    factor = _validate_factor(par_umol_per_w_m2)
+    return float(w_m2) * factor
+
+
+__all__ = [
+    "PAR_UMOL_PER_WM2",
+    "PAR_UMOL_PER_W_M2",
+    "par_umol_to_w_m2",
+    "w_m2_to_par_umol",
+]

--- a/tests/test_tomato_tthorp_make_features_script.py
+++ b/tests/test_tomato_tthorp_make_features_script.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import build_exp_key, load_config
+from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import config_payload_for_exp_key
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src" / "stomatal_optimiaztion").mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text("[tool.poetry]\nname = 'demo'\n", encoding="utf-8")
+    return repo_root
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "make_features.py"
+
+
+def _write_config(repo_root: Path, *, include_features_dir: bool) -> Path:
+    configs_dir = repo_root / "configs"
+    exp_dir = configs_dir / "exp"
+    exp_dir.mkdir(parents=True)
+    (configs_dir / "base.yaml").write_text(
+        "\n".join(
+            [
+                "exp:",
+                "  name: tomato_dayrun",
+                "forcing:",
+                "  csv_path: ../../data/forcing.csv",
+                "  default_co2_ppm: 430.0",
+                "  default_n_fruits_per_truss: 5",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    lines = [
+        "extends: ../base.yaml",
+        "forcing:",
+        "  max_steps: 2",
+    ]
+    if include_features_dir:
+        lines.extend(
+            [
+                "paths:",
+                "  features_dir: artifacts/features-alt",
+            ]
+        )
+    lines.append("")
+    config_path = exp_dir / "tomato_dayrun.yaml"
+    config_path.write_text("\n".join(lines), encoding="utf-8")
+    return config_path
+
+
+def test_make_features_script_builds_feature_csv_with_override_output(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "datetime": ["2026-01-01T00:00:00", "2026-01-01T01:00:00", "2026-01-01T02:00:00"],
+            "SW_in_Wm2": [100.0, 200.0, 300.0],
+            "T_air_C": [21.0, 22.0, 23.0],
+            "RH_percent": [70.0, 65.0, 60.0],
+            "wind_speed_ms": [0.8, 1.0, 1.2],
+        }
+    ).to_csv(forcing_path, index=False)
+    config_path = _write_config(repo_root, include_features_dir=False)
+    output_path = tmp_path / "features.csv"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--config",
+            str(config_path),
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()) == output_path.resolve()
+    df = pd.read_csv(output_path)
+    assert len(df) == 2
+    assert df["PAR_umol"].tolist() == [460.0, 920.0]
+    assert df["CO2_ppm"].tolist() == [430.0, 430.0]
+    assert df["n_fruits_per_truss"].tolist() == [5, 5]
+
+
+def test_make_features_script_uses_default_features_dir_and_existing_columns(
+    tmp_path: Path,
+) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    forcing_path = repo_root / "data" / "forcing.csv"
+    forcing_path.parent.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "datetime": ["2026-01-01T00:00:00", "2026-01-01T01:00:00", "2026-01-01T02:00:00"],
+            "r_incom": [50.0, 75.0, 100.0],
+            "PAR_umol": [10.0, 20.0, 30.0],
+            "CO2_ppm": [400.0, 405.0, 410.0],
+            "n_fruits_per_truss": [3, 4, 5],
+            "T_air_C": [20.0, 21.0, 22.0],
+            "RH_percent": [60.0, 62.0, 64.0],
+            "wind_speed_ms": [1.0, 1.1, 1.2],
+        }
+    ).to_csv(forcing_path, index=False)
+    config_path = _write_config(repo_root, include_features_dir=True)
+    config = load_config(config_path)
+    exp_key = build_exp_key(config_payload_for_exp_key(config), prefix="tomato_dayrun")
+    expected_output = (repo_root / "artifacts" / "features-alt" / f"{exp_key}.features.csv").resolve()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--config",
+            str(config_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()) == expected_output
+    df = pd.read_csv(expected_output)
+    assert len(df) == 2
+    assert df["PAR_umol"].tolist() == [10.0, 20.0]
+    assert df["CO2_ppm"].tolist() == [400.0, 405.0]
+    assert df["n_fruits_per_truss"].tolist() == [3, 4]

--- a/tests/test_tomato_tthorp_util_units.py
+++ b/tests/test_tomato_tthorp_util_units.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tthorp.core import (
+    PAR_UMOL_PER_W_M2,
+    PAR_UMOL_PER_WM2,
+    par_umol_to_w_m2,
+    w_m2_to_par_umol,
+)
+
+
+def test_par_conversion_alias_constants_match() -> None:
+    assert PAR_UMOL_PER_WM2 == pytest.approx(4.6)
+    assert PAR_UMOL_PER_W_M2 == PAR_UMOL_PER_WM2
+
+
+def test_par_conversion_round_trip_is_stable() -> None:
+    par_umol = 345.0
+
+    w_m2 = par_umol_to_w_m2(par_umol)
+    recovered = w_m2_to_par_umol(w_m2)
+
+    assert math.isfinite(w_m2)
+    assert recovered == pytest.approx(par_umol)
+
+
+def test_par_conversion_rejects_invalid_factor() -> None:
+    with pytest.raises(ValueError, match="positive finite value"):
+        w_m2_to_par_umol(100.0, par_umol_per_w_m2=0.0)


### PR DESCRIPTION
## Background
- `slice 037` landed the TOMATO repo-level pipeline runner, but the migrated repo still lacked the deterministic feature-builder script used to prepare forcing CSVs for downstream runs.
- This PR lands `slice 038` by migrating `scripts/make_features.py` plus the direct `core.util_units` dependency, and moves the next TOMATO architectural uncertainty to the THORP reference adapter seam at `models/thorp_ref/adapter.py`.

## Changes
- add the migrated repo-local `scripts/make_features.py` feature-builder over the already ported TOMATO package seams
- add the shared `core.util_units` PAR conversion helper and expose it through the `core` surface
- add subprocess-based script tests and direct unit-conversion tests
- update architecture artifacts and README so `slice 038` is recorded and `models/thorp_ref/adapter.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- the migrated workspace now has a repo-level feature-builder script and shared PAR conversion helpers for TOMATO forcing preparation
- THORP reference bridging and remaining plotting scripts stay explicitly blocked and documented for the next slice

## Linked issue
Closes #71
