### PR TITLE
[Model Change] Migrate TOMATO tTHORP THORP reference adapter seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-038 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapter, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level pipeline script, and feature-builder script seams
-- Next blocked seam: TOMATO `tTHORP` THORP reference adapter at `models/thorp_ref/adapter.py`
+- Slices 025-039 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, and THORP reference adapter seams
+- Next blocked seam: TOMATO `tTHORP` simulation plotting script at `scripts/plot_simulation_png.py`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` dayrun pipeline seam is migrated as slice 036.
 - TOMATO `tTHORP` repo-level pipeline script seam is migrated as slice 037.
 - TOMATO `tTHORP` feature-builder script seam is migrated as slice 038.
+- TOMATO `tTHORP` THORP reference adapter seam is migrated as slice 039.
 
 ## Next validation
-- Audit the TOMATO THORP reference adapter seam at `models/thorp_ref/adapter.py`.
+- Audit the TOMATO simulation plotting seam at `scripts/plot_simulation_png.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 038
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 038 approved for TOMATO
+- Gate C. Validation plan ready through slice 039
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 039 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -275,3 +275,9 @@ Slice 038:
 - target: `scripts/make_features.py`, `src/stomatal_optimiaztion/domains/tomato/tthorp/core/util_units.py`, and feature/unit-conversion tests
 - scope: bounded TOMATO feature-building surface covering deterministic feature CSV output, SW-to-PAR derivation, forcing defaults, and shared PAR conversion helpers
 - excluded: `models/thorp_ref/adapter.py`, plotting scripts, and broader non-TOMATO entrypoints
+
+Slice 039:
+- source: `TOMATO/tTHORP/src/tthorp/models/thorp_ref/{adapter.py,__init__.py}`
+- target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/`, package exports, and `tests/test_tomato_tthorp_thorp_ref_adapter.py`
+- scope: bounded TOMATO THORP-reference bridge covering forcing-column normalization, migrated THORP runtime binding, and legacy-shaped DataFrame outputs
+- excluded: repo-level plotting scripts, PNG summary generation, and broader non-TOMATO entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -348,8 +348,16 @@ The thirty-eighth slice opens the next bounded TOMATO seam:
 - preserve deterministic feature CSV naming, SW-to-PAR derivation, forcing defaults, and printed output-path behavior
 - leave `models/thorp_ref/adapter.py` blocked as the next seam
 
+## Slice 039: TOMATO tTHORP THORP Reference Adapter
+
+The thirty-ninth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/src/tthorp/models/thorp_ref/adapter.py` and its package export into the staged `domains/tomato/tthorp` package
+- bind the adapter to the migrated `stomatal_optimiaztion.domains.thorp` runtime instead of requiring an external THORP source checkout
+- preserve forcing-column normalization, default fallback values, and the legacy-shaped output DataFrame contract
+- leave `scripts/plot_simulation_png.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first fourteen TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first fifteen TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `models/thorp_ref/adapter.py`
+3. prepare the next TOMATO source audit for `scripts/plot_simulation_png.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 038 completed and slice 039 planning
+- Current phase: slice 039 completed and slice 040 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO THORP reference adapter seam at `models/thorp_ref/adapter.py`
-2. decide how much of `models/thorp_ref/adapter.py` can land without reopening broader THORP workspace assumptions prematurely
+1. audit the TOMATO simulation plotting seam at `scripts/plot_simulation_png.py`
+2. decide whether plotting dependencies should remain optional repo-level tooling or move into the migrated package surface
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-039-tomato-tthorp-thorp-reference-adapter.md
+++ b/docs/architecture/architecture/module_specs/module-039-tomato-tthorp-thorp-reference-adapter.md
@@ -1,0 +1,37 @@
+# Module Spec 039: TOMATO tTHORP THORP Reference Adapter
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the THORP reference adapter that reshapes tabular forcing into THORP runtime inputs and exposes legacy-shaped summary outputs.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/src/tthorp/models/thorp_ref/adapter.py`
+- `TOMATO/tTHORP/src/tthorp/models/thorp_ref/__init__.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/adapter.py`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/__init__.py`
+- `tests/test_tomato_tthorp_thorp_ref_adapter.py`
+
+## Responsibilities
+
+1. preserve forcing-column normalization, datetime reconstruction, and fallback defaults for THORP reference runs
+2. bind the adapter to the migrated `stomatal_optimiaztion.domains.thorp` runtime instead of an external THORP checkout
+3. preserve the legacy-shaped output DataFrame with `theta_substrate`, `water_supply_stress`, `e`, `g_w`, `a_n`, and `r_d`
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/scripts/plot_simulation_png.py`
+- migrate `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py`
+- broaden into non-TOMATO reporting or visualization entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/scripts/plot_simulation_png.py`

