### PR TITLE
[Model Change] Migrate TOMATO tTHORP simulation plotting script seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-039 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, and THORP reference adapter seams
-- Next blocked seam: TOMATO `tTHORP` simulation plotting script at `scripts/plot_simulation_png.py`
+- Slices 025-040 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, and simulation plotting seams
+- Next blocked seam: TOMATO `tTHORP` allocation-comparison plotting script at `scripts/plot_allocation_compare_png.py`

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` repo-level pipeline script seam is migrated as slice 037.
 - TOMATO `tTHORP` feature-builder script seam is migrated as slice 038.
 - TOMATO `tTHORP` THORP reference adapter seam is migrated as slice 039.
+- TOMATO `tTHORP` simulation plotting script seam is migrated as slice 040.
 
 ## Next validation
-- Audit the TOMATO simulation plotting seam at `scripts/plot_simulation_png.py`.
+- Audit the TOMATO allocation-comparison plotting seam at `scripts/plot_allocation_compare_png.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 039
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 039 approved for TOMATO
+- Gate C. Validation plan ready through slice 040
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 040 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -281,3 +281,9 @@ Slice 039:
 - target: `src/stomatal_optimiaztion/domains/tomato/tthorp/models/thorp_ref/`, package exports, and `tests/test_tomato_tthorp_thorp_ref_adapter.py`
 - scope: bounded TOMATO THORP-reference bridge covering forcing-column normalization, migrated THORP runtime binding, and legacy-shaped DataFrame outputs
 - excluded: repo-level plotting scripts, PNG summary generation, and broader non-TOMATO entrypoints
+
+Slice 040:
+- source: `TOMATO/tTHORP/scripts/plot_simulation_png.py`
+- target: `scripts/plot_simulation_png.py` and `tests/test_tomato_tthorp_plot_simulation_png_script.py`
+- scope: bounded TOMATO repo-level plotting surface covering CLI parsing, CSV subsampling, four-panel simulation-summary plotting, and optional matplotlib dependency behavior
+- excluded: `scripts/plot_allocation_compare_png.py`, shared plotting packages, and broader non-TOMATO reporting entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -356,8 +356,16 @@ The thirty-ninth slice opens the next bounded TOMATO seam:
 - preserve forcing-column normalization, default fallback values, and the legacy-shaped output DataFrame contract
 - leave `scripts/plot_simulation_png.py` blocked as the next seam
 
+## Slice 040: TOMATO tTHORP Simulation Plotting Script
+
+The fortieth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/scripts/plot_simulation_png.py` into the repo-local `scripts/` surface
+- preserve CLI parsing, CSV subsampling, four-panel simulation-summary plotting, and printed output-path behavior
+- keep `matplotlib` as an optional plotting dependency instead of widening the core package runtime
+- leave `scripts/plot_allocation_compare_png.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first fifteen TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first sixteen TOMATO `tTHORP` seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `scripts/plot_simulation_png.py`
+3. prepare the next TOMATO source audit for `scripts/plot_allocation_compare_png.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 039 completed and slice 040 planning
+- Current phase: slice 040 completed and slice 041 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO simulation plotting seam at `scripts/plot_simulation_png.py`
-2. decide whether plotting dependencies should remain optional repo-level tooling or move into the migrated package surface
+1. audit the TOMATO allocation-comparison plotting seam at `scripts/plot_allocation_compare_png.py`
+2. decide whether the remaining plotting helpers can share a bounded repo-level plotting convention without creating a premature shared package
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-040-tomato-tthorp-simulation-plotting-script.md
+++ b/docs/architecture/architecture/module_specs/module-040-tomato-tthorp-simulation-plotting-script.md
@@ -1,0 +1,35 @@
+# Module Spec 040: TOMATO tTHORP Simulation Plotting Script
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the repo-level plotting script that renders simulation CSV outputs into a four-panel PNG summary.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/scripts/plot_simulation_png.py`
+
+## Target Outputs
+
+- `scripts/plot_simulation_png.py`
+- `tests/test_tomato_tthorp_plot_simulation_png_script.py`
+
+## Responsibilities
+
+1. preserve CLI parsing for input path, output path, row stride, and DPI
+2. preserve CSV subsampling and the four-panel simulation-summary plotting layout
+3. keep matplotlib optional and fail with a clear error when the plotting dependency is unavailable
+
+## Non-Goals
+
+- migrate `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py`
+- introduce a shared plotting package or repo-wide visualization layer
+- widen the migrated core package runtime dependency surface
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py`

--- a/docs/architecture/executor/issue-040-model-change.md
+++ b/docs/architecture/executor/issue-040-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 039` landed the TOMATO THORP reference adapter, so the next bounded TOMATO `tTHORP` seam is the repo-level simulation plotting script at `scripts/plot_simulation_png.py`.
+- The migrated repo still lacks the CLI wrapper that reads simulation CSV outputs, subsamples rows, and renders the legacy four-panel PNG summary for canopy, biomass, flux, and allocation diagnostics.
+- This plotting seam should remain a repo-level utility with an optional `matplotlib` dependency instead of widening the package runtime surface.
+
+## Affected model
+- `TOMATO tTHORP`
+- `scripts/plot_simulation_png.py`
+- related TOMATO plotting tests and architecture docs
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for CLI argument parsing, CSV subsampling, optional plotting dependency behavior, and deterministic output-path printing
+
+## Comparison target
+- legacy `TOMATO/tTHORP/scripts/plot_simulation_png.py`
+- current migrated TOMATO repo-level scripts and architecture slice records

