### PR TITLE
[Model Change] Migrate TOMATO tGOSM interface seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-042 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, and `tGOSM` contracts
-- Next blocked seam: TOMATO `tGOSM` interface seam at `src/tgosm/interface.py`
+- Slices 025-043 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, and `tGOSM` contract/interface seams
+- Next blocked seam: TOMATO `tTDGM` contracts seam at `src/ttdgm/contracts.py`

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` simulation plotting script seam is migrated as slice 040.
 - TOMATO `tTHORP` allocation-comparison plotting script seam is migrated as slice 041.
 - TOMATO `tGOSM` contracts seam is migrated as slice 042.
+- TOMATO `tGOSM` interface seam is migrated as slice 043.
 
 ## Next validation
-- Audit the TOMATO `tGOSM` interface seam at `src/tgosm/interface.py`.
+- Audit the TOMATO `tTDGM` contracts seam at `src/ttdgm/contracts.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 042
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 042 approved for TOMATO
+- Gate C. Validation plan ready through slice 043
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 043 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -299,3 +299,9 @@ Slice 042:
 - target: `src/stomatal_optimiaztion/domains/tomato/tgosm/`, root TOMATO exports, and `tests/test_tomato_tgosm_contracts.py`
 - scope: bounded TOMATO `tGOSM` contract surface covering optimization request/result dataclasses, nonnegative clamping, and package import identity
 - excluded: `src/tgosm/interface.py`, optimizer implementation details, `tTDGM`, and broader non-TOMATO entrypoints
+
+Slice 043:
+- source: `TOMATO/tGOSM/src/tgosm/interface.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py`, package exports, and `tests/test_tomato_tgosm_interface.py`
+- scope: bounded TOMATO `tGOSM` interface surface covering placeholder optimizer behavior, conductance target clamping, and explicit WUE/objective placeholders
+- excluded: `tTDGM`, non-placeholder optimizer dependencies, and broader non-TOMATO entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -380,8 +380,16 @@ The forty-second slice opens the next bounded TOMATO seam:
 - keep the slice contract-first and avoid pulling in `interface.py` or wider optimizer behavior yet
 - leave `TOMATO/tGOSM/src/tgosm/interface.py` blocked as the next seam
 