--- a/docs/architecture/executor/issue-039-model-change.md
+++ b/docs/architecture/executor/issue-039-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 038` landed the TOMATO repo-level feature builder, so the next bounded TOMATO `tTHORP` seam is the THORP reference bridge at `models/thorp_ref/adapter.py`.
+- The migrated repo still lacks the adapter that reshapes tabular forcing into THORP forcing arrays and exposes THORP outputs through the TOMATO `tTHORP` DataFrame contract.
+- The current repository already contains a migrated `stomatal_optimiaztion.domains.thorp` runtime, so this seam should bind to that local surface instead of depending on an external THORP source checkout.
+
+## Affected model
+- `TOMATO tTHORP`
+- `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/`
+- related TOMATO THORP reference-adapter tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for forcing-column normalization, default fallback values, migrated THORP runtime binding, and adapter output shape
+
+## Comparison target
+- legacy `TOMATO/tTHORP/src/tthorp/models/thorp_ref/adapter.py`
+- legacy `TOMATO/tTHORP/src/tthorp/models/thorp_ref/__init__.py`
+- current migrated `stomatal_optimiaztion.domains.thorp` runtime surface

--- a/docs/architecture/executor/pr-073-tomato-thorp-reference-adapter.md
+++ b/docs/architecture/executor/pr-073-tomato-thorp-reference-adapter.md
@@ -1,0 +1,20 @@
+## Background
+- This PR lands `slice 039` by migrating the TOMATO `tTHORP` THORP reference adapter seam into the staged package layout.
+- The legacy adapter depended on external THORP source discovery, but the current repository already contains a migrated `domains.thorp` runtime surface.
+- Closing this seam moves the next TOMATO architectural uncertainty to the repo-level simulation plotting script at `scripts/plot_simulation_png.py`.
+
+## What Changed
+- add `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/adapter.py` and package exports
+- bind the adapter to migrated THORP defaults and `run()` instead of external source-path probing
+- add regression coverage for forcing normalization, empty-output handling, and a smoke path against the migrated THORP runtime
+- update architecture artifacts and README so `slice 039` is recorded and `scripts/plot_simulation_png.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- TOMATO `tTHORP` now has both the legacy tomato bridge and the THORP reference bridge inside the migrated repository
+- downstream TOMATO work can compare legacy and THORP-reference outputs without depending on a separate THORP checkout
+
+Closes #73

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the feature-builder script seam | the THORP reference adapter and remaining plotting/utility entrypoints can still hide legacy coupling assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the THORP reference adapter seam | the remaining plotting and reporting entrypoints can still hide output and dependency assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/__init__.py
@@ -15,6 +15,7 @@ from stomatal_optimiaztion.domains.tomato.tthorp.models.tomato_legacy import (
     iter_forcing_csv,
     make_tomato_legacy_model,
 )
