### PR TITLE
[Model Change] Migrate TOMATO tTDGM contracts seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-043 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, and `tGOSM` contract/interface seams
-- Next blocked seam: TOMATO `tTDGM` contracts seam at `src/ttdgm/contracts.py`
+- Slices 025-044 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, `tGOSM` contract/interface seams, and the `tTDGM` contracts seam
+- Next blocked seam: TOMATO `tTDGM` interface seam at `src/ttdgm/interface.py`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ poetry run ruff check .
 - TOMATO `tTHORP` allocation-comparison plotting script seam is migrated as slice 041.
 - TOMATO `tGOSM` contracts seam is migrated as slice 042.
 - TOMATO `tGOSM` interface seam is migrated as slice 043.
+- TOMATO `tTDGM` contracts seam is migrated as slice 044.
 
 ## Next validation
-- Audit the TOMATO `tTDGM` contracts seam at `src/ttdgm/contracts.py`.
+- Audit the TOMATO `tTDGM` interface seam at `src/ttdgm/interface.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 043
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 043 approved for TOMATO
+- Gate C. Validation plan ready through slice 044
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 044 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -305,3 +305,9 @@ Slice 043:
 - target: `src/stomatal_optimiaztion/domains/tomato/tgosm/interface.py`, package exports, and `tests/test_tomato_tgosm_interface.py`
 - scope: bounded TOMATO `tGOSM` interface surface covering placeholder optimizer behavior, conductance target clamping, and explicit WUE/objective placeholders
 - excluded: `tTDGM`, non-placeholder optimizer dependencies, and broader non-TOMATO entrypoints
+
+Slice 044:
+- source: `TOMATO/tTDGM/src/ttdgm/contracts.py` and `TOMATO/tTDGM/tests/{test_ttdgm_contracts.py,test_ttdgm_import.py}`
+- target: `src/stomatal_optimiaztion/domains/tomato/ttdgm/`, root TOMATO exports, and `tests/test_tomato_ttdgm_contracts.py`
+- scope: bounded TOMATO `tTDGM` contract surface covering growth-step dataclasses, allocation validation, and package import identity
+- excluded: `src/ttdgm/interface.py`, placeholder growth-step behavior, `load-cell-data`, and broader non-TOMATO entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -388,8 +388,16 @@ The forty-third slice opens the next bounded TOMATO seam:
 - keep the seam intentionally small and avoid wider optimizer dependencies beyond the migrated contracts
 - leave `TOMATO/tTDGM/src/ttdgm/contracts.py` blocked as the next seam
 
+## Slice 044: TOMATO tTDGM Contracts
+
+The forty-fourth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTDGM/src/ttdgm/contracts.py` into a new staged `domains/tomato/ttdgm` package
+- preserve growth-step dataclasses, allocation validation semantics, and the package import identity `MODEL_NAME == "tTDGM"`
+- keep the slice contract-first and avoid pulling in `interface.py` or placeholder growth-step behavior yet
+- leave `TOMATO/tTDGM/src/ttdgm/interface.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first nineteen TOMATO bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first twenty TOMATO bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `TOMATO/tTDGM/src/ttdgm/contracts.py`
+3. prepare the next TOMATO source audit for `TOMATO/tTDGM/src/ttdgm/interface.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 043 completed and slice 044 planning
+- Current phase: slice 044 completed and slice 045 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO `tTDGM` contracts seam at `src/ttdgm/contracts.py`
-2. decide whether `tTDGM` should mirror the same contract/interface-first migration order now established for `tTHORP` and `tGOSM`
+1. audit the TOMATO `tTDGM` interface seam at `src/ttdgm/interface.py`
+2. preserve the same contract/interface-first migration order now established for `tTHORP`, `tGOSM`, and `tTDGM`
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-044-tomato-ttdgm-contracts.md
+++ b/docs/architecture/architecture/module_specs/module-044-tomato-ttdgm-contracts.md
@@ -1,0 +1,39 @@
+# Module Spec 044: TOMATO tTDGM Contracts
+
+## Purpose
+
+Open the next bounded TOMATO seam by porting the `tTDGM` contract surface that defines growth-step payloads, allocation fractions, and package import identity.
+
+## Source Inputs
+
+- `TOMATO/tTDGM/src/ttdgm/contracts.py`
+- `TOMATO/tTDGM/tests/test_ttdgm_contracts.py`
+- `TOMATO/tTDGM/tests/test_ttdgm_import.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/ttdgm/contracts.py`
+- `src/stomatal_optimiaztion/domains/tomato/ttdgm/__init__.py`
+- `src/stomatal_optimiaztion/domains/tomato/__init__.py`
+- `tests/test_tomato_ttdgm_contracts.py`
+
+## Responsibilities
+
+1. preserve frozen contract dataclasses for organ pools, growth drivers, allocation fractions, and growth-step outputs
+2. preserve allocation validation semantics that require a positive unity sum
+3. expose the package import identity `MODEL_NAME == "tTDGM"` so the later interface seam can land on a canonical package surface
+
+## Non-Goals
+
+- migrate `TOMATO/tTDGM/src/ttdgm/interface.py`
+- introduce growth-step behavior beyond the contract dataclasses
+- widen into `load-cell-data` or cross-model shared abstractions
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `TOMATO/tTDGM/src/ttdgm/interface.py`