+## Slice 043: TOMATO tGOSM Interface
+
+The forty-third slice opens the next bounded TOMATO seam:
+- move `TOMATO/tGOSM/src/tgosm/interface.py` into the staged `domains/tomato/tgosm` package
+- preserve the placeholder optimizer behavior that maps request stress to a nonnegative conductance target and explicit WUE/objective placeholders
+- keep the seam intentionally small and avoid wider optimizer dependencies beyond the migrated contracts
+- leave `TOMATO/tTDGM/src/ttdgm/contracts.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first eighteen TOMATO bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first nineteen TOMATO bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `TOMATO/tGOSM/src/tgosm/interface.py`
+3. prepare the next TOMATO source audit for `TOMATO/tTDGM/src/ttdgm/contracts.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 042 completed and slice 043 planning
+- Current phase: slice 043 completed and slice 044 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO `tGOSM` interface seam at `src/tgosm/interface.py`
-2. decide how far the `tGOSM` placeholder optimizer can land without reopening wider optimizer dependencies too early
-3. keep `tTDGM` and `load-cell-data` blocked until their source audits are deeper
+1. audit the TOMATO `tTDGM` contracts seam at `src/ttdgm/contracts.py`
+2. decide whether `tTDGM` should mirror the same contract/interface-first migration order now established for `tTHORP` and `tGOSM`
+3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-043-tomato-tgosm-interface.md
+++ b/docs/architecture/architecture/module_specs/module-043-tomato-tgosm-interface.md
@@ -1,0 +1,37 @@
+# Module Spec 043: TOMATO tGOSM Interface
+
+## Purpose
+
+Open the next bounded TOMATO seam by porting the `tGOSM` interface surface that exposes the placeholder stomatal optimization function on top of the migrated contracts.
+
+## Source Inputs
+
+- `TOMATO/tGOSM/src/tgosm/interface.py`
+- `TOMATO/tGOSM/tests/test_tgosm_contracts.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py`
+- `src/stomatal_optimiaztion/domains/tomato/tgosm/__init__.py`
+- `tests/test_tomato_tgosm_interface.py`
+
+## Responsibilities
+
+1. preserve the placeholder optimizer behavior that maps water-supply stress to a nonnegative conductance target
+2. preserve explicit `lambda_wue` and `objective_value` placeholders in the returned result
+3. expose the interface through the staged `tgosm` package without widening into non-placeholder optimizer dependencies
+
+## Non-Goals
+
+- migrate `TOMATO/tTDGM/src/ttdgm/contracts.py`
+- introduce a wider stomatal optimization backend
+- widen into cross-model shared abstractions
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTDGM/src/ttdgm/contracts.py`

--- a/docs/architecture/executor/issue-043-model-change.md
+++ b/docs/architecture/executor/issue-043-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 042` opened the `tGOSM` package boundary, so the next bounded TOMATO seam is the placeholder optimizer interface at `src/tgosm/interface.py`.
+- The migrated repo now has request/result contracts but still lacks the canonical function that maps optimizer requests to a nonnegative conductance target.
+- This slice should keep the implementation intentionally small and placeholder-like, matching the legacy `tGOSM` surface without reopening wider optimizer dependencies yet.
+
+## Affected model
+- `TOMATO tGOSM`
+- `src/stomatal_optimiaztion/domains/tomato/tgosm/`
+- related TOMATO `tGOSM` interface tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for placeholder optimizer behavior, nonnegative target clamping, and package import surface
+
+## Comparison target
+- legacy `TOMATO/tGOSM/src/tgosm/interface.py`
+- legacy `TOMATO/tGOSM/tests/test_tgosm_contracts.py`
+- current migrated `src/stomatal_optimiaztion/domains/tomato/tgosm/contracts.py`

--- a/docs/architecture/executor/pr-081-tomato-tgosm-interface.md
+++ b/docs/architecture/executor/pr-081-tomato-tgosm-interface.md
@@ -1,0 +1,20 @@
+## Background
+- This PR lands `slice 043` by migrating the TOMATO `tGOSM` interface seam into the staged package layout.
+- The repository already had `tGOSM` request/result contracts, but it still lacked the canonical placeholder optimizer entrypoint that downstream TOMATO flows can call.
+- Closing this seam moves the next TOMATO architectural uncertainty to the `tTDGM` contracts seam at `src/ttdgm/contracts.py`.
+
+## What Changed
+- add `src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py`
+- export `run_stomatal_optimization()` through the staged `tgosm` package
+- add regression coverage for placeholder optimizer behavior, nonnegative target clamping, and explicit WUE/objective placeholders
+- update architecture artifacts and README so `slice 043` is recorded and `src/ttdgm/contracts.py` becomes the next blocked seam
+
+## Validation
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Impact
+- TOMATO `tGOSM` now has both a canonical contract surface and a minimal callable interface inside the migrated repository
+- the next migration loop can step into `tTDGM` with the same contract/interface-first pattern already established for sibling TOMATO packages
+
+Closes #81

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the first `tGOSM` contract seam | `tGOSM` interface behavior and `tTDGM` package contracts remain unmigrated, so cross-model boundary assumptions are still implicit | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the completed `tGOSM` interface seam | `tTDGM` package contracts remain unmigrated, so cross-model boundary assumptions are still implicit across sibling TOMATO packages | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/tgosm/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tgosm/__init__.py
@@ -3,6 +3,7 @@ from stomatal_optimiaztion.domains.tomato.tgosm.contracts import (
     OptimizationResult,
     clamp_nonnegative,
 )
+from stomatal_optimiaztion.domains.tomato.tgosm.interface import run_stomatal_optimization
 
 MODEL_NAME = "tGOSM"
 