+from stomatal_optimiaztion.domains.tomato.tthorp.models.thorp_ref import THORPReferenceAdapter
 from stomatal_optimiaztion.domains.tomato.tthorp.pipelines import (
     TomatoDayrunArtifacts,
     config_payload_for_exp_key,
@@ -42,6 +43,7 @@ __all__ = [
     "TomatoLegacyModule",
     "make_tomato_legacy_model",
     "TomatoModel",
+    "THORPReferenceAdapter",
     "create_sample_input_csv",
     "TomatoDayrunArtifacts",
     "resolve_repo_root",

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/__init__.py
@@ -1,3 +1,3 @@
-from stomatal_optimiaztion.domains.tomato.tthorp.models import tomato_legacy
+from stomatal_optimiaztion.domains.tomato.tthorp.models import thorp_ref, tomato_legacy
 
-__all__ = ["tomato_legacy"]
+__all__ = ["thorp_ref", "tomato_legacy"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/__init__.py
@@ -1,0 +1,3 @@
+from stomatal_optimiaztion.domains.tomato.tthorp.models.thorp_ref.adapter import THORPReferenceAdapter
+
+__all__ = ["THORPReferenceAdapter"]

--- a/src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/adapter.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/adapter.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from stomatal_optimiaztion.domains.thorp import Forcing, default_params, run, thorp_params_from_defaults
+from stomatal_optimiaztion.domains.thorp.params import THORPParams
+
+ParamsFactory = Callable[[], THORPParams]
+RunModel = Callable[..., object]
+
+
+def _default_params_factory() -> THORPParams:
+    return thorp_params_from_defaults(default_params())
+
+
+def _default_run_model(*, params: THORPParams, forcing: Forcing, max_steps: int | None) -> object:
+    return run(params=params, forcing=forcing, max_steps=max_steps)
+
+
+def _numeric_series(df: pd.DataFrame, candidates: tuple[str, ...], *, default: float, length: int) -> np.ndarray:
+    for name in candidates:
+        if name in df.columns:
+            values = pd.to_numeric(df[name], errors="coerce").to_numpy(dtype=float)
+            break
+    else:
+        values = np.full(df.shape[0], default, dtype=float)
+
+    finite = np.isfinite(values)
+    values = np.where(finite, values, default).astype(float, copy=False)
+    if values.size < length:
+        pad_value = float(values[-1]) if values.size else float(default)
+        values = np.concatenate([values, np.full(length - values.size, pad_value, dtype=float)])
+    elif values.size > length:
+        values = values[:length]
+    return values
+
+
+def _datetime_seconds(df: pd.DataFrame, *, length: int, default_dt_s: float = 6.0 * 3600.0) -> tuple[np.ndarray, pd.Timestamp]:
+    if "datetime" in df.columns:
+        dt = pd.to_datetime(df["datetime"], errors="coerce")
+        if dt.notna().all():
+            t0 = dt.iloc[0]
+            seconds = (dt - t0).dt.total_seconds().to_numpy(dtype=float)
+            positive_deltas = np.diff(seconds)
+            positive_deltas = positive_deltas[positive_deltas > 0]
+            dt_s = float(np.median(positive_deltas)) if positive_deltas.size else default_dt_s
+            if seconds.size < length:
+                extension = seconds[-1] + dt_s * np.arange(1, length - seconds.size + 1, dtype=float)
+                seconds = np.concatenate([seconds, extension])
+            elif seconds.size > length:
+                seconds = seconds[:length]
+            return seconds, t0
+
+    seconds = np.arange(length, dtype=float) * float(default_dt_s)
+    t0 = pd.Timestamp("1970-01-01T00:00:00")
+    return seconds, t0
+
+
+def _build_forcing(df: pd.DataFrame, *, max_steps: int | None) -> tuple[Forcing, pd.Timestamp, np.ndarray]:
+    if df.empty:
+        raise ValueError("forcing DataFrame must contain at least one row")
+
+    requested_steps = max(int(max_steps), 1) if max_steps is not None else max(df.shape[0] - 1, 1)
+    length = max(df.shape[0], requested_steps + 1)
+
+    t, t0 = _datetime_seconds(df, length=length)
+    t_a = _numeric_series(df, ("t_air_c", "T_air_C", "t_a"), default=25.0, length=length)
+    t_soil = _numeric_series(
+        df,
+        ("t_soil_c", "T_soil_C", "t_soil", "root_zone_temp_c"),
+        default=22.0,
+        length=length,
+    )
+    rh = _numeric_series(df, ("rh", "RH_percent"), default=0.6, length=length)
+    if np.nanmax(rh) > 1.0:
+        rh = rh / 100.0
+    rh = np.clip(rh, 0.0, 1.0)
+
+    forcing = Forcing(
+        t=t,
+        t_a=t_a,
+        t_soil=t_soil,
+        rh=rh,
+        precip=_numeric_series(df, ("precip", "precip_mm"), default=0.0, length=length),
+        u10=_numeric_series(df, ("u10", "wind_speed_m_s", "wind_speed_ms"), default=1.0, length=length),
+        r_incom=_numeric_series(df, ("r_incom_w_m2", "r_incom", "SW_in_Wm2"), default=400.0, length=length),
+        z_a=_numeric_series(df, ("z_a",), default=0.8, length=length),
+    )
+    theta = _numeric_series(df, ("theta_substrate",), default=0.35, length=length)
+    return forcing, t0, theta
+
+
+def _as_runtime_outputs(candidate: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        t_ts=np.asarray(getattr(candidate, "t_ts"), dtype=float),
+        e_ts=np.asarray(getattr(candidate, "e_ts"), dtype=float),
+        g_w_ts=np.asarray(getattr(candidate, "g_w_ts"), dtype=float),
+        a_n_ts=np.asarray(getattr(candidate, "a_n_ts"), dtype=float),
+        r_d_ts=np.asarray(getattr(candidate, "r_d_ts"), dtype=float),
+    )
+
+
+class THORPReferenceAdapter:
+    """Expose migrated THORP outputs through the legacy tTHORP DataFrame contract."""
+
+    def __init__(
+        self,
+        *,
+        params_factory: ParamsFactory | None = None,
+        run_model: RunModel | None = None,
+    ) -> None:
+        self._params_factory = params_factory or _default_params_factory
+        self._run_model = run_model or _default_run_model
+
+    def simulate(self, forcing: pd.DataFrame, *, max_steps: int | None = None) -> pd.DataFrame:
+        forcing_obj, t0, theta = _build_forcing(forcing, max_steps=max_steps)
+        out = _as_runtime_outputs(
+            self._run_model(
+                params=self._params_factory(),
+                forcing=forcing_obj,
+                max_steps=max_steps,
+            )
+        )
+
+        t_seconds = out.t_ts
+        if t_seconds.size == 0:
+            return pd.DataFrame(
+                columns=["datetime", "theta_substrate", "water_supply_stress", "e", "g_w", "a_n", "r_d"]
+            )
+
+        idx = np.searchsorted(forcing_obj.t, t_seconds, side="left")
+        idx = np.clip(idx, 0, forcing_obj.t.size - 1)
+
+        g_w = out.g_w_ts
+        finite_g_w = np.abs(g_w[np.isfinite(g_w)])
+        g_w_scale = float(np.nanmax(finite_g_w)) if finite_g_w.size else 0.0
+        g_w_scale = max(g_w_scale, 1e-12)
+        stress = np.clip(np.abs(g_w) / g_w_scale, 0.0, 1.0)
+
+        return pd.DataFrame(
+            {
+                "datetime": t0 + pd.to_timedelta(t_seconds, unit="s"),
+                "theta_substrate": theta[idx],
+                "water_supply_stress": stress,
+                "e": out.e_ts,
+                "g_w": g_w,
+                "a_n": out.a_n_ts,
+                "r_d": out.r_d_ts,
+            }
+        )

--- a/tests/test_tomato_tthorp_thorp_ref_adapter.py
+++ b/tests/test_tomato_tthorp_thorp_ref_adapter.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+from numpy.testing import assert_allclose
+
+from stomatal_optimiaztion.domains.tomato.tthorp.models.thorp_ref import THORPReferenceAdapter
+
+
+def test_thorp_reference_adapter_normalizes_forcing_and_maps_outputs() -> None:
+    captures: dict[str, object] = {}
+    sentinel_params = object()
+
+    def params_factory() -> object:
+        return sentinel_params
+
+    def run_model(*, params: object, forcing: object, max_steps: int | None) -> object:
+        captures["params"] = params
+        captures["forcing"] = forcing
+        captures["max_steps"] = max_steps
+        return SimpleNamespace(
+            t_ts=np.array([0.0, 6.0 * 3600.0, 12.0 * 3600.0], dtype=float),
+            e_ts=np.array([0.1, 0.2, 0.3], dtype=float),
+            g_w_ts=np.array([0.0, 0.2, -0.4], dtype=float),
+            a_n_ts=np.array([1.0, 2.0, 3.0], dtype=float),
+            r_d_ts=np.array([0.01, 0.02, 0.03], dtype=float),
+        )
+
+    forcing = pd.DataFrame(
+        {
+            "datetime": [datetime(2026, 1, 1, 0, 0, 0), datetime(2026, 1, 1, 6, 0, 0)],
+            "t_air_c": [24.0, 26.0],
+            "t_soil_c": [20.0, 21.0],
+            "rh": [60.0, 70.0],
+            "precip_mm": [0.0, 1.5],
+            "wind_speed_ms": [1.2, 1.4],
+            "SW_in_Wm2": [100.0, 120.0],
+            "theta_substrate": [0.30, 0.31],
+        }
+    )
+
+    adapter = THORPReferenceAdapter(params_factory=params_factory, run_model=run_model)
+    out = adapter.simulate(forcing, max_steps=3)
+
+    forcing_obj = captures["forcing"]
+    assert captures["params"] is sentinel_params
+    assert captures["max_steps"] == 3
+
+    assert_allclose(getattr(forcing_obj, "t"), np.array([0.0, 21600.0, 43200.0, 64800.0]))
+    assert_allclose(getattr(forcing_obj, "t_a"), np.array([24.0, 26.0, 26.0, 26.0]))
+    assert_allclose(getattr(forcing_obj, "t_soil"), np.array([20.0, 21.0, 21.0, 21.0]))
+    assert_allclose(getattr(forcing_obj, "rh"), np.array([0.6, 0.7, 0.7, 0.7]))
+    assert_allclose(getattr(forcing_obj, "precip"), np.array([0.0, 1.5, 1.5, 1.5]))
+    assert_allclose(getattr(forcing_obj, "u10"), np.array([1.2, 1.4, 1.4, 1.4]))
+    assert_allclose(getattr(forcing_obj, "r_incom"), np.array([100.0, 120.0, 120.0, 120.0]))
+    assert_allclose(getattr(forcing_obj, "z_a"), np.array([0.8, 0.8, 0.8, 0.8]))
+
+    assert list(out.columns) == [
+        "datetime",
+        "theta_substrate",
+        "water_supply_stress",
+        "e",
+        "g_w",
+        "a_n",
+        "r_d",
+    ]
+    assert out["datetime"].tolist() == [
+        pd.Timestamp("2026-01-01 00:00:00"),
+        pd.Timestamp("2026-01-01 06:00:00"),
+        pd.Timestamp("2026-01-01 12:00:00"),
+    ]
+    assert_allclose(out["theta_substrate"].to_numpy(dtype=float), np.array([0.30, 0.31, 0.31]))
+    assert_allclose(out["water_supply_stress"].to_numpy(dtype=float), np.array([0.0, 0.5, 1.0]))
+    assert_allclose(out["e"].to_numpy(dtype=float), np.array([0.1, 0.2, 0.3]))
+    assert_allclose(out["g_w"].to_numpy(dtype=float), np.array([0.0, 0.2, -0.4]))
+    assert_allclose(out["a_n"].to_numpy(dtype=float), np.array([1.0, 2.0, 3.0]))
+    assert_allclose(out["r_d"].to_numpy(dtype=float), np.array([0.01, 0.02, 0.03]))
+
+
+def test_thorp_reference_adapter_returns_empty_frame_when_runtime_outputs_empty() -> None:
+    adapter = THORPReferenceAdapter(
+        params_factory=lambda: object(),
+        run_model=lambda **_: SimpleNamespace(
+            t_ts=np.array([], dtype=float),
+            e_ts=np.array([], dtype=float),
+            g_w_ts=np.array([], dtype=float),
+            a_n_ts=np.array([], dtype=float),
+            r_d_ts=np.array([], dtype=float),
+        ),
+    )
+
+    out = adapter.simulate(pd.DataFrame({"datetime": [datetime(2026, 1, 1, 0, 0, 0)]}))
+
+    assert out.empty
+    assert list(out.columns) == [
+        "datetime",
+        "theta_substrate",
+        "water_supply_stress",
+        "e",
+        "g_w",
+        "a_n",
+        "r_d",
+    ]
+
+
+def test_thorp_reference_adapter_smoke_with_migrated_runtime() -> None:
+    start = datetime(2026, 1, 1, 0, 0, 0)
+    steps = 20
+    forcing = pd.DataFrame(
+        {
+            "datetime": [start + i * timedelta(hours=6) for i in range(steps)],
+            "theta_substrate": np.full(steps, 0.33),
+            "t_air_c": np.full(steps, 25.0),
+            "t_soil_c": np.full(steps, 22.0),
+            "rh": np.full(steps, 0.60),
+            "r_incom_w_m2": np.full(steps, 400.0),
+            "u10": np.full(steps, 1.0),
+            "precip": np.zeros(steps),
+            "z_a": np.full(steps, 0.8),
+        }
+    )
+
+    model = THORPReferenceAdapter()
+    out = model.simulate(forcing, max_steps=steps)
+
+    expected_columns = {
+        "datetime",
+        "theta_substrate",
+        "water_supply_stress",
+        "e",
+        "g_w",
+        "a_n",
+        "r_d",
+    }
+    assert expected_columns.issubset(out.columns)
+    assert not out.empty
+    assert out["datetime"].is_monotonic_increasing
+
+    numeric = out[["theta_substrate", "water_supply_stress", "e", "g_w", "a_n", "r_d"]].to_numpy(dtype=float)
+    assert np.isfinite(numeric).all()


### PR DESCRIPTION
## Background
- This PR lands `slice 039` by migrating the TOMATO `tTHORP` THORP reference adapter seam into the staged package layout.
- The legacy adapter depended on external THORP source discovery, but the current repository already contains a migrated `domains.thorp` runtime surface.
- Closing this seam moves the next TOMATO architectural uncertainty to the repo-level simulation plotting script at `scripts/plot_simulation_png.py`.

## What Changed
- add `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/adapter.py` and package exports
- bind the adapter to migrated THORP defaults and `run()` instead of external source-path probing
- add regression coverage for forcing normalization, empty-output handling, and a smoke path against the migrated THORP runtime
- update architecture artifacts and README so `slice 039` is recorded and `scripts/plot_simulation_png.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- TOMATO `tTHORP` now has both the legacy tomato bridge and the THORP reference bridge inside the migrated repository
- downstream TOMATO work can compare legacy and THORP-reference outputs without depending on a separate THORP checkout

Closes #73
