### PR TITLE
[Model Change] Migrate TOMATO tTDGM interface seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -11,5 +11,5 @@ Current status:
 - Architecture scaffold seeded
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
-- Slices 025-044 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, `tGOSM` contract/interface seams, and the `tTDGM` contracts seam
-- Next blocked seam: TOMATO `tTDGM` interface seam at `src/ttdgm/interface.py`
+- Slices 025-045 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, `tGOSM` contract/interface seams, and `tTDGM` contract/interface seams
+- Next blocked seam: `load-cell-data` config seam at `loadcell_pipeline/config.py`

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ poetry run ruff check .
 - TOMATO `tGOSM` contracts seam is migrated as slice 042.
 - TOMATO `tGOSM` interface seam is migrated as slice 043.
 - TOMATO `tTDGM` contracts seam is migrated as slice 044.
+- TOMATO `tTDGM` interface seam is migrated as slice 045.
 
 ## Next validation
-- Audit the TOMATO `tTDGM` interface seam at `src/ttdgm/interface.py`.
+- Audit the `load-cell-data` pipeline config seam at `loadcell_pipeline/config.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 044
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 044 approved for TOMATO
+- Gate C. Validation plan ready through slice 045
+- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 045 approved for TOMATO
 
 ## Migrated THORP Slices
 
@@ -311,3 +311,9 @@ Slice 044:
 - target: `src/stomatal_optimiaztion/domains/tomato/ttdgm/`, root TOMATO exports, and `tests/test_tomato_ttdgm_contracts.py`
 - scope: bounded TOMATO `tTDGM` contract surface covering growth-step dataclasses, allocation validation, and package import identity
 - excluded: `src/ttdgm/interface.py`, placeholder growth-step behavior, `load-cell-data`, and broader non-TOMATO entrypoints
+
+Slice 045:
+- source: `TOMATO/tTDGM/src/ttdgm/interface.py`
+- target: `src/stomatal_optimiaztion/domains/tomato/ttdgm/interface.py`, package exports, and `tests/test_tomato_ttdgm_interface.py`
+- scope: bounded TOMATO `tTDGM` interface surface covering placeholder growth-step behavior, allocation validation, and explicit four-organ growth outputs
+- excluded: `load-cell-data`, non-placeholder growth dynamics, and broader cross-domain abstractions

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -396,8 +396,16 @@ The forty-fourth slice opens the next bounded TOMATO seam:
 - keep the slice contract-first and avoid pulling in `interface.py` or placeholder growth-step behavior yet
 - leave `TOMATO/tTDGM/src/ttdgm/interface.py` blocked as the next seam
 
+## Slice 045: TOMATO tTDGM Interface
+
+The forty-fifth slice opens the next bounded TOMATO seam:
+- move `TOMATO/tTDGM/src/ttdgm/interface.py` into the staged `domains/tomato/ttdgm` package
+- preserve placeholder growth-step behavior that validates allocations and returns explicit zeroed leaf/stem/root/fruit growth channels
+- keep the seam intentionally small and avoid wider physiology or shared abstractions beyond the migrated contracts
+- leave `load-cell-data/loadcell_pipeline/config.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first twenty TOMATO bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams plus the first twenty-one TOMATO bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next TOMATO source audit for `TOMATO/tTDGM/src/ttdgm/interface.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/config.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 044 completed and slice 045 planning
+- Current phase: slice 045 completed and slice 046 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the TOMATO `tTDGM` interface seam at `src/ttdgm/interface.py`
-2. preserve the same contract/interface-first migration order now established for `tTHORP`, `tGOSM`, and `tTDGM`
+1. audit the `load-cell-data` config seam at `loadcell_pipeline/config.py`
+2. decide whether the `load-cell-data` domain should start with config helpers before preprocessing and CLI seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-045-tomato-ttdgm-interface.md
+++ b/docs/architecture/architecture/module_specs/module-045-tomato-ttdgm-interface.md
@@ -1,0 +1,37 @@
+# Module Spec 045: TOMATO tTDGM Interface
+
+## Purpose
+
+Open the next bounded TOMATO seam by porting the `tTDGM` interface surface that exposes the placeholder growth-step function on top of the migrated contracts.
+
+## Source Inputs
+
+- `TOMATO/tTDGM/src/ttdgm/interface.py`
+- `TOMATO/tTDGM/tests/test_ttdgm_contracts.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/tomato/ttdgm/interface.py`
+- `src/stomatal_optimiaztion/domains/tomato/ttdgm/__init__.py`
+- `tests/test_tomato_ttdgm_interface.py`
+
+## Responsibilities
+
+1. preserve the placeholder growth-step behavior that validates allocations and returns explicit zeroed organ growth channels
+2. preserve the pool passthrough semantics for the returned `GrowthStepOutput`
+3. expose the interface through the staged `ttdgm` package without widening into new physiology or shared abstractions
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/config.py`
+- introduce non-placeholder `tTDGM` growth behavior
+- widen into cross-domain shared abstractions
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/config.py`

--- a/docs/architecture/executor/issue-045-model-change.md
+++ b/docs/architecture/executor/issue-045-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 044` opened the TOMATO `tTDGM` contract surface, so the next bounded seam is the placeholder growth-step interface at `src/ttdgm/interface.py`.
+- The migrated repo now has the package contracts but still lacks the canonical function that validates allocations and emits an explicit four-organ growth output.
+- This slice should stay intentionally small and placeholder-like, matching the legacy `tTDGM` surface without widening into new physiology or shared abstractions.
+
+## Affected model
+- `TOMATO tTDGM`
+- `src/stomatal_optimiaztion/domains/tomato/ttdgm/`
+- related TOMATO `tTDGM` interface tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for placeholder growth-step behavior, invalid allocation rejection, and package import surface
+
+## Comparison target
+- legacy `TOMATO/tTDGM/src/ttdgm/interface.py`
+- legacy `TOMATO/tTDGM/tests/test_ttdgm_contracts.py`
+- current migrated `src/stomatal_optimiaztion/domains/tomato/ttdgm/contracts.py`