@@ -11,4 +12,5 @@ __all__ = [
     "OptimizationRequest",
     "OptimizationResult",
     "clamp_nonnegative",
+    "run_stomatal_optimization",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.tomato.tgosm.contracts import (
+    OptimizationRequest,
+    OptimizationResult,
+    clamp_nonnegative,
+)
+
+
+def run_stomatal_optimization(request: OptimizationRequest) -> OptimizationResult:
+    """tGOSM step contract.
+
+    Placeholder optimizer that returns a nonnegative conductance target and
+    keeps explicit WUE multiplier output for downstream coupling.
+    """
+
+    stress_gain = max(0.0, min(1.0, request.water_supply_stress))
+    g_w_opt = clamp_nonnegative(request.current_g_w * stress_gain)
+    return OptimizationResult(
+        g_w_opt=g_w_opt,
+        lambda_wue=1.0,
+        objective_value=0.0,
+    )

--- a/tests/test_tomato_tgosm_interface.py
+++ b/tests/test_tomato_tgosm_interface.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.tomato.tgosm import OptimizationRequest, run_stomatal_optimization
+
+
+def test_run_stomatal_optimization_returns_nonnegative_target() -> None:
+    out = run_stomatal_optimization(
+        OptimizationRequest(
+            theta_substrate=0.3,
+            water_supply_stress=0.7,
+            vpd_kpa=1.3,
+            co2_air_ppm=420.0,
+            fruit_sink_strength=0.6,
+            vegetative_sink_strength=0.4,
+            current_g_w=0.3,
+        )
+    )
+
+    assert out.g_w_opt == 0.21
+    assert out.lambda_wue == 1.0
+    assert out.objective_value == 0.0
+
+
+def test_run_stomatal_optimization_clamps_negative_target() -> None:
+    out = run_stomatal_optimization(
+        OptimizationRequest(
+            theta_substrate=0.3,
+            water_supply_stress=0.8,
+            vpd_kpa=1.3,
+            co2_air_ppm=420.0,
+            fruit_sink_strength=0.6,
+            vegetative_sink_strength=0.4,
+            current_g_w=-0.3,
+        )
+    )
+
+    assert out.g_w_opt == 0.0
+
+
+def test_run_stomatal_optimization_clips_stress_gain_to_unit_interval() -> None:
+    high = run_stomatal_optimization(
+        OptimizationRequest(
+            theta_substrate=0.3,
+            water_supply_stress=1.5,
+            vpd_kpa=1.3,
+            co2_air_ppm=420.0,
+            fruit_sink_strength=0.6,
+            vegetative_sink_strength=0.4,
+            current_g_w=0.3,
+        )
+    )
+    low = run_stomatal_optimization(
+        OptimizationRequest(
+            theta_substrate=0.3,
+            water_supply_stress=-0.2,
+            vpd_kpa=1.3,
+            co2_air_ppm=420.0,
+            fruit_sink_strength=0.6,
+            vegetative_sink_strength=0.4,
+            current_g_w=0.3,
+        )
+    )
+
+    assert high.g_w_opt == 0.3
+    assert low.g_w_opt == 0.0


### PR DESCRIPTION
## Background
- This PR lands `slice 043` by migrating the TOMATO `tGOSM` interface seam into the staged package layout.
- The repository already had `tGOSM` request/result contracts, but it still lacked the canonical placeholder optimizer entrypoint that downstream TOMATO flows can call.
- Closing this seam moves the next TOMATO architectural uncertainty to the `tTDGM` contracts seam at `src/ttdgm/contracts.py`.

## What Changed
- add `src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py`
- export `run_stomatal_optimization()` through the staged `tgosm` package
- add regression coverage for placeholder optimizer behavior, nonnegative target clamping, and explicit WUE/objective placeholders
- update architecture artifacts and README so `slice 043` is recorded and `src/ttdgm/contracts.py` becomes the next blocked seam

## Validation
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- TOMATO `tGOSM` now has both a canonical contract surface and a minimal callable interface inside the migrated repository
- the next migration loop can step into `tTDGM` with the same contract/interface-first pattern already established for sibling TOMATO packages

Closes #81
