### PR TITLE
[Model Change] Migrate TOMATO tGOSM contracts seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-041 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, and plotting seams
-- Next blocked seam: TOMATO `tGOSM` contracts seam at `src/tgosm/contracts.py`
+- Slices 025-042 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, and `tGOSM` contracts
+- Next blocked seam: TOMATO `tGOSM` interface seam at `src/tgosm/interface.py`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` THORP reference adapter seam is migrated as slice 039.
 - TOMATO `tTHORP` simulation plotting script seam is migrated as slice 040.
 - TOMATO `tTHORP` allocation-comparison plotting script seam is migrated as slice 041.
+- TOMATO `tGOSM` contracts seam is migrated as slice 042.
 
 ## Next validation
-- Audit the TOMATO `tGOSM` contracts seam at `src/tgosm/contracts.py`.
+- Audit the TOMATO `tGOSM` interface seam at `src/tgosm/interface.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 041
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 041 approved for TOMATO
+- Gate C. Validation plan ready through slice 042
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 042 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -293,3 +293,9 @@ Slice 041:
 - target: `scripts/plot_allocation_compare_png.py` and `tests/test_tomato_tthorp_plot_allocation_compare_png_script.py`
 - scope: bounded TOMATO repo-level allocation-comparison plotting surface covering CSV alignment, allocation-column reshaping, overlap filtering, subsampling, and optional matplotlib dependency behavior
 - excluded: `tGOSM`, `tTDGM`, shared plotting packages, and broader non-TOMATO reporting entrypoints
+
+Slice 042:
+- source: `TOMATO/tGOSM/src/tgosm/contracts.py` and `TOMATO/tGOSM/tests/{test_tgosm_contracts.py,test_tgosm_import.py}`
+- target: `src/stomatal_optimiaztion/domains/tomato/tgosm/`, root TOMATO exports, and `tests/test_tomato_tgosm_contracts.py`
+- scope: bounded TOMATO `tGOSM` contract surface covering optimization request/result dataclasses, nonnegative clamping, and package import identity
+- excluded: `src/tgosm/interface.py`, optimizer implementation details, `tTDGM`, and broader non-TOMATO entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -372,8 +372,16 @@ The forty-first slice opens the next bounded TOMATO seam:
 - keep `matplotlib` as an optional plotting dependency instead of widening the core package runtime
 - leave `TOMATO/tGOSM/src/tgosm/contracts.py` blocked as the next seam
 
+## Slice 042: TOMATO tGOSM Contracts
+
+The forty-second slice opens the next bounded TOMATO seam:
+- move `TOMATO/tGOSM/src/tgosm/contracts.py` into a new staged `domains/tomato/tgosm` package
+- preserve optimization request/result dataclasses, nonnegative clamping, and the package import identity `MODEL_NAME == "tGOSM"`
+- keep the slice contract-first and avoid pulling in `interface.py` or wider optimizer behavior yet
+- leave `TOMATO/tGOSM/src/tgosm/interface.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first seventeen TOMATO bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first eighteen TOMATO bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `TOMATO/tGOSM/src/tgosm/contracts.py`
+3. prepare the next TOMATO source audit for `TOMATO/tGOSM/src/tgosm/interface.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 041 completed and slice 042 planning
+- Current phase: slice 042 completed and slice 043 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO `tGOSM` contracts seam at `src/tgosm/contracts.py`
-2. decide whether `tGOSM` should mirror the `tTHORP` contract/interface-first migration order or needs a different package boundary
-3. keep `tGOSM`, `tTDGM`, and `load-cell-data` blocked until their source audits are deeper
+1. audit the TOMATO `tGOSM` interface seam at `src/tgosm/interface.py`
+2. decide how far the `tGOSM` placeholder optimizer can land without reopening wider optimizer dependencies too early
+3. keep `tTDGM` and `load-cell-data` blocked until their source audits are deeper

