### PR TITLE
[Model Change] Migrate load-cell-data IO seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -13,4 +13,5 @@ Current status:
 - Slices 001-024 migrated: THORP bounded runtime, reporting, config, IO, and CLI seams
 - Slices 025-045 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, `tGOSM` contract/interface seams, and `tTDGM` contract/interface seams
 - Slice 046 migrated: `load-cell-data` config seam
-- Next blocked seam: `load-cell-data` ingestion seam at `loadcell_pipeline/io.py`
+- Slice 047 migrated: `load-cell-data` IO seam
+- Next blocked seam: `load-cell-data` aggregation seam at `loadcell_pipeline/aggregation.py`

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ poetry run ruff check .
 - TOMATO `tTDGM` contracts seam is migrated as slice 044.
 - TOMATO `tTDGM` interface seam is migrated as slice 045.
 - `load-cell-data` config seam is migrated as slice 046.
+- `load-cell-data` IO seam is migrated as slice 047.
 
 ## Next validation
-- Audit the `load-cell-data` ingestion seam at `loadcell_pipeline/io.py`.
+- Audit the `load-cell-data` aggregation seam at `loadcell_pipeline/aggregation.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 046
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slice 046 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 047
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 047 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -323,3 +323,9 @@ Slice 046:
 - target: `src/stomatal_optimiaztion/domains/load_cell/`, root domain exports, and `tests/test_load_cell_config.py`
 - scope: bounded `load-cell-data` config surface covering pipeline defaults, path serialization, YAML loading, and override precedence
 - excluded: `loadcell_pipeline/io.py`, preprocessing, workflow, CLI, and dashboard entrypoints
+
+Slice 047:
+- source: `load-cell-data/loadcell_pipeline/io.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/io.py`, package exports, and `tests/test_load_cell_io.py`
+- scope: bounded `load-cell-data` IO surface covering raw CSV ingestion, interpolation flags, duplicate-timestamp handling, and single/multi-resolution artifact writing
+- excluded: `loadcell_pipeline/aggregation.py`, preprocessing, workflow, CLI, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -412,8 +412,16 @@ The forty-sixth slice opens the first bounded `load-cell-data` seam:
 - keep the slice config-first and avoid widening into ingestion, preprocessing, workflow, or CLI seams yet
 - leave `load-cell-data/loadcell_pipeline/io.py` blocked as the next seam
 
+## Slice 047: load-cell-data IO
+
+The forty-seventh slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/io.py` into the staged `domains/load_cell` package
+- preserve raw CSV ingestion, duplicate-timestamp handling, interpolation flags, and single/multi-resolution artifact writing behavior
+- keep optional Excel export behavior explicit without widening into aggregation, preprocessing, workflow, or CLI seams
+- leave `load-cell-data/loadcell_pipeline/aggregation.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first `load-cell-data` bounded seam
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first two `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/io.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/aggregation.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 046 completed and slice 047 planning
+- Current phase: slice 047 completed and slice 048 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` ingestion seam at `loadcell_pipeline/io.py`
-2. preserve the config-first package boundary while deciding whether ingestion should precede preprocessing and workflow seams
+1. audit the `load-cell-data` aggregation seam at `loadcell_pipeline/aggregation.py`
+2. preserve the config-and-ingestion-first package boundary while deciding whether aggregation should precede preprocessing and workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-047-load-cell-io.md
+++ b/docs/architecture/architecture/module_specs/module-047-load-cell-io.md
@@ -1,0 +1,36 @@
+# Module Spec 047: load-cell-data IO
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the ingestion and result-writing helper surface that reads raw CSV data and persists processed artifacts.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/io.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/io.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_io.py`
+
+## Responsibilities
+
+1. preserve raw load-cell CSV ingestion, duplicate-timestamp handling, interpolation flags, and 1-second reindexing behavior
+2. preserve CSV artifact writing for single-resolution and multi-resolution outputs
+3. keep optional Excel export behavior explicit without widening into workflow or preprocessing seams
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/aggregation.py`
+- migrate `load-cell-data/loadcell_pipeline/preprocessing.py`
+- widen into CLI, workflow, or dashboard entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/aggregation.py`