--- a/docs/architecture/executor/pr-075-tomato-simulation-plotting-script.md
+++ b/docs/architecture/executor/pr-075-tomato-simulation-plotting-script.md
@@ -1,0 +1,19 @@
+## Background
+- This PR lands `slice 040` by migrating the TOMATO `tTHORP` repo-level simulation plotting script.
+- The script is kept as repo-level tooling and continues to treat `matplotlib` as an optional plotting dependency rather than a core package requirement.
+- Closing this seam moves the next TOMATO architectural uncertainty to the allocation-comparison plotting script at `scripts/plot_allocation_compare_png.py`.
+
+## What Changed
+- add `scripts/plot_simulation_png.py`
+- add regression coverage for CLI parsing, CSV subsampling, output-path printing, and optional matplotlib error behavior
+- update architecture artifacts and README so `slice 040` is recorded and `scripts/plot_allocation_compare_png.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- TOMATO `tTHORP` now has a migrated repo-level plotting entrypoint for simulation summary PNG generation
+- downstream review of legacy-vs-migrated outputs can reuse one bounded plotting utility without introducing plotting dependencies into the core runtime
+
+Closes #75

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the THORP reference adapter seam | the remaining plotting and reporting entrypoints can still hide output and dependency assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the simulation plotting seam | the remaining allocation-comparison plotting and reporting entrypoints can still hide output and dependency assumptions | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/scripts/plot_simulation_png.py
+++ b/scripts/plot_simulation_png.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plot tomato simulation CSV outputs to a PNG summary.")
+    parser.add_argument(
+        "--input",
+        default="data/output/KNU_Tomato_Env__sim.csv",
+        help="Input CSV path (model outputs).",
+    )
+    parser.add_argument(
+        "--output",
+        default="data/output/KNU_Tomato_Env__sim.summary.png",
+        help="Output PNG path.",
+    )
+    parser.add_argument(
+        "--every",
+        type=int,
+        default=10,
+        help="Row stride for plotting (e.g., 10 plots every 10th row).",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=160,
+        help="PNG DPI.",
+    )
+    return parser
+
+
+def _maybe_get(df: pd.DataFrame, column: str) -> pd.Series | None:
+    if column not in df.columns:
+        return None
+    return pd.to_numeric(df[column], errors="coerce")
+
+
+def _plot(df: pd.DataFrame, *, out_path: Path, dpi: int) -> None:
+    try:
+        import matplotlib.dates as mdates
+        import matplotlib.pyplot as plt
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "Plotting requires matplotlib. Install with: python -m pip install matplotlib"
+        ) from exc
+
+    x = df["datetime"]
+
+    fig, axes = plt.subplots(nrows=4, ncols=1, sharex=True, figsize=(14, 10), constrained_layout=True)
+
+    ax = axes[0]
+    lai = _maybe_get(df, "LAI")
+    t_canopy = _maybe_get(df, "T_canopy_C")
+    if lai is not None:
+        ax.plot(x, lai, label="LAI", color="tab:green", linewidth=1.0)
+        ax.set_ylabel("LAI")
+    if t_canopy is not None:
+        ax2 = ax.twinx()
+        ax2.plot(x, t_canopy, label="T_canopy_C", color="tab:red", linewidth=1.0, alpha=0.8)
+        ax2.set_ylabel("T_canopy (C)")
+    ax.grid(True, alpha=0.25)
+    ax.set_title("tTHORP Tomato Legacy Simulation Summary")
+
+    ax = axes[1]
+    total_dw = _maybe_get(df, "total_dry_weight_g_m2")
+    leaf_dw = _maybe_get(df, "leaf_dry_weight_g_m2")
+    stem_dw = _maybe_get(df, "stem_dry_weight_g_m2")
+    root_dw = _maybe_get(df, "root_dry_weight_g_m2")
+    fruit_dw = _maybe_get(df, "fruit_dry_weight_g_m2")
+    if total_dw is not None:
+        ax.plot(x, total_dw, label="total", color="black", linewidth=1.0)
+    if leaf_dw is not None:
+        ax.plot(x, leaf_dw, label="leaf", linewidth=0.9)
+    if stem_dw is not None:
+        ax.plot(x, stem_dw, label="stem", linewidth=0.9)
+    if root_dw is not None:
+        ax.plot(x, root_dw, label="root", linewidth=0.9)
+    if fruit_dw is not None:
+        ax.plot(x, fruit_dw, label="fruit", linewidth=0.9)
+    ax.set_ylabel("Dry weight (g/m2)")
+    ax.grid(True, alpha=0.25)
+    ax.legend(loc="upper left", ncols=5, fontsize=9)
+
+    ax = axes[2]
+    co2_flux = _maybe_get(df, "co2_flux_g_m2_s")
+    transp_rate = _maybe_get(df, "transpiration_rate_g_s_m2")
+    if co2_flux is not None:
+        ax.plot(x, co2_flux, label="co2_flux_g_m2_s", color="tab:blue", linewidth=0.9)
+        ax.set_ylabel("CO2 flux (g/m2/s)")
+    if transp_rate is not None:
+        ax2 = ax.twinx()
+        ax2.plot(x, transp_rate, label="transpiration_rate_g_s_m2", color="tab:purple", linewidth=0.9, alpha=0.8)
+        ax2.set_ylabel("Transp. rate (g/m2/s)")
+    ax.grid(True, alpha=0.25)
+
+    ax = axes[3]
+    for col, label, color in (
+        ("alloc_frac_fruit", "fruit", "tab:orange"),
+        ("alloc_frac_leaf", "leaf", "tab:green"),
+        ("alloc_frac_stem", "stem", "tab:brown"),
+        ("alloc_frac_root", "root", "tab:gray"),
+        ("alloc_frac_shoot", "shoot", "tab:cyan"),
+    ):
+        series = _maybe_get(df, col)
+        if series is None:
+            continue
+        ax.plot(x, series, label=label, linewidth=0.9, alpha=0.9, color=color)
+    ax.set_ylabel("Allocation fraction (-)")
+    ax.set_ylim(-0.05, 1.05)
+    ax.grid(True, alpha=0.25)
+    ax.legend(loc="upper left", ncols=5, fontsize=9)
+
+    locator = mdates.AutoDateLocator(minticks=4, maxticks=10)
+    axes[-1].xaxis.set_major_locator(locator)
+    axes[-1].xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+    axes[-1].set_xlabel("datetime")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=int(dpi), bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    input_path = Path(args.input).resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input CSV not found: {input_path}")
+
+    every = max(int(args.every), 1)
+    df = pd.read_csv(input_path, parse_dates=["datetime"])
+    if df.empty:
+        raise ValueError(f"Input CSV is empty: {input_path}")
+
+    df_plot = df.iloc[::every].copy()
+    out_path = Path(args.output).resolve()
+    _plot(df_plot, out_path=out_path, dpi=int(args.dpi))
+    print(out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tomato_tthorp_plot_simulation_png_script.py
+++ b/tests/test_tomato_tthorp_plot_simulation_png_script.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "plot_simulation_png.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("plot_simulation_png_script", _script_path())
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load plot_simulation_png.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plot_simulation_script_main_subsamples_rows_and_prints_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+    input_path = tmp_path / "simulation.csv"
+    output_path = tmp_path / "out" / "summary.png"
+
+    pd.DataFrame(
+        {
+            "datetime": pd.date_range("2026-01-01", periods=5, freq="6h"),
+            "LAI": [1.0, 1.1, 1.2, 1.3, 1.4],
+            "total_dry_weight_g_m2": [10, 11, 12, 13, 14],
+        }
+    ).to_csv(input_path, index=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_plot(df: pd.DataFrame, *, out_path: Path, dpi: int) -> None:
+        captured["rows"] = len(df)
+        captured["datetimes"] = list(df["datetime"])
+        captured["out_path"] = out_path
+        captured["dpi"] = dpi
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text("fake-png", encoding="utf-8")
+
+    monkeypatch.setattr(module, "_plot", fake_plot)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(_script_path()),
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--every",
+            "2",
+            "--dpi",
+            "200",
+        ],
+    )
+
+    assert module.main() == 0
+    assert captured["rows"] == 3
+    assert captured["dpi"] == 200
+    assert captured["out_path"] == output_path.resolve()
+    assert output_path.exists()
+    assert Path(capsys.readouterr().out.strip()) == output_path.resolve()
+
+
+def test_plot_simulation_script_rejects_empty_input_csv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module()
+    input_path = tmp_path / "empty.csv"
+    pd.DataFrame(columns=["datetime"]).to_csv(input_path, index=False)
+
+    monkeypatch.setattr(sys, "argv", [str(_script_path()), "--input", str(input_path)])
+
+    with pytest.raises(ValueError, match="Input CSV is empty"):
+        module.main()
+
+
+def test_plot_simulation_script_plot_raises_helpful_error_without_matplotlib(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module()
+    df = pd.DataFrame({"datetime": pd.date_range("2026-01-01", periods=2, freq="6h"), "LAI": [1.0, 1.1]})
+    out_path = tmp_path / "summary.png"
+    real_import = builtins.__import__
+
+    def fake_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        if name.startswith("matplotlib"):
+            raise ModuleNotFoundError("No module named 'matplotlib'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError, match="Plotting requires matplotlib"):
+        module._plot(df, out_path=out_path, dpi=160)


### PR DESCRIPTION
## Background
- This PR lands `slice 040` by migrating the TOMATO `tTHORP` repo-level simulation plotting script.
- The script is kept as repo-level tooling and continues to treat `matplotlib` as an optional plotting dependency rather than a core package requirement.
- Closing this seam moves the next TOMATO architectural uncertainty to the allocation-comparison plotting script at `scripts/plot_allocation_compare_png.py`.

## What Changed
- add `scripts/plot_simulation_png.py`
- add regression coverage for CLI parsing, CSV subsampling, output-path printing, and optional matplotlib error behavior
- update architecture artifacts and README so `slice 040` is recorded and `scripts/plot_allocation_compare_png.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- TOMATO `tTHORP` now has a migrated repo-level plotting entrypoint for simulation summary PNG generation
- downstream review of legacy-vs-migrated outputs can reuse one bounded plotting utility without introducing plotting dependencies into the core runtime

Closes #75