--- a/docs/architecture/architecture/module_specs/module-042-tomato-tgosm-contracts.md
+++ b/docs/architecture/architecture/module_specs/module-042-tomato-tgosm-contracts.md
@@ -1,0 +1,39 @@
+# Module Spec 042: TOMATO tGOSM Contracts
+
+## Purpose
+
+Open the next bounded TOMATO seam by porting the `tGOSM` contract surface that defines optimizer request/result payloads and the minimal nonnegative helper.
+
+## Source Inputs
+
+- `TOMATO/tGOSM/src/tgosm/contracts.py`
+- `TOMATO/tGOSM/tests/test_tgosm_contracts.py`
+- `TOMATO/tGOSM/tests/test_tgosm_import.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tgosm/contracts.py`
+- `src/stomatal_optimiaztion/domains/tomato/tgosm/__init__.py`
+- `src/stomatal_optimiaztion/domains/tomato/__init__.py`
+- `tests/test_tomato_tgosm_contracts.py`
+
+## Responsibilities
+
+1. preserve optimization request/result dataclasses and the nonnegative clamp helper
+2. expose the package import identity `MODEL_NAME == "tGOSM"`
+3. keep the seam contract-first so later `tGOSM` interface work can build on one canonical package surface
+
+## Non-Goals
+
+- migrate `TOMATO/tGOSM/src/tgosm/interface.py`
+- introduce optimizer behavior beyond the contract dataclasses
+- widen into `tTDGM` or cross-model shared abstractions
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tGOSM/src/tgosm/interface.py`

--- a/docs/architecture/executor/issue-042-model-change.md
+++ b/docs/architecture/executor/issue-042-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 041` completed the bounded `tTHORP` plotting utilities, so the next TOMATO architectural seam is the `tGOSM` package entry boundary at `src/tgosm/contracts.py`.
+- The migrated repo still has no `tGOSM` package surface, so downstream TOMATO model work cannot rely on a canonical contract for optimization requests and results.
+- This first `tGOSM` slice should stay contract-first, mirroring the early `tTHORP` migration order and avoiding premature optimizer implementation details.
+
+## Affected model
+- `TOMATO tGOSM`
+- `src/stomatal_optimiaztion/domains/tomato/tgosm/`
+- related TOMATO `tGOSM` contract and import tests
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for request/result dataclasses, nonnegative clamping, and package import surface
+
+## Comparison target
+- legacy `TOMATO/tGOSM/src/tgosm/contracts.py`
+- legacy `TOMATO/tGOSM/tests/test_tgosm_contracts.py`
+- legacy `TOMATO/tGOSM/tests/test_tgosm_import.py`