--- a/docs/architecture/executor/issue-047-model-change.md
+++ b/docs/architecture/executor/issue-047-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 046` opened the first `load-cell-data` package boundary, so the next bounded seam is the ingestion and result-writing helper surface at `loadcell_pipeline/io.py`.
+- The migrated repo now has config helpers but still lacks the canonical CSV reader and artifact writer functions that later preprocessing and workflow seams depend on.
+- This slice should stay IO-bounded: CSV ingestion, interpolation flags, and result writers only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell IO tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for CSV ingestion, duplicate timestamp handling, interpolation flags, multi-resolution output writing, and error paths
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/io.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/config.py`

--- a/docs/architecture/executor/pr-089-load-cell-io.md
+++ b/docs/architecture/executor/pr-089-load-cell-io.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` IO seam into the staged `domains/load_cell` package
+- preserve CSV ingestion, interpolation flags, and single/multi-resolution artifact writing behavior
+- add seam-level regression tests and update architecture records for slice 047
+
+## Validation
+- poetry run pytest
+- poetry run ruff check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/aggregation.py`
+
+Closes #89

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed config seam | ingestion helpers, preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed IO seam | aggregation, preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -2,8 +2,16 @@ from stomatal_optimiaztion.domains.load_cell.config import (
     PipelineConfig,
     load_config,
 )
+from stomatal_optimiaztion.domains.load_cell.io import (
+    read_load_cell_csv,
+    write_multi_resolution_results,
+    write_results,
+)
 
 __all__ = [
     "PipelineConfig",
     "load_config",
+    "read_load_cell_csv",
+    "write_multi_resolution_results",
+    "write_results",
 ]

