### PR TITLE
[Model Change] Migrate TOMATO tTHORP allocation-comparison plotting script seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-040 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, and simulation plotting seams
-- Next blocked seam: TOMATO `tTHORP` allocation-comparison plotting script at `scripts/plot_allocation_compare_png.py`
+- Slices 025-041 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, and plotting seams
+- Next blocked seam: TOMATO `tGOSM` contracts seam at `src/tgosm/contracts.py`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` feature-builder script seam is migrated as slice 038.
 - TOMATO `tTHORP` THORP reference adapter seam is migrated as slice 039.
 - TOMATO `tTHORP` simulation plotting script seam is migrated as slice 040.
+- TOMATO `tTHORP` allocation-comparison plotting script seam is migrated as slice 041.
 
 ## Next validation
-- Audit the TOMATO allocation-comparison plotting seam at `scripts/plot_allocation_compare_png.py`.
+- Audit the TOMATO `tGOSM` contracts seam at `src/tgosm/contracts.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 040
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 040 approved for TOMATO
+- Gate C. Validation plan ready through slice 041
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 041 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -287,3 +287,9 @@ Slice 040:
 - target: `scripts/plot_simulation_png.py` and `tests/test_tomato_tthorp_plot_simulation_png_script.py`
 - scope: bounded TOMATO repo-level plotting surface covering CLI parsing, CSV subsampling, four-panel simulation-summary plotting, and optional matplotlib dependency behavior
 - excluded: `scripts/plot_allocation_compare_png.py`, shared plotting packages, and broader non-TOMATO reporting entrypoints
+
+Slice 041:
+- source: `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py`
+- target: `scripts/plot_allocation_compare_png.py` and `tests/test_tomato_tthorp_plot_allocation_compare_png_script.py`
+- scope: bounded TOMATO repo-level allocation-comparison plotting surface covering CSV alignment, allocation-column reshaping, overlap filtering, subsampling, and optional matplotlib dependency behavior
+- excluded: `tGOSM`, `tTDGM`, shared plotting packages, and broader non-TOMATO reporting entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -364,8 +364,16 @@ The fortieth slice opens the next bounded TOMATO seam:
 - keep `matplotlib` as an optional plotting dependency instead of widening the core package runtime
 - leave `scripts/plot_allocation_compare_png.py` blocked as the next seam
 
+## Slice 041: TOMATO tTHORP Allocation-Comparison Plotting Script
+
+The forty-first slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py` into the repo-local `scripts/` surface
+- preserve allocation-column ingestion, datetime alignment, overlap filtering, subsampling, and four-panel comparison plotting behavior
+- keep `matplotlib` as an optional plotting dependency instead of widening the core package runtime
+- leave `TOMATO/tGOSM/src/tgosm/contracts.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first sixteen TOMATO `tTHORP` seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first seventeen TOMATO bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `scripts/plot_allocation_compare_png.py`
+3. prepare the next TOMATO source audit for `TOMATO/tGOSM/src/tgosm/contracts.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 040 completed and slice 041 planning
+- Current phase: slice 041 completed and slice 042 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO allocation-comparison plotting seam at `scripts/plot_allocation_compare_png.py`
-2. decide whether the remaining plotting helpers can share a bounded repo-level plotting convention without creating a premature shared package
+1. audit the TOMATO `tGOSM` contracts seam at `src/tgosm/contracts.py`
+2. decide whether `tGOSM` should mirror the `tTHORP` contract/interface-first migration order or needs a different package boundary
 3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-041-tomato-tthorp-allocation-compare-plotting-script.md
+++ b/docs/architecture/architecture/module_specs/module-041-tomato-tthorp-allocation-compare-plotting-script.md
@@ -1,0 +1,35 @@
+# Module Spec 041: TOMATO tTHORP Allocation-Comparison Plotting Script
+
+## Purpose
+
+Open the next bounded TOMATO `tTHORP` seam by porting the repo-level plotting script that compares allocation-fraction time series between baseline and candidate simulation CSV outputs.
+
+## Source Inputs
+
+- `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py`
+
+## Target Outputs
+
+- `scripts/plot_allocation_compare_png.py`
+- `tests/test_tomato_tthorp_plot_allocation_compare_png_script.py`
+
+## Responsibilities
+
+1. preserve CLI parsing for baseline/candidate paths, legend labels, output path, row stride, and DPI
+2. preserve allocation-column ingestion, datetime alignment, overlap filtering, subsampling, and four-panel comparison plotting behavior
+3. keep matplotlib optional and fail with a clear error when the plotting dependency is unavailable
+
+## Non-Goals
+
+- migrate `TOMATO/tGOSM/src/tgosm/contracts.py`
+- introduce a shared plotting package or repo-wide visualization layer
+- widen the migrated core package runtime dependency surface
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tGOSM/src/tgosm/contracts.py`