--- a/docs/architecture/executor/pr-079-tomato-tgosm-contracts.md
+++ b/docs/architecture/executor/pr-079-tomato-tgosm-contracts.md
@@ -1,0 +1,20 @@
+## Background
+- This PR lands `slice 042` by migrating the TOMATO `tGOSM` contracts seam into the staged package layout.
+- The repository previously had no `tGOSM` package surface, so downstream TOMATO model work could not rely on a canonical optimizer request/result contract.
+- Closing this seam moves the next TOMATO architectural uncertainty to the `tGOSM` interface seam at `src/tgosm/interface.py`.
+
+## What Changed
+- add `src/stomatal_optimiaztion/domains/tomato/tgosm/contracts.py` and package exports
+- expose `MODEL_NAME == "tGOSM"` and update the root TOMATO domain export surface
+- add regression coverage for request/result dataclasses, frozen import identity, and `clamp_nonnegative()`
+- update architecture artifacts and README so `slice 042` is recorded and `src/tgosm/interface.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- TOMATO `tGOSM` now has a canonical contract surface inside the migrated repository
+- the next migration loop can add the `tGOSM` interface on top of an explicit package boundary instead of creating that boundary implicitly
+
+Closes #79

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the completed `tTHORP` plotting seams | `tGOSM` and `tTDGM` package contracts remain unmigrated, so cross-model boundary assumptions are still implicit | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the first `tGOSM` contract seam | `tGOSM` interface behavior and `tTDGM` package contracts remain unmigrated, so cross-model boundary assumptions are still implicit | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/__init__.py
@@ -1,3 +1,3 @@
-from stomatal_optimiaztion.domains.tomato import tthorp
+from stomatal_optimiaztion.domains.tomato import tgosm, tthorp
 
-__all__ = ["tthorp"]
+__all__ = ["tgosm", "tthorp"]

--- a/src/stomatal_optimiaztion/domains/tomato/tgosm/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tgosm/__init__.py
@@ -1,0 +1,14 @@
+from stomatal_optimiaztion.domains.tomato.tgosm.contracts import (
+    OptimizationRequest,
+    OptimizationResult,
+    clamp_nonnegative,
+)
+
+MODEL_NAME = "tGOSM"
+
+__all__ = [
+    "MODEL_NAME",
+    "OptimizationRequest",
+    "OptimizationResult",
+    "clamp_nonnegative",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tgosm/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tgosm/contracts.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OptimizationRequest:
+    theta_substrate: float
+    water_supply_stress: float
+    vpd_kpa: float
+    co2_air_ppm: float
+    fruit_sink_strength: float
+    vegetative_sink_strength: float
+    current_g_w: float
+
+
+@dataclass(frozen=True, slots=True)
+class OptimizationResult:
+    g_w_opt: float
+    lambda_wue: float
+    objective_value: float
+
+
+def clamp_nonnegative(value: float) -> float:
+    if value < 0:
+        return 0.0
+    return value

--- a/tests/test_tomato_tgosm_contracts.py
+++ b/tests/test_tomato_tgosm_contracts.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tgosm import (
+    MODEL_NAME,
+    OptimizationRequest,
+    OptimizationResult,
+    clamp_nonnegative,
+)
+
+
+def test_tgosm_import_surface_exposes_model_name() -> None:
+    assert MODEL_NAME == "tGOSM"
+
+
+def test_optimization_request_and_result_store_values() -> None:
+    request = OptimizationRequest(
+        theta_substrate=0.3,
+        water_supply_stress=0.7,
+        vpd_kpa=1.3,
+        co2_air_ppm=420.0,
+        fruit_sink_strength=0.6,
+        vegetative_sink_strength=0.4,
+        current_g_w=0.3,
+    )
+    result = OptimizationResult(g_w_opt=0.2, lambda_wue=1.0, objective_value=0.0)
+
+    assert request.theta_substrate == 0.3
+    assert request.current_g_w == 0.3
+    assert result.g_w_opt == 0.2
+    assert result.lambda_wue == 1.0
+
+
+def test_tgosm_contracts_are_frozen_dataclasses() -> None:
+    request = OptimizationRequest(
+        theta_substrate=0.3,
+        water_supply_stress=0.7,
+        vpd_kpa=1.3,
+        co2_air_ppm=420.0,
+        fruit_sink_strength=0.6,
+        vegetative_sink_strength=0.4,
+        current_g_w=0.3,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        request.current_g_w = 0.4  # type: ignore[misc]
+
+
+def test_clamp_nonnegative() -> None:
+    assert clamp_nonnegative(-1.0) == 0.0
+    assert clamp_nonnegative(0.2) == 0.2


### PR DESCRIPTION
## Background
- This PR lands `slice 042` by migrating the TOMATO `tGOSM` contracts seam into the staged package layout.
- The repository previously had no `tGOSM` package surface, so downstream TOMATO model work could not rely on a canonical optimizer request/result contract.
- Closing this seam moves the next TOMATO architectural uncertainty to the `tGOSM` interface seam at `src/tgosm/interface.py`.

## What Changed
- add `src/stomatal_optimiaztion/domains/tomato/tgosm/contracts.py` and package exports
- expose `MODEL_NAME == "tGOSM"` and update the root TOMATO domain export surface
- add regression coverage for request/result dataclasses, frozen import identity, and `clamp_nonnegative()`
- update architecture artifacts and README so `slice 042` is recorded and `src/tgosm/interface.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- TOMATO `tGOSM` now has a canonical contract surface inside the migrated repository
- the next migration loop can add the `tGOSM` interface on top of an explicit package boundary instead of creating that boundary implicitly

Closes #79