--- a/src/stomatal_optimiaztion/domains/load_cell/io.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/io.py
@@ -1,0 +1,142 @@
+"""Input/output utilities for load-cell data ingestion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from pandas.errors import ParserError
+
+
+def read_load_cell_csv(
+    path: Path,
+    timestamp_column: str = "timestamp",
+    weight_column: str = "weight_kg",
+) -> pd.DataFrame:
+    """Read raw load-cell CSV data and return a 1-second indexed DataFrame."""
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Input CSV not found: {path}")
+
+    try:
+        df = pd.read_csv(
+            path,
+            usecols=[timestamp_column, weight_column],
+            low_memory=False,
+        )
+    except ParserError:
+        df = pd.read_csv(
+            path,
+            usecols=[timestamp_column, weight_column],
+            engine="python",
+            on_bad_lines="skip",
+        )
+
+    if timestamp_column not in df.columns:
+        raise KeyError(f"Missing timestamp column '{timestamp_column}' in CSV.")
+    if weight_column not in df.columns:
+        raise KeyError(f"Missing weight column '{weight_column}' in CSV.")
+
+    df = df[[timestamp_column, weight_column]].copy()
+    df[timestamp_column] = pd.to_datetime(
+        df[timestamp_column], utc=False, errors="coerce"
+    )
+    df[weight_column] = pd.to_numeric(df[weight_column], errors="coerce")
+    df = df.dropna(subset=[timestamp_column]).sort_values(timestamp_column)
+
+    weight_series = df.groupby(timestamp_column, sort=True)[weight_column].first()
+    df = weight_series.to_frame(name="weight_raw_kg")
+    df.index = pd.DatetimeIndex(df.index, freq=None, name="timestamp")
+
+    original_index = df.index.copy()
+    full_index = pd.date_range(
+        start=original_index.min(),
+        end=original_index.max(),
+        freq="1s",
+        name="timestamp",
+    )
+
+    df = df.reindex(full_index)
+    is_time_inserted = ~df.index.isin(original_index)
+    is_value_missing = df["weight_raw_kg"].isna()
+    df["is_interpolated"] = (is_time_inserted | is_value_missing).fillna(False)
+    df["weight_kg"] = df["weight_raw_kg"].ffill().bfill()
+
+    return df
+
+
+def write_results(
+    df: pd.DataFrame,
+    output_path: Path,
+    include_excel: bool = False,
+) -> None:
+    """Persist processed per-second fluxes to CSV and optional Excel."""
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df.to_csv(output_path, index_label="timestamp")
+
+    if include_excel:
+        excel_path = output_path.with_suffix(".xlsx")
+        try:
+            df.to_excel(excel_path, index_label="timestamp")
+        except ImportError as exc:  # pragma: no cover - depends on engines
+            raise RuntimeError(
+                "Writing Excel output requires 'openpyxl' or 'xlsxwriter'.",
+            ) from exc
+
+
+def write_multi_resolution_results(
+    frames: dict[str, pd.DataFrame],
+    output_path: Path,
+    include_excel: bool = False,
+) -> None:
+    """Write multiple time resolutions to CSV and optional multi-sheet Excel."""
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if "1s" not in frames:
+        raise KeyError("frames must contain the '1s' DataFrame.")
+
+    df_1s = frames["1s"]
+    df_1s.to_csv(output_path, index_label="timestamp")
+
+    suffixes = {
+        "10s": "_10s",
+        "1min": "_1min",
+        "1h": "_1h",
+        "daily": "_daily",
+    }
+    for key, suffix in suffixes.items():
+        df = frames.get(key)
+        if df is None or df.empty:
+            continue
+        path_for_resolution = output_path.with_name(
+            f"{output_path.stem}{suffix}{output_path.suffix}"
+        )
+        index_label = "day" if key == "daily" else "timestamp"
+        df.to_csv(path_for_resolution, index_label=index_label)
+
+    if include_excel:
+        excel_path = output_path.with_suffix(".xlsx")
+        try:
+            with pd.ExcelWriter(excel_path) as writer:
+                for key, sheet_name in [
+                    ("1s", "1s"),
+                    ("10s", "10s"),
+                    ("1min", "1min"),
+                    ("1h", "1h"),
+                    ("daily", "daily"),
+                ]:
+                    df = frames.get(key)
+                    if df is None or df.empty:
+                        continue
+                    index_label = "day" if key == "daily" else "timestamp"
+                    df.to_excel(writer, sheet_name=sheet_name, index_label=index_label)
+        except ImportError as exc:  # pragma: no cover - depends on engines
+            raise RuntimeError(
+                "Writing Excel output requires 'openpyxl' or 'xlsxwriter'.",
+            ) from exc

--- a/tests/test_load_cell_io.py
+++ b/tests/test_load_cell_io.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from pandas.errors import ParserError
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import (
+    read_load_cell_csv,
+    write_multi_resolution_results,
+    write_results,
+)
+
+
+def test_load_cell_import_surface_exposes_io_helpers() -> None:
+    assert load_cell.read_load_cell_csv is read_load_cell_csv
+    assert load_cell.write_results is write_results
+    assert load_cell.write_multi_resolution_results is write_multi_resolution_results
+
+
+def test_read_load_cell_csv_reindexes_and_marks_interpolation(tmp_path: Path) -> None:
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "timestamp,weight_kg",
+                "2025-06-01 00:00:00,1.0",
+                "2025-06-01 00:00:00,",
+                "bad-row,5.0",
+                "2025-06-01 00:00:02,",
+                "2025-06-01 00:00:03,1.3",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    df = read_load_cell_csv(csv_path)
+
+    assert list(df.columns) == ["weight_raw_kg", "is_interpolated", "weight_kg"]
+    assert list(df.index.astype(str)) == [
+        "2025-06-01 00:00:00",
+        "2025-06-01 00:00:01",
+        "2025-06-01 00:00:02",
+        "2025-06-01 00:00:03",
+    ]
+    assert df.loc["2025-06-01 00:00:00", "weight_raw_kg"] == 1.0
+    assert pd.isna(df.loc["2025-06-01 00:00:01", "weight_raw_kg"])
+    assert pd.isna(df.loc["2025-06-01 00:00:02", "weight_raw_kg"])
+    assert df.loc["2025-06-01 00:00:03", "weight_raw_kg"] == 1.3
+    assert bool(df.loc["2025-06-01 00:00:01", "is_interpolated"])
+    assert bool(df.loc["2025-06-01 00:00:02", "is_interpolated"])
+    assert df.loc["2025-06-01 00:00:02", "weight_kg"] == 1.0
+
+
+def test_read_load_cell_csv_falls_back_after_parser_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text("timestamp,weight_kg\n2025-06-01 00:00:00,1.0\n", encoding="utf-8")
+
+    calls: list[dict[str, object]] = []
+
+    def fake_read_csv(*args: object, **kwargs: object) -> pd.DataFrame:
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            raise ParserError("broken csv")
+        return pd.DataFrame(
+            {
+                "timestamp": ["2025-06-01 00:00:00"],
+                "weight_kg": [1.0],
+            }
+        )
+
+    monkeypatch.setattr(
+        "stomatal_optimiaztion.domains.load_cell.io.pd.read_csv",
+        fake_read_csv,
+    )
+
+    df = read_load_cell_csv(csv_path)
+
+    assert len(calls) == 2
+    assert calls[1]["engine"] == "python"
+    assert calls[1]["on_bad_lines"] == "skip"
+    assert df.loc["2025-06-01 00:00:00", "weight_kg"] == 1.0
+
+
+def test_read_load_cell_csv_raises_for_missing_file(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.csv"
+
+    with pytest.raises(FileNotFoundError):
+        read_load_cell_csv(missing_path)
+
+
+def test_write_results_writes_csv(tmp_path: Path) -> None:
+    output_path = tmp_path / "out" / "results.csv"
+    frame = pd.DataFrame({"weight_kg": [1.0, 1.2]})
+    frame.index = pd.date_range("2025-06-01", periods=2, freq="1s", name="timestamp")
+
+    write_results(frame, output_path)
+
+    written = pd.read_csv(output_path)
+    assert list(written.columns) == ["timestamp", "weight_kg"]
+    assert len(written) == 2
+
+
+def test_write_results_wraps_excel_import_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = tmp_path / "out" / "results.csv"
+    frame = pd.DataFrame({"weight_kg": [1.0]})
+    frame.index = pd.date_range("2025-06-01", periods=1, freq="1s", name="timestamp")
+
+    def fake_to_excel(*args: object, **kwargs: object) -> None:
+        raise ImportError("missing engine")
+
+    monkeypatch.setattr(pd.DataFrame, "to_excel", fake_to_excel)
+
+    with pytest.raises(RuntimeError, match="openpyxl|xlsxwriter"):
+        write_results(frame, output_path, include_excel=True)
+
+
+def test_write_multi_resolution_results_writes_expected_csvs(tmp_path: Path) -> None:
+    output_path = tmp_path / "out" / "results.csv"
+    frames = {
+        "1s": pd.DataFrame({"weight_kg": [1.0]}),
+        "10s": pd.DataFrame({"weight_kg": [1.1]}),
+        "daily": pd.DataFrame({"weight_kg": [1.2]}),
+    }
+    frames["1s"].index = pd.date_range("2025-06-01", periods=1, freq="1s", name="timestamp")
+    frames["10s"].index = pd.date_range("2025-06-01", periods=1, freq="10s", name="timestamp")
+    frames["daily"].index = pd.Index(["2025-06-01"], name="day")
+
+    write_multi_resolution_results(frames, output_path)
+
+    assert output_path.exists()
+    assert output_path.with_name("results_10s.csv").exists()
+    assert output_path.with_name("results_daily.csv").exists()
+    assert not output_path.with_name("results_1h.csv").exists()
+
+
+def test_write_multi_resolution_results_requires_1s_frame(tmp_path: Path) -> None:
+    output_path = tmp_path / "out" / "results.csv"
+
+    with pytest.raises(KeyError, match="1s"):
+        write_multi_resolution_results({}, output_path)


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` IO seam into the staged `domains/load_cell` package
- preserve CSV ingestion, interpolation flags, and single/multi-resolution artifact writing behavior
- add seam-level regression tests and update architecture records for slice 047

## Validation
- poetry run pytest
- poetry run ruff check .

## Next Seam
- `load-cell-data/loadcell_pipeline/aggregation.py`

Closes #89
