### PR TITLE
[Model Change] Migrate load-cell-data config seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -12,4 +12,5 @@ Current status:
 - Target repo shape finalized as a staged single-package domain workspace
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
 - Slices 025-045 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, `tGOSM` contract/interface seams, and `tTDGM` contract/interface seams
-- Next blocked seam: `load-cell-data` config seam at `loadcell_pipeline/config.py`
+- Slice 046 migrated: `load-cell-data` config seam
+- Next blocked seam: `load-cell-data` ingestion seam at `loadcell_pipeline/io.py`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ poetry run ruff check .
 - TOMATO `tGOSM` interface seam is migrated as slice 043.
 - TOMATO `tTDGM` contracts seam is migrated as slice 044.
 - TOMATO `tTDGM` interface seam is migrated as slice 045.
+- `load-cell-data` config seam is migrated as slice 046.
 
 ## Next validation
-- Audit the `load-cell-data` pipeline config seam at `loadcell_pipeline/config.py`.
+- Audit the `load-cell-data` ingestion seam at `loadcell_pipeline/io.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 045
-- Gate D. Bounded slices 001 through 024 approved for THORP and slices 025 through 045 approved for TOMATO
+- Gate C. Validation plan ready through slice 046
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slice 046 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -317,3 +317,9 @@ Slice 045:
 - target: `src/stomatal_optimiaztion/domains/tomato/ttdgm/interface.py`, package exports, and `tests/test_tomato_ttdgm_interface.py`
 - scope: bounded TOMATO `tTDGM` interface surface covering placeholder growth-step behavior, allocation validation, and explicit four-organ growth outputs
 - excluded: `load-cell-data`, non-placeholder growth dynamics, and broader cross-domain abstractions
+
+Slice 046:
+- source: `load-cell-data/loadcell_pipeline/config.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/`, root domain exports, and `tests/test_load_cell_config.py`
+- scope: bounded `load-cell-data` config surface covering pipeline defaults, path serialization, YAML loading, and override precedence
+- excluded: `loadcell_pipeline/io.py`, preprocessing, workflow, CLI, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -404,8 +404,16 @@ The forty-fifth slice opens the next bounded TOMATO seam:
 - keep the seam intentionally small and avoid wider physiology or shared abstractions beyond the migrated contracts
 - leave `load-cell-data/loadcell_pipeline/config.py` blocked as the next seam
 
+## Slice 046: load-cell-data Config
+
+The forty-sixth slice opens the first bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/config.py` into a new staged `domains/load_cell` package
+- preserve `PipelineConfig` defaults, `to_dict()` path serialization, YAML loading, and override precedence
+- keep the slice config-first and avoid widening into ingestion, preprocessing, workflow, or CLI seams yet
+- leave `load-cell-data/loadcell_pipeline/io.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams plus the first twenty-one TOMATO bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first `load-cell-data` bounded seam
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/config.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/io.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 045 completed and slice 046 planning
+- Current phase: slice 046 completed and slice 047 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` config seam at `loadcell_pipeline/config.py`
-2. decide whether the `load-cell-data` domain should start with config helpers before preprocessing and CLI seams
+1. audit the `load-cell-data` ingestion seam at `loadcell_pipeline/io.py`
+2. preserve the config-first package boundary while deciding whether ingestion should precede preprocessing and workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-046-load-cell-config.md
+++ b/docs/architecture/architecture/module_specs/module-046-load-cell-config.md
@@ -1,0 +1,37 @@
+# Module Spec 046: load-cell-data Config
+
+## Purpose
+
+Open the first bounded `load-cell-data` seam by porting the pipeline configuration surface that defines runtime defaults, path coercion, and YAML loading behavior.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/config.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/config.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `src/stomatal_optimiaztion/domains/__init__.py`
+- `tests/test_load_cell_config.py`
+
+## Responsibilities
+
+1. preserve the `PipelineConfig` dataclass default surface for load-cell preprocessing, thresholding, grouping, and flux options
+2. preserve `to_dict()` path serialization and `load_config()` YAML/override behavior
+3. open a canonical `domains/load_cell` package surface so later ingestion and workflow seams land on one import boundary
+
+## Non-Goals
+
+- migrate `loadcell_pipeline/io.py`
+- migrate `loadcell_pipeline/preprocessing.py`
+- widen into CLI, workflow, or dashboard entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/io.py`

--- a/docs/architecture/executor/issue-046-model-change.md
+++ b/docs/architecture/executor/issue-046-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 045` completed the bounded TOMATO `tTDGM` interface seam, so the next unresolved domain boundary is the first `load-cell-data` config/helper surface at `loadcell_pipeline/config.py`.
+- The migrated repo currently has no `load_cell` package, which blocks later preprocessing, workflow, and CLI seams from landing on a canonical package surface.
+- This slice should stay config-first: dataclass defaults, path coercion, YAML loading, and override behavior only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell config tests and domain exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for config defaults, `Path` serialization, YAML loading, override precedence, and invalid config file behavior
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/config.py`
+- current repo architecture docs for the `domains/load_cell` target layout

--- a/docs/architecture/executor/pr-087-load-cell-config.md
+++ b/docs/architecture/executor/pr-087-load-cell-config.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` config seam into a new staged `domains/load_cell` package
+- preserve `PipelineConfig` defaults plus YAML loading, override precedence, and path coercion behavior
+- add seam-level regression tests and update architecture records for slice 046
+
+## Validation
+- poetry run pytest
+- poetry run ruff check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/io.py`
+
+Closes #87

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed TOMATO `tTDGM` interface seam | the first `load-cell-data` config/helper surface is still unmigrated, so the third domain boundary is not yet explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed config seam | ingestion helpers, preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/__init__.py
+++ b/src/stomatal_optimiaztion/domains/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["thorp", "tomato"]
+__all__ = ["load_cell", "thorp", "tomato"]

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -1,0 +1,9 @@
+from stomatal_optimiaztion.domains.load_cell.config import (
+    PipelineConfig,
+    load_config,
+)
+
+__all__ = [
+    "PipelineConfig",
+    "load_config",
+]

--- a/src/stomatal_optimiaztion/domains/load_cell/config.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/config.py
@@ -1,0 +1,96 @@
+"""Configuration helpers for the load-cell processing pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml should exist but guard anyway
+    yaml = None
+
+
+@dataclass(slots=True)
+class PipelineConfig:
+    """Container for configurable parameters of the load-cell pipeline."""
+
+    input_path: Path | None = None
+    output_path: Path | None = None
+    timestamp_column: str = "timestamp"
+    weight_column: str = "weight_kg"
+
+    smooth_method: str = "savgol"
+    smooth_window_sec: int = 31
+    poly_order: int = 2
+    k_outlier: float = 10.0
+    max_spike_width_sec: int = 2
+    derivative_method: str = "central"
+
+    use_auto_thresholds: bool = True
+    irrigation_step_threshold_kg: float | None = None
+    drainage_step_threshold_kg: float | None = None
+    min_pos_events: int = 5
+    min_neg_events: int = 5
+    k_tail: float = 4.0
+    min_factor: float = 3.0
+    exclude_interpolated_from_thresholds: bool = True
+
+    use_hysteresis_labels: bool = False
+    hysteresis_ratio: float = 0.5
+
+    min_event_duration_sec: int = 2
+    merge_irrigation_gap_sec: int | None = None
+
+    interpolate_transpiration_during_events: bool = True
+    fix_water_balance: bool = True
+    water_balance_scale_min: float = 0.0
+    water_balance_scale_max: float | None = 3.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON/YAML-friendly dictionary representation."""
+
+        data = asdict(self)
+        for key in ("input_path", "output_path"):
+            value = data.get(key)
+            if isinstance(value, Path):
+                data[key] = str(value)
+        return data
+
+
+def load_config(
+    path: Path | str | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> PipelineConfig:
+    """Load YAML configuration or return defaults when no path is provided."""
+
+    config_data: dict[str, Any] = {}
+    if path is not None:
+        config_path = Path(path)
+        if not config_path.exists():
+            raise FileNotFoundError(f"Config file not found: {config_path}")
+        if yaml is None:
+            raise RuntimeError(
+                "PyYAML is required to load configuration files but is not installed.",
+            )
+        with config_path.open("r", encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+        if not isinstance(loaded, Mapping):
+            raise ValueError("Config YAML must define a mapping at the root.")
+        config_data.update(loaded)
+
+    if overrides:
+        config_data.update(overrides)
+
+    def _coerce_path(value: Any) -> Path | None:
+        if value in (None, ""):
+            return None
+        return Path(value)
+
+    if "input_path" in config_data:
+        config_data["input_path"] = _coerce_path(config_data["input_path"])
+    if "output_path" in config_data:
+        config_data["output_path"] = _coerce_path(config_data["output_path"])
+
+    return PipelineConfig(**config_data)

--- a/tests/test_load_cell_config.py
+++ b/tests/test_load_cell_config.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import PipelineConfig, load_config
+
+
+def test_load_cell_import_surface_exposes_config_helpers() -> None:
+    assert load_cell.PipelineConfig is PipelineConfig
+    assert load_cell.load_config is load_config
+
+
+def test_pipeline_config_to_dict_serializes_paths() -> None:
+    config = PipelineConfig(
+        input_path=Path("input.csv"),
+        output_path=Path("out.csv"),
+    )
+
+    data = config.to_dict()
+
+    assert data["input_path"] == "input.csv"
+    assert data["output_path"] == "out.csv"
+    assert data["smooth_method"] == "savgol"
+
+
+def test_load_config_without_path_returns_defaults() -> None:
+    config = load_config()
+
+    assert config.input_path is None
+    assert config.output_path is None
+    assert config.timestamp_column == "timestamp"
+    assert config.water_balance_scale_max == 3.0
+
+
+def test_load_config_reads_yaml_and_coerces_paths(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "input_path: data/raw.csv",
+                "output_path: artifacts/out.csv",
+                "smooth_window_sec: 61",
+                "use_hysteresis_labels: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.input_path == Path("data/raw.csv")
+    assert config.output_path == Path("artifacts/out.csv")
+    assert config.smooth_window_sec == 61
+    assert config.use_hysteresis_labels is True
+
+
+def test_load_config_overrides_take_precedence(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("smooth_window_sec: 61\noutput_path: artifacts/out.csv\n", encoding="utf-8")
+
+    config = load_config(
+        config_path,
+        overrides={
+            "smooth_window_sec": 15,
+            "output_path": "",
+        },
+    )
+
+    assert config.smooth_window_sec == 15
+    assert config.output_path is None
+
+
+def test_load_config_raises_for_missing_file(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.yaml"
+
+    with pytest.raises(FileNotFoundError):
+        load_config(missing_path)
+
+
+def test_load_config_requires_mapping_root(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("- bad\n- config\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mapping"):
+        load_config(config_path)


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` config seam into a new staged `domains/load_cell` package
- preserve `PipelineConfig` defaults plus YAML loading, override precedence, and path coercion behavior
- add seam-level regression tests and update architecture records for slice 046

## Validation
- poetry run pytest
- poetry run ruff check .

## Next Seam
- `load-cell-data/loadcell_pipeline/io.py`

Closes #87