--- a/docs/architecture/executor/issue-041-model-change.md
+++ b/docs/architecture/executor/issue-041-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 040` landed the TOMATO simulation plotting script, so the next bounded TOMATO `tTHORP` seam is the allocation-comparison plotting script at `scripts/plot_allocation_compare_png.py`.
+- The migrated repo still lacks the CLI utility that compares baseline and candidate simulation CSV outputs, aligns them on `datetime`, and renders the legacy four-panel allocation-fraction comparison PNG.
+- This seam should remain repo-level tooling with an optional `matplotlib` dependency instead of widening the package runtime surface.
+
+## Affected model
+- `TOMATO tTHORP`
+- `scripts/plot_allocation_compare_png.py`
+- related TOMATO plotting tests and architecture docs
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for CLI parsing, allocation-column ingestion, overlap filtering, subsampling, and optional plotting dependency behavior
+
+## Comparison target
+- legacy `TOMATO/tTHORP/scripts/plot_allocation_compare_png.py`
+- current migrated TOMATO repo-level plotting utilities and architecture slice records

--- a/docs/architecture/executor/pr-077-tomato-allocation-compare-plotting-script.md
+++ b/docs/architecture/executor/pr-077-tomato-allocation-compare-plotting-script.md
@@ -1,0 +1,19 @@
+## Background
+- This PR lands `slice 041` by migrating the TOMATO `tTHORP` repo-level allocation-comparison plotting script.
+- The script remains repo-level tooling and continues to treat `matplotlib` as an optional plotting dependency rather than a core package requirement.
+- Closing this seam completes the bounded `tTHORP` plotting utilities and moves the next TOMATO architectural uncertainty to the `tGOSM` contracts seam.
+
+## What Changed
+- add `scripts/plot_allocation_compare_png.py`
+- add regression coverage for allocation-column ingestion, overlap filtering, subsampling, output-path printing, and optional matplotlib error behavior
+- update architecture artifacts and README so `slice 041` is recorded and `TOMATO/tGOSM/src/tgosm/contracts.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- TOMATO `tTHORP` now has both repo-level plotting utilities migrated inside the current repository
+- the next TOMATO migration loop can move from `tTHORP` scripts into `tGOSM` package contracts without reopening unresolved plotting assumptions
+
+Closes #77

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the simulation plotting seam | the remaining allocation-comparison plotting and reporting entrypoints can still hide output and dependency assumptions | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the completed `tTHORP` plotting seams | `tGOSM` and `tTDGM` package contracts remain unmigrated, so cross-model boundary assumptions are still implicit | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/scripts/plot_allocation_compare_png.py
+++ b/scripts/plot_allocation_compare_png.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+ALLOC_COLS: tuple[str, ...] = (
+    "alloc_frac_fruit",
+    "alloc_frac_leaf",
+    "alloc_frac_stem",
+    "alloc_frac_root",
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compare allocation fractions between two simulation CSV outputs.")
+    parser.add_argument(
+        "--baseline",
+        default="data/output/KNU_Tomato_Env__sim.csv",
+        help="Baseline (legacy) simulation CSV.",
+    )
+    parser.add_argument(
+        "--candidate",
+        default="data/output/KNU_Tomato_Env__thorp_fruit_veg_4pool.csv",
+        help="Candidate simulation CSV to compare against baseline.",
+    )
+    parser.add_argument(
+        "--baseline-label",
+        default="legacy (sink_based)",
+        help="Legend label for baseline.",
+    )
+    parser.add_argument(
+        "--candidate-label",
+        default="THORP (thorp_fruit_veg, 4pool)",
+        help="Legend label for candidate.",
+    )
+    parser.add_argument(
+        "--output",
+        default="data/output/KNU_Tomato_Env__alloc_frac_compare.png",
+        help="Output PNG path.",
+    )
+    parser.add_argument(
+        "--every",
+        type=int,
+        default=60,
+        help="Row stride for plotting (e.g., 60 plots every 60th row).",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=170,
+        help="PNG DPI.",
+    )
+    return parser
+
+
+def _read_alloc_csv(path: Path, *, suffix: str) -> pd.DataFrame:
+    cols = ["datetime", *ALLOC_COLS]
+    df = pd.read_csv(path, usecols=cols, parse_dates=["datetime"])
+    missing = [c for c in cols if c not in df.columns]
+    if missing:
+        raise KeyError(f"Missing required columns in {path}: {missing}")
+
+    rename_map = {col: f"{col}{suffix}" for col in ALLOC_COLS}
+    return df.rename(columns=rename_map).sort_values("datetime").reset_index(drop=True)
+
+
+def _plot(
+    merged: pd.DataFrame,
+    *,
+    baseline_label: str,
+    candidate_label: str,
+    out_path: Path,
+    dpi: int,
+) -> None:
+    try:
+        import matplotlib.dates as mdates
+        import matplotlib.pyplot as plt
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "Plotting requires matplotlib. Install with: python -m pip install matplotlib"
+        ) from exc
+
+    x = merged["datetime"]
+
+    fig, axes = plt.subplots(nrows=4, ncols=1, sharex=True, figsize=(14, 10), constrained_layout=True)
+    mapping = (
+        ("fruit", "alloc_frac_fruit"),
+        ("leaf", "alloc_frac_leaf"),
+        ("stem", "alloc_frac_stem"),
+        ("root", "alloc_frac_root"),
+    )
+
+    for ax, (name, col) in zip(axes, mapping, strict=True):
+        base = pd.to_numeric(merged[f"{col}__baseline"], errors="coerce")
+        cand = pd.to_numeric(merged[f"{col}__candidate"], errors="coerce")
+
+        ax.plot(x, base, label=baseline_label, color="black", linewidth=0.9, alpha=0.85)
+        ax.plot(x, cand, label=candidate_label, color="tab:blue", linewidth=0.9, alpha=0.85)
+        ax.set_ylabel(f"{name} (-)")
+        ax.set_ylim(-0.05, 1.05)
+        ax.grid(True, alpha=0.25)
+        if ax is axes[0]:
+            ax.legend(loc="upper left", fontsize=9)
+
+    locator = mdates.AutoDateLocator(minticks=4, maxticks=10)
+    axes[-1].xaxis.set_major_locator(locator)
+    axes[-1].xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+    axes[-1].set_xlabel("datetime")
+
+    axes[0].set_title("Allocation Fractions Comparison")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=int(dpi), bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    baseline_path = Path(args.baseline).resolve()
+    candidate_path = Path(args.candidate).resolve()
+    if not baseline_path.exists():
+        raise FileNotFoundError(f"Baseline CSV not found: {baseline_path}")
+    if not candidate_path.exists():
+        raise FileNotFoundError(f"Candidate CSV not found: {candidate_path}")
+
+    baseline = _read_alloc_csv(baseline_path, suffix="__baseline")
+    candidate = _read_alloc_csv(candidate_path, suffix="__candidate")
+
+    merged = pd.merge(baseline, candidate, on="datetime", how="inner")
+    if merged.empty:
+        raise ValueError("No overlapping datetime rows between baseline and candidate.")
+
+    every = max(int(args.every), 1)
+    merged_plot = merged.iloc[::every].copy()
+
+    out_path = Path(args.output).resolve()
+    _plot(
+        merged_plot,
+        baseline_label=str(args.baseline_label),
+        candidate_label=str(args.candidate_label),
+        out_path=out_path,
+        dpi=int(args.dpi),
+    )
+    print(out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tomato_tthorp_plot_allocation_compare_png_script.py
+++ b/tests/test_tomato_tthorp_plot_allocation_compare_png_script.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "plot_allocation_compare_png.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("plot_allocation_compare_png_script", _script_path())
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load plot_allocation_compare_png.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_alloc_csv(path: Path, *, timestamps: list[str], fruit: list[float]) -> None:
+    pd.DataFrame(
+        {
+            "datetime": timestamps,
+            "alloc_frac_fruit": fruit,
+            "alloc_frac_leaf": [0.2] * len(timestamps),
+            "alloc_frac_stem": [0.3] * len(timestamps),
+            "alloc_frac_root": [0.4] * len(timestamps),
+        }
+    ).to_csv(path, index=False)
+
+
+def test_plot_allocation_compare_script_reads_and_renames_alloc_columns(tmp_path: Path) -> None:
+    module = _load_script_module()
+    input_path = tmp_path / "baseline.csv"
+    _write_alloc_csv(
+        input_path,
+        timestamps=["2026-01-01T12:00:00", "2026-01-01T00:00:00"],
+        fruit=[0.6, 0.4],
+    )
+
+    out = module._read_alloc_csv(input_path, suffix="__baseline")
+
+    assert list(out.columns) == [
+        "datetime",
+        "alloc_frac_fruit__baseline",
+        "alloc_frac_leaf__baseline",
+        "alloc_frac_stem__baseline",
+        "alloc_frac_root__baseline",
+    ]
+    assert out["datetime"].tolist() == [
+        pd.Timestamp("2026-01-01 00:00:00"),
+        pd.Timestamp("2026-01-01 12:00:00"),
+    ]
+
+
+def test_plot_allocation_compare_script_main_merges_subsamples_and_prints_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+    baseline_path = tmp_path / "baseline.csv"
+    candidate_path = tmp_path / "candidate.csv"
+    output_path = tmp_path / "out" / "alloc.png"
+    timestamps = [
+        "2026-01-01T00:00:00",
+        "2026-01-01T06:00:00",
+        "2026-01-01T12:00:00",
+        "2026-01-01T18:00:00",
+    ]
+    _write_alloc_csv(baseline_path, timestamps=timestamps, fruit=[0.1, 0.2, 0.3, 0.4])
+    _write_alloc_csv(candidate_path, timestamps=timestamps, fruit=[0.2, 0.3, 0.4, 0.5])
+
+    captured: dict[str, object] = {}
+
+    def fake_plot(
+        merged: pd.DataFrame,
+        *,
+        baseline_label: str,
+        candidate_label: str,
+        out_path: Path,
+        dpi: int,
+    ) -> None:
+        captured["rows"] = len(merged)
+        captured["baseline_label"] = baseline_label
+        captured["candidate_label"] = candidate_label
+        captured["out_path"] = out_path
+        captured["dpi"] = dpi
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text("fake-png", encoding="utf-8")
+
+    monkeypatch.setattr(module, "_plot", fake_plot)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(_script_path()),
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+            "--baseline-label",
+            "baseline-run",
+            "--candidate-label",
+            "candidate-run",
+            "--output",
+            str(output_path),
+            "--every",
+            "2",
+            "--dpi",
+            "210",
+        ],
+    )
+
+    assert module.main() == 0
+    assert captured == {
+        "rows": 2,
+        "baseline_label": "baseline-run",
+        "candidate_label": "candidate-run",
+        "out_path": output_path.resolve(),
+        "dpi": 210,
+    }
+    assert output_path.exists()
+    assert Path(capsys.readouterr().out.strip()) == output_path.resolve()
+
+
+def test_plot_allocation_compare_script_rejects_non_overlapping_datetimes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module()
+    baseline_path = tmp_path / "baseline.csv"
+    candidate_path = tmp_path / "candidate.csv"
+    _write_alloc_csv(baseline_path, timestamps=["2026-01-01T00:00:00"], fruit=[0.2])
+    _write_alloc_csv(candidate_path, timestamps=["2026-01-02T00:00:00"], fruit=[0.3])
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(_script_path()),
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="No overlapping datetime rows"):
+        module.main()
+
+
+def test_plot_allocation_compare_script_plot_raises_helpful_error_without_matplotlib(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module()
+    merged = pd.DataFrame(
+        {
+            "datetime": pd.date_range("2026-01-01", periods=2, freq="6h"),
+            "alloc_frac_fruit__baseline": [0.1, 0.2],
+            "alloc_frac_leaf__baseline": [0.2, 0.3],
+            "alloc_frac_stem__baseline": [0.3, 0.4],
+            "alloc_frac_root__baseline": [0.4, 0.5],
+            "alloc_frac_fruit__candidate": [0.2, 0.3],
+            "alloc_frac_leaf__candidate": [0.3, 0.4],
+            "alloc_frac_stem__candidate": [0.4, 0.5],
+            "alloc_frac_root__candidate": [0.5, 0.6],
+        }
+    )
+    out_path = tmp_path / "alloc.png"
+    real_import = builtins.__import__
+
+    def fake_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+        if name.startswith("matplotlib"):
+            raise ModuleNotFoundError("No module named 'matplotlib'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError, match="Plotting requires matplotlib"):
+        module._plot(
+            merged,
+            baseline_label="baseline",
+            candidate_label="candidate",
+            out_path=out_path,
+            dpi=170,
+        )


### PR DESCRIPTION
## Background
- This PR lands `slice 041` by migrating the TOMATO `tTHORP` repo-level allocation-comparison plotting script.
- The script remains repo-level tooling and continues to treat `matplotlib` as an optional plotting dependency rather than a core package requirement.
- Closing this seam completes the bounded `tTHORP` plotting utilities and moves the next TOMATO architectural uncertainty to the `tGOSM` contracts seam.

## What Changed
- add `scripts/plot_allocation_compare_png.py`
- add regression coverage for allocation-column ingestion, overlap filtering, subsampling, output-path printing, and optional matplotlib error behavior
- update architecture artifacts and README so `slice 041` is recorded and `TOMATO/tGOSM/src/tgosm/contracts.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- TOMATO `tTHORP` now has both repo-level plotting utilities migrated inside the current repository
- the next TOMATO migration loop can move from `tTHORP` scripts into `tGOSM` package contracts without reopening unresolved plotting assumptions

Closes #77