--- a/docs/architecture/executor/pr-085-tomato-ttdgm-interface.md
+++ b/docs/architecture/executor/pr-085-tomato-ttdgm-interface.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded TOMATO `tTDGM` interface seam into the staged repo package
+- expose `run_growth_step()` through the `ttdgm` import surface with placeholder growth behavior intact
+- add seam-level regression tests and update architecture records for slice 045
+
+## Validation
+- poetry run pytest
+- poetry run ruff check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/config.py`
+
+Closes #85

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | TOMATO migration depth is still shallow beyond the completed `tTDGM` contracts seam | `tTDGM` interface and later growth-step behavior remain unmigrated, so sibling TOMATO package boundaries are only partially explicit | next TOMATO module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed TOMATO `tTDGM` interface seam | the first `load-cell-data` config/helper surface is still unmigrated, so the third domain boundary is not yet explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/tomato/ttdgm/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/ttdgm/__init__.py
@@ -5,6 +5,7 @@ from stomatal_optimiaztion.domains.tomato.ttdgm.contracts import (
     OrganCarbonPools,
     validate_allocations,
 )
+from stomatal_optimiaztion.domains.tomato.ttdgm.interface import run_growth_step
 
 MODEL_NAME = "tTDGM"
 
@@ -15,4 +16,5 @@ __all__ = [
     "OrganAllocationFractions",
     "OrganCarbonPools",
     "validate_allocations",
+    "run_growth_step",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/ttdgm/interface.py
+++ b/src/stomatal_optimiaztion/domains/tomato/ttdgm/interface.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.tomato.ttdgm.contracts import (
+    GrowthDrivers,
+    GrowthStepOutput,
+    OrganAllocationFractions,
+    OrganCarbonPools,
+    validate_allocations,
+)
+
+
+def run_growth_step(
+    *,
+    pools: OrganCarbonPools,
+    drivers: GrowthDrivers,
+    allocations: OrganAllocationFractions,
+) -> GrowthStepOutput:
+    """tTDGM step contract.
+
+    Placeholder implementation that preserves pool values and exposes explicit
+    organ growth channels (leaf/stem/root/fruit) for tomato.
+    """
+
+    if not validate_allocations(allocations):
+        raise ValueError("Organ allocations must sum to 1.0.")
+
+    return GrowthStepOutput(
+        pools=pools,
+        g_leaf=0.0,
+        g_stem=0.0,
+        g_root=0.0,
+        g_fruit=0.0,
+    )

--- a/tests/test_tomato_ttdgm_interface.py
+++ b/tests/test_tomato_ttdgm_interface.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.ttdgm import (
+    GrowthDrivers,
+    OrganAllocationFractions,
+    OrganCarbonPools,
+    run_growth_step,
+)
+
+
+def test_run_growth_step_preserves_pools_and_exposes_fruit_channel() -> None:
+    pools = OrganCarbonPools(
+        c_leaf=1.0,
+        c_stem=1.0,
+        c_root=1.0,
+        c_fruit=1.0,
+        c_nsc=0.5,
+    )
+
+    output = run_growth_step(
+        pools=pools,
+        drivers=GrowthDrivers(
+            water_supply_stress=0.8,
+            e=0.0,
+            g_w=0.0,
+            a_n=0.0,
+            r_d=0.0,
+            t_air_c=24.0,
+            theta_substrate=0.35,
+        ),
+        allocations=OrganAllocationFractions(0.25, 0.25, 0.25, 0.25),
+    )
+
+    assert output.pools is pools
+    assert output.g_leaf == 0.0
+    assert output.g_stem == 0.0
+    assert output.g_root == 0.0
+    assert output.g_fruit == 0.0
+    assert output.pools.c_fruit == 1.0
+
+
+def test_run_growth_step_rejects_invalid_allocations() -> None:
+    pools = OrganCarbonPools(
+        c_leaf=1.0,
+        c_stem=1.0,
+        c_root=1.0,
+        c_fruit=1.0,
+        c_nsc=0.5,
+    )
+
+    with pytest.raises(ValueError, match="sum to 1.0"):
+        run_growth_step(
+            pools=pools,
+            drivers=GrowthDrivers(
+                water_supply_stress=0.8,
+                e=0.0,
+                g_w=0.0,
+                a_n=0.0,
+                r_d=0.0,
+                t_air_c=24.0,
+                theta_substrate=0.35,
+            ),
+            allocations=OrganAllocationFractions(0.1, 0.1, 0.1, 0.1),
+        )


### PR DESCRIPTION
## Summary
- migrate the bounded TOMATO `tTDGM` interface seam into the staged repo package
- expose `run_growth_step()` through the `ttdgm` import surface with placeholder growth behavior intact
- add seam-level regression tests and update architecture records for slice 045

## Validation
- poetry run pytest
- poetry run ruff check .

## Next Seam
- `load-cell-data/loadcell_pipeline/config.py`

Closes #85
