### PR TITLE
[Model Change] Migrate load-cell-data aggregation seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -14,4 +14,5 @@ Current status:
 - Slices 025-045 migrated: TOMATO `tTHORP` contracts, interface, forcing, adapters, `TomatoModel`, runner, partitioning-package, package-level legacy pipeline, shared IO, shared scheduler, dayrun pipeline, repo-level scripts, feature-builder script, THORP reference adapter, plotting seams, `tGOSM` contract/interface seams, and `tTDGM` contract/interface seams
 - Slice 046 migrated: `load-cell-data` config seam
 - Slice 047 migrated: `load-cell-data` IO seam
-- Next blocked seam: `load-cell-data` aggregation seam at `loadcell_pipeline/aggregation.py`
+- Slice 048 migrated: `load-cell-data` aggregation seam
+- Next blocked seam: `load-cell-data` threshold-detection seam at `loadcell_pipeline/thresholds.py`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ poetry run ruff check .
 - TOMATO `tTDGM` interface seam is migrated as slice 045.
 - `load-cell-data` config seam is migrated as slice 046.
 - `load-cell-data` IO seam is migrated as slice 047.
+- `load-cell-data` aggregation seam is migrated as slice 048.
 
 ## Next validation
-- Audit the `load-cell-data` aggregation seam at `loadcell_pipeline/aggregation.py`.
+- Audit the `load-cell-data` threshold-detection seam at `loadcell_pipeline/thresholds.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 047
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 047 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 048
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 048 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -329,3 +329,9 @@ Slice 047:
 - target: `src/stomatal_optimiaztion/domains/load_cell/io.py`, package exports, and `tests/test_load_cell_io.py`
 - scope: bounded `load-cell-data` IO surface covering raw CSV ingestion, interpolation flags, duplicate-timestamp handling, and single/multi-resolution artifact writing
 - excluded: `loadcell_pipeline/aggregation.py`, preprocessing, workflow, CLI, and dashboard entrypoints
+
+Slice 048:
+- source: `load-cell-data/loadcell_pipeline/aggregation.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/aggregation.py`, package exports, and `tests/test_load_cell_aggregation.py`
+- scope: bounded `load-cell-data` aggregation surface covering flux resampling, daily summaries, event counts, label-derived durations, and metadata passthrough
+- excluded: `loadcell_pipeline/thresholds.py`, preprocessing, workflow, CLI, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -420,8 +420,16 @@ The forty-seventh slice opens the next bounded `load-cell-data` seam:
 - keep optional Excel export behavior explicit without widening into aggregation, preprocessing, workflow, or CLI seams
 - leave `load-cell-data/loadcell_pipeline/aggregation.py` blocked as the next seam
 
+## Slice 048: load-cell-data Aggregation
+
+The forty-eighth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/aggregation.py` into the staged `domains/load_cell` package
+- preserve coarse-timescale flux aggregation, daily summary assembly, event counts, label-derived durations, and metadata passthrough
+- keep the seam aggregation-bounded without widening into threshold detection, preprocessing, workflow, or CLI surfaces
+- leave `load-cell-data/loadcell_pipeline/thresholds.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first two `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first three `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/aggregation.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/thresholds.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 047 completed and slice 048 planning
+- Current phase: slice 048 completed and slice 049 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` aggregation seam at `loadcell_pipeline/aggregation.py`
-2. preserve the config-and-ingestion-first package boundary while deciding whether aggregation should precede preprocessing and workflow seams
+1. audit the `load-cell-data` threshold-detection seam at `loadcell_pipeline/thresholds.py`
+2. preserve the config-plus-IO-plus-aggregation package boundary while deciding whether threshold detection should precede preprocessing and workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-048-load-cell-aggregation.md
+++ b/docs/architecture/architecture/module_specs/module-048-load-cell-aggregation.md
@@ -1,0 +1,36 @@
+# Module Spec 048: load-cell-data Aggregation
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the aggregation helpers that downsample per-second flux outputs and assemble daily summaries.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/aggregation.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/aggregation.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_aggregation.py`
+
+## Responsibilities
+
+1. preserve coarse-timescale resampling of irrigation, drainage, and transpiration fluxes
+2. preserve daily summary assembly, including event counts, label-derived durations, and metadata passthrough
+3. keep the seam aggregation-bounded without widening into preprocessing, workflow, or CLI surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/thresholds.py`
+- migrate `load-cell-data/loadcell_pipeline/preprocessing.py`
+- widen into workflow or dashboard entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/thresholds.py`

--- a/docs/architecture/executor/issue-048-model-change.md
+++ b/docs/architecture/executor/issue-048-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 047` opened the bounded `load-cell-data` IO seam, so the next staged helper surface is the time-aggregation module at `loadcell_pipeline/aggregation.py`.
+- The migrated repo can now read and write per-second data, but it still lacks the canonical resampling and daily-summary helpers used by later workflow and CLI paths.
+- This slice should stay aggregation-bounded: time-step resampling, daily summary assembly, and metadata passthrough only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell aggregation tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for required-column validation, resampled flux totals/rates, daily summary event counts, label-derived durations, and metadata passthrough
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/aggregation.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/io.py`

--- a/docs/architecture/executor/pr-091-load-cell-aggregation.md
+++ b/docs/architecture/executor/pr-091-load-cell-aggregation.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` aggregation seam into the staged `domains/load_cell` package
+- preserve coarse-timescale flux aggregation, daily summary assembly, event counts, and metadata passthrough behavior
+- add seam-level regression tests and update architecture records for slice 048
+
+## Validation
+- poetry run pytest
+- poetry run ruff check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/thresholds.py`
+
+Closes #91

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed IO seam | aggregation, preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed aggregation seam | threshold detection, preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -1,3 +1,7 @@
+from stomatal_optimiaztion.domains.load_cell.aggregation import (
+    daily_summary,
+    resample_flux_timeseries,
+)
 from stomatal_optimiaztion.domains.load_cell.config import (
     PipelineConfig,
     load_config,
@@ -9,7 +13,9 @@ from stomatal_optimiaztion.domains.load_cell.io import (
 )
 
 __all__ = [
+    "daily_summary",
     "PipelineConfig",
+    "resample_flux_timeseries",
     "load_config",
     "read_load_cell_csv",
     "write_multi_resolution_results",

--- a/src/stomatal_optimiaztion/domains/load_cell/aggregation.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/aggregation.py
@@ -1,0 +1,199 @@
+"""Time aggregation utilities for load-cell pipeline outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+def resample_flux_timeseries(df_1s: pd.DataFrame, rule: str) -> pd.DataFrame:
+    """Resample per-second flux outputs to a coarser time step."""
+
+    if not isinstance(df_1s.index, pd.DatetimeIndex):
+        raise TypeError("df_1s must have a DateTimeIndex for resampling.")
+    if df_1s.empty:
+        return pd.DataFrame()
+
+    required = {"irrigation_kg_s", "drainage_kg_s", "transpiration_kg_s"}
+    missing = required - set(df_1s.columns)
+    if missing:
+        raise KeyError(f"df_1s missing required flux columns: {missing}")
+
+    grouped = df_1s.resample(rule)
+    out = pd.DataFrame(index=grouped.size().index)
+    out.index.name = "timestamp"
+
+    n_samples = grouped.size().astype("int64")
+    out["n_samples"] = n_samples
+
+    out["irrigation_kg"] = grouped["irrigation_kg_s"].sum(min_count=1).fillna(0.0)
+    out["drainage_kg"] = grouped["drainage_kg_s"].sum(min_count=1).fillna(0.0)
+    out["transpiration_kg"] = grouped["transpiration_kg_s"].sum(min_count=1).fillna(
+        0.0
+    )
+
+    denom = n_samples.replace(0, np.nan).astype(float)
+    out["irrigation_kg_s"] = (out["irrigation_kg"] / denom).fillna(0.0)
+    out["drainage_kg_s"] = (out["drainage_kg"] / denom).fillna(0.0)
+    out["transpiration_kg_s"] = (out["transpiration_kg"] / denom).fillna(0.0)
+
+    out["cum_irrigation_kg"] = out["irrigation_kg"].cumsum()
+    out["cum_drainage_kg"] = out["drainage_kg"].cumsum()
+    out["cum_transpiration_kg"] = out["transpiration_kg"].cumsum()
+
+    for col in [
+        "weight_raw_kg",
+        "weight_kg",
+        "weight_smooth_kg",
+        "reconstructed_weight_kg",
+        "water_balance_error_before_fix_kg",
+        "water_balance_error_kg",
+    ]:
+        if col in df_1s.columns:
+            out[f"{col}_end"] = grouped[col].last()
+
+    if "water_balance_error_kg" in df_1s.columns:
+        out["water_balance_error_kg_mean_abs"] = (
+            df_1s["water_balance_error_kg"].abs().resample(rule).mean()
+        )
+
+    if "is_interpolated" in df_1s.columns:
+        out["interpolated_frac"] = df_1s["is_interpolated"].resample(rule).mean()
+    if "is_outlier" in df_1s.columns:
+        out["outlier_frac"] = df_1s["is_outlier"].resample(rule).mean()
+    if "transpiration_scale" in df_1s.columns:
+        out["transpiration_scale"] = grouped["transpiration_scale"].last()
+
+    for col in [
+        "irrigation_time_sec",
+        "drainage_time_sec",
+        "irrigation_time_sec_raw",
+        "drainage_time_sec_raw",
+    ]:
+        if col in df_1s.columns:
+            out[col] = df_1s[col].resample(rule).sum().fillna(0.0)
+            out[col] = out[col].astype("int64")
+            out[col.replace("_sec", "_frac")] = (out[col] / denom).fillna(0.0)
+
+    for col in ["substrate_ec_ds", "substrate_moisture_percent"]:
+        if col in df_1s.columns:
+            out[col] = df_1s[col].resample(rule).mean()
+
+    return out
+
+
+def daily_summary(
+    df_1s: pd.DataFrame,
+    events_df: pd.DataFrame | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    """Build 1-day summary rows from per-second results."""
+
+    if not isinstance(df_1s.index, pd.DatetimeIndex):
+        raise TypeError("df_1s must have a DateTimeIndex for resampling.")
+    if df_1s.empty:
+        return pd.DataFrame()
+
+    day_rule = "1D"
+    out = pd.DataFrame(index=df_1s.resample(day_rule).size().index)
+    out.index.name = "day"
+
+    out["n_samples"] = df_1s.resample(day_rule).size().astype("int64")
+    index_series = df_1s.index.to_series()
+    out["start_time"] = index_series.resample(day_rule).min()
+    out["end_time"] = index_series.resample(day_rule).max()
+
+    if "irrigation_kg_s" in df_1s.columns:
+        out["total_irrigation_kg"] = df_1s["irrigation_kg_s"].resample(day_rule).sum()
+    if "drainage_kg_s" in df_1s.columns:
+        out["total_drainage_kg"] = df_1s["drainage_kg_s"].resample(day_rule).sum()
+    if "transpiration_kg_s" in df_1s.columns:
+        out["total_transpiration_kg"] = (
+            df_1s["transpiration_kg_s"].resample(day_rule).sum()
+        )
+
+    if "water_balance_error_kg" in df_1s.columns:
+        out["final_balance_error_kg"] = (
+            df_1s["water_balance_error_kg"].resample(day_rule).last()
+        )
+        out["mean_abs_balance_error_kg"] = (
+            df_1s["water_balance_error_kg"].abs().resample(day_rule).mean()
+        )
+
+    if "is_interpolated" in df_1s.columns:
+        out["interpolated_frac"] = df_1s["is_interpolated"].resample(day_rule).mean()
+    if "is_outlier" in df_1s.columns:
+        out["outlier_frac"] = df_1s["is_outlier"].resample(day_rule).mean()
+    if "transpiration_scale" in df_1s.columns:
+        out["transpiration_scale"] = (
+            df_1s["transpiration_scale"].resample(day_rule).last()
+        )
+
+    for col in [
+        "irrigation_time_sec",
+        "drainage_time_sec",
+        "irrigation_time_sec_raw",
+        "drainage_time_sec_raw",
+    ]:
+        if col in df_1s.columns:
+            out[col] = df_1s[col].resample(day_rule).sum().fillna(0.0).astype("int64")
+
+    if "irrigation_time_sec" not in out.columns and "label" in df_1s.columns:
+        labels = df_1s["label"].fillna("baseline").astype(str)
+        out["irrigation_time_sec_raw"] = (
+            (labels == "irrigation").resample(day_rule).sum().fillna(0.0).astype("int64")
+        )
+        out["drainage_time_sec_raw"] = (
+            (labels == "drainage").resample(day_rule).sum().fillna(0.0).astype("int64")
+        )
+
+    denom_day = out["n_samples"].replace(0, np.nan).astype(float)
+    for col in [
+        "irrigation_time_sec",
+        "drainage_time_sec",
+        "irrigation_time_sec_raw",
+        "drainage_time_sec_raw",
+    ]:
+        if col in out.columns:
+            out[col.replace("_sec", "_frac")] = (out[col] / denom_day).fillna(0.0)
+
+    for col in ["substrate_ec_ds", "substrate_moisture_percent"]:
+        if col in df_1s.columns:
+            out[col] = df_1s[col].resample(day_rule).mean()
+
+    out["irrigation_event_count"] = 0
+    out["drainage_event_count"] = 0
+    if (
+        events_df is not None
+        and isinstance(events_df, pd.DataFrame)
+        and not events_df.empty
+        and {"start_time", "event_type"}.issubset(events_df.columns)
+    ):
+        events = events_df.copy()
+        events["day"] = pd.to_datetime(events["start_time"], errors="coerce").dt.floor(
+            "D"
+        )
+        counts = (
+            events.dropna(subset=["day"])
+            .groupby(["day", "event_type"])
+            .size()
+            .unstack(fill_value=0)
+        )
+        if "irrigation" in counts.columns:
+            out["irrigation_event_count"] = (
+                out.index.map(counts["irrigation"]).fillna(0).astype(int)
+            )
+        if "drainage" in counts.columns:
+            out["drainage_event_count"] = (
+                out.index.map(counts["drainage"]).fillna(0).astype(int)
+            )
+
+    if metadata:
+        if "irrigation_threshold" in metadata:
+            out["irrigation_threshold"] = float(metadata["irrigation_threshold"])
+        if "drainage_threshold" in metadata:
+            out["drainage_threshold"] = float(metadata["drainage_threshold"])
+
+    return out

--- a/tests/test_load_cell_aggregation.py
+++ b/tests/test_load_cell_aggregation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import (
+    daily_summary,
+    resample_flux_timeseries,
+)
+
+
+def _make_flux_frame() -> pd.DataFrame:
+    index = pd.date_range("2025-06-01 00:00:00", periods=4, freq="1s", name="timestamp")
+    return pd.DataFrame(
+        {
+            "irrigation_kg_s": [1.0, 0.0, 0.0, 0.0],
+            "drainage_kg_s": [0.0, 1.0, 0.0, 0.0],
+            "transpiration_kg_s": [0.1, 0.1, 0.2, 0.2],
+            "weight_raw_kg": [10.0, 10.1, 10.2, 10.3],
+            "weight_kg": [10.0, 10.1, 10.2, 10.3],
+            "water_balance_error_kg": [0.0, 0.1, 0.0, 0.1],
+            "is_interpolated": [False, True, False, False],
+            "is_outlier": [False, False, True, False],
+            "transpiration_scale": [1.0, 1.0, 0.9, 0.9],
+            "irrigation_time_sec": [1, 0, 0, 0],
+            "drainage_time_sec": [0, 1, 0, 0],
+            "substrate_ec_ds": [2.0, 2.2, 2.4, 2.6],
+            "substrate_moisture_percent": [30.0, 31.0, 32.0, 33.0],
+            "label": ["irrigation", "drainage", "baseline", "baseline"],
+        },
+        index=index,
+    )
+
+
+def test_load_cell_import_surface_exposes_aggregation_helpers() -> None:
+    assert load_cell.resample_flux_timeseries is resample_flux_timeseries
+    assert load_cell.daily_summary is daily_summary
+
+
+def test_resample_flux_timeseries_aggregates_totals_and_rates() -> None:
+    out = resample_flux_timeseries(_make_flux_frame(), "2s")
+
+    assert list(out.index.astype(str)) == [
+        "2025-06-01 00:00:00",
+        "2025-06-01 00:00:02",
+    ]
+    assert out.loc["2025-06-01 00:00:00", "n_samples"] == 2
+    assert out.loc["2025-06-01 00:00:00", "irrigation_kg"] == 1.0
+    assert out.loc["2025-06-01 00:00:00", "drainage_kg"] == 1.0
+    assert out.loc["2025-06-01 00:00:00", "transpiration_kg"] == 0.2
+    assert out.loc["2025-06-01 00:00:00", "irrigation_kg_s"] == 0.5
+    assert out.loc["2025-06-01 00:00:00", "drainage_kg_s"] == 0.5
+    assert out.loc["2025-06-01 00:00:02", "cum_transpiration_kg"] == pytest.approx(0.6)
+    assert out.loc["2025-06-01 00:00:00", "weight_kg_end"] == 10.1
+    assert out.loc["2025-06-01 00:00:00", "interpolated_frac"] == 0.5
+    assert out.loc["2025-06-01 00:00:02", "outlier_frac"] == 0.5
+    assert out.loc["2025-06-01 00:00:00", "irrigation_time_frac"] == 0.5
+    assert out.loc["2025-06-01 00:00:00", "substrate_ec_ds"] == 2.1
+
+
+def test_resample_flux_timeseries_validates_input() -> None:
+    frame = _make_flux_frame().reset_index(drop=True)
+    with pytest.raises(TypeError, match="DateTimeIndex"):
+        resample_flux_timeseries(frame, "2s")
+
+    with pytest.raises(KeyError, match="required flux columns"):
+        resample_flux_timeseries(_make_flux_frame()[["weight_kg"]], "2s")
+
+    assert resample_flux_timeseries(_make_flux_frame().iloc[0:0], "2s").empty
+
+
+def test_daily_summary_uses_events_and_metadata() -> None:
+    events_df = pd.DataFrame(
+        {
+            "start_time": ["2025-06-01 00:00:00", "2025-06-01 12:00:00"],
+            "event_type": ["irrigation", "drainage"],
+        }
+    )
+
+    out = daily_summary(
+        _make_flux_frame(),
+        events_df=events_df,
+        metadata={"irrigation_threshold": 0.3, "drainage_threshold": -0.2},
+    )
+
+    assert list(out.index.astype(str)) == ["2025-06-01"]
+    assert out.loc["2025-06-01", "n_samples"] == 4
+    assert out.loc["2025-06-01", "total_irrigation_kg"] == 1.0
+    assert out.loc["2025-06-01", "total_drainage_kg"] == 1.0
+    assert out.loc["2025-06-01", "total_transpiration_kg"] == pytest.approx(0.6)
+    assert out.loc["2025-06-01", "irrigation_event_count"] == 1
+    assert out.loc["2025-06-01", "drainage_event_count"] == 1
+    assert out.loc["2025-06-01", "irrigation_time_sec"] == 1
+    assert out.loc["2025-06-01", "irrigation_time_frac"] == 0.25
+    assert out.loc["2025-06-01", "irrigation_threshold"] == 0.3
+    assert out.loc["2025-06-01", "drainage_threshold"] == -0.2
+
+
+def test_daily_summary_derives_raw_durations_from_labels_when_needed() -> None:
+    frame = _make_flux_frame().drop(columns=["irrigation_time_sec", "drainage_time_sec"])
+
+    out = daily_summary(frame)
+
+    assert out.loc["2025-06-01", "irrigation_time_sec_raw"] == 1
+    assert out.loc["2025-06-01", "drainage_time_sec_raw"] == 1
+    assert out.loc["2025-06-01", "irrigation_time_frac_raw"] == 0.25
+    assert out.loc["2025-06-01", "drainage_time_frac_raw"] == 0.25
+
+
+def test_daily_summary_validates_input() -> None:
+    frame = _make_flux_frame().reset_index(drop=True)
+    with pytest.raises(TypeError, match="DateTimeIndex"):
+        daily_summary(frame)
+
+    assert daily_summary(_make_flux_frame().iloc[0:0]).empty


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` aggregation seam into the staged `domains/load_cell` package
- preserve coarse-timescale flux aggregation, daily summary assembly, event counts, and metadata passthrough behavior
- add seam-level regression tests and update architecture records for slice 048

## Validation
- poetry run pytest
- poetry run ruff check .

## Next Seam
- `load-cell-data/loadcell_pipeline/thresholds.py`

Closes #91