--- a/docs/architecture/executor/issue-044-model-change.md
+++ b/docs/architecture/executor/issue-044-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 043` opened the TOMATO `tGOSM` interface seam, so the next bounded TOMATO source is the `tTDGM` contract surface at `src/ttdgm/contracts.py`.
+- The migrated repo currently has no `tomato.ttdgm` package, which blocks later growth-step interface work from landing on a canonical import surface.
+- This slice should stay contract-first: dataclasses, allocation validation, and package identity only.
+
+## Affected model
+- `TOMATO tTDGM`
+- `src/stomatal_optimiaztion/domains/tomato/ttdgm/`
+- related TOMATO `tTDGM` contract tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for frozen contract dataclasses, allocation validation, and package import identity
+
+## Comparison target
+- legacy `TOMATO/tTDGM/src/ttdgm/contracts.py`
+- legacy `TOMATO/tTDGM/tests/test_ttdgm_contracts.py`
+- legacy `TOMATO/tTDGM/tests/test_ttdgm_import.py`

--- a/docs/architecture/executor/pr-083-tomato-ttdgm-contracts.md
+++ b/docs/architecture/executor/pr-083-tomato-ttdgm-contracts.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded TOMATO `tTDGM` contracts seam into the staged repo package
+- expose `MODEL_NAME == "tTDGM"` and contract dataclasses through the package import surface
+- add seam-level regression tests and update architecture records for slice 044
+
+## Validation
+- poetry run pytest
+- poetry run ruff check .
+
+## Next Seam
+- `TOMATO/tTDGM/src/ttdgm/interface.py`
+
+Closes #83

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the completed `tGOSM` interface seam | `tTDGM` package contracts remain unmigrated, so cross-model boundary assumptions are still implicit across sibling TOMATO packages | next TOMATO module spec |
+| GAP-002 | TOMATO migration depth is still shallow beyond the completed `tTDGM` contracts seam | `tTDGM` interface and later growth-step behavior remain unmigrated, so sibling TOMATO package boundaries are only partially explicit | next TOMATO module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/__init__.py
@@ -1,3 +1,3 @@
-from stomatal_optimiaztion.domains.tomato import tgosm, tthorp
+from stomatal_optimiaztion.domains.tomato import tgosm, ttdgm, tthorp
 
-__all__ = ["tgosm", "tthorp"]
+__all__ = ["tgosm", "ttdgm", "tthorp"]

--- a/src/stomatal_optimiaztion/domains/tomato/ttdgm/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/ttdgm/__init__.py
@@ -1,0 +1,18 @@
+from stomatal_optimiaztion.domains.tomato.ttdgm.contracts import (
+    GrowthDrivers,
+    GrowthStepOutput,
+    OrganAllocationFractions,
+    OrganCarbonPools,
+    validate_allocations,
+)
+
+MODEL_NAME = "tTDGM"
+
+__all__ = [
+    "MODEL_NAME",
+    "GrowthDrivers",
+    "GrowthStepOutput",
+    "OrganAllocationFractions",
+    "OrganCarbonPools",
+    "validate_allocations",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/ttdgm/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/ttdgm/contracts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OrganCarbonPools:
+    c_leaf: float
+    c_stem: float
+    c_root: float
+    c_fruit: float
+    c_nsc: float
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthDrivers:
+    water_supply_stress: float
+    e: float
+    g_w: float
+    a_n: float
+    r_d: float
+    t_air_c: float
+    theta_substrate: float
+
+
+@dataclass(frozen=True, slots=True)
+class OrganAllocationFractions:
+    u_leaf: float
+    u_stem: float
+    u_root: float
+    u_fruit: float
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthStepOutput:
+    pools: OrganCarbonPools
+    g_leaf: float
+    g_stem: float
+    g_root: float
+    g_fruit: float
+
+
+def validate_allocations(alloc: OrganAllocationFractions) -> bool:
+    total = alloc.u_leaf + alloc.u_stem + alloc.u_root + alloc.u_fruit
+    if total <= 0:
+        return False
+    return abs(total - 1.0) <= 1e-8

--- a/tests/test_tomato_ttdgm_contracts.py
+++ b/tests/test_tomato_ttdgm_contracts.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato import ttdgm
+from stomatal_optimiaztion.domains.tomato.ttdgm import (
+    MODEL_NAME,
+    GrowthDrivers,
+    GrowthStepOutput,
+    OrganAllocationFractions,
+    OrganCarbonPools,
+    validate_allocations,
+)
+
+
+def test_ttdgm_import_surface_exposes_model_name() -> None:
+    assert MODEL_NAME == "tTDGM"
+    assert ttdgm.MODEL_NAME == "tTDGM"
+
+
+def test_ttdgm_contracts_store_values() -> None:
+    pools = OrganCarbonPools(
+        c_leaf=1.0,
+        c_stem=2.0,
+        c_root=3.0,
+        c_fruit=4.0,
+        c_nsc=0.5,
+    )
+    drivers = GrowthDrivers(
+        water_supply_stress=0.8,
+        e=0.02,
+        g_w=0.3,
+        a_n=1.5,
+        r_d=0.1,
+        t_air_c=24.0,
+        theta_substrate=0.35,
+    )
+    output = GrowthStepOutput(
+        pools=pools,
+        g_leaf=0.0,
+        g_stem=0.0,
+        g_root=0.0,
+        g_fruit=0.0,
+    )
+
+    assert pools.c_fruit == 4.0
+    assert drivers.t_air_c == 24.0
+    assert output.pools.c_nsc == 0.5
+    assert output.g_fruit == 0.0
+
+
+def test_ttdgm_contracts_are_frozen_dataclasses() -> None:
+    pools = OrganCarbonPools(
+        c_leaf=1.0,
+        c_stem=2.0,
+        c_root=3.0,
+        c_fruit=4.0,
+        c_nsc=0.5,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        pools.c_leaf = 2.0  # type: ignore[misc]
+
+
+def test_validate_allocations_requires_positive_unity_sum() -> None:
+    assert validate_allocations(
+        OrganAllocationFractions(0.25, 0.25, 0.25, 0.25)
+    )
+    assert not validate_allocations(
+        OrganAllocationFractions(0.1, 0.1, 0.1, 0.1)
+    )
+    assert not validate_allocations(
+        OrganAllocationFractions(0.0, 0.0, 0.0, 0.0)
+    )


### PR DESCRIPTION
## Summary
- migrate the bounded TOMATO `tTDGM` contracts seam into the staged repo package
- expose `MODEL_NAME == "tTDGM"` and contract dataclasses through the package import surface
- add seam-level regression tests and update architecture records for slice 044

## Validation
- poetry run pytest
- poetry run ruff check .

## Next Seam
- `TOMATO/tTDGM/src/ttdgm/interface.py`

Closes #83
