### PR TITLE
[Model Change] Migrate load-cell-data thresholds seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -15,4 +15,5 @@ Current status:
 - Slice 046 migrated: `load-cell-data` config seam
 - Slice 047 migrated: `load-cell-data` IO seam
 - Slice 048 migrated: `load-cell-data` aggregation seam
-- Next blocked seam: `load-cell-data` threshold-detection seam at `loadcell_pipeline/thresholds.py`
+- Slice 049 migrated: `load-cell-data` threshold-detection seam
+- Next blocked seam: `load-cell-data` preprocessing seam at `loadcell_pipeline/preprocessing.py`

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ poetry run ruff check .
 - `load-cell-data` config seam is migrated as slice 046.
 - `load-cell-data` IO seam is migrated as slice 047.
 - `load-cell-data` aggregation seam is migrated as slice 048.
+- `load-cell-data` threshold-detection seam is migrated as slice 049.
 
 ## Next validation
-- Audit the `load-cell-data` threshold-detection seam at `loadcell_pipeline/thresholds.py`.
+- Audit the `load-cell-data` preprocessing seam at `loadcell_pipeline/preprocessing.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 048
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 048 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 049
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 049 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -335,3 +335,9 @@ Slice 048:
 - target: `src/stomatal_optimiaztion/domains/load_cell/aggregation.py`, package exports, and `tests/test_load_cell_aggregation.py`
 - scope: bounded `load-cell-data` aggregation surface covering flux resampling, daily summaries, event counts, label-derived durations, and metadata passthrough
 - excluded: `loadcell_pipeline/thresholds.py`, preprocessing, workflow, CLI, and dashboard entrypoints
+
+Slice 049:
+- source: `load-cell-data/loadcell_pipeline/thresholds.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/thresholds.py`, package exports, and `tests/test_load_cell_thresholds.py`
+- scope: bounded `load-cell-data` threshold surface covering robust sigma estimation, valid-mask fallback, and irrigation/drainage threshold constraints
+- excluded: `loadcell_pipeline/preprocessing.py`, workflow, CLI, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -428,8 +428,16 @@ The forty-eighth slice opens the next bounded `load-cell-data` seam:
 - keep the seam aggregation-bounded without widening into threshold detection, preprocessing, workflow, or CLI surfaces
 - leave `load-cell-data/loadcell_pipeline/thresholds.py` blocked as the next seam
 
+## Slice 049: load-cell-data Thresholds
+
+The forty-ninth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/thresholds.py` into the staged `domains/load_cell` package
+- preserve robust derivative-distribution threshold detection, valid-mask fallback, and physical sign constraints
+- keep the seam threshold-bounded without widening into preprocessing, workflow, or CLI surfaces
+- leave `load-cell-data/loadcell_pipeline/preprocessing.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first three `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first four `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/thresholds.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/preprocessing.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 048 completed and slice 049 planning
+- Current phase: slice 049 completed and slice 050 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` threshold-detection seam at `loadcell_pipeline/thresholds.py`
-2. preserve the config-plus-IO-plus-aggregation package boundary while deciding whether threshold detection should precede preprocessing and workflow seams
+1. audit the `load-cell-data` preprocessing seam at `loadcell_pipeline/preprocessing.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds package boundary while deciding whether preprocessing should precede workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-049-load-cell-thresholds.md
+++ b/docs/architecture/architecture/module_specs/module-049-load-cell-thresholds.md
@@ -1,0 +1,36 @@
+# Module Spec 049: load-cell-data Thresholds
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the adaptive threshold detector that converts smoothed derivatives into irrigation and drainage thresholds.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/thresholds.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/thresholds.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_thresholds.py`
+
+## Responsibilities
+
+1. preserve robust baseline and sigma estimation from the derivative distribution
+2. preserve valid-mask fallback behavior plus physical sign constraints on irrigation and drainage thresholds
+3. keep the seam threshold-bounded without widening into preprocessing, workflow, or CLI surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/preprocessing.py`
+- migrate event-labeling or workflow orchestration
+- widen into dashboard entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/preprocessing.py`

--- a/docs/architecture/executor/issue-049-model-change.md
+++ b/docs/architecture/executor/issue-049-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 048` opened the bounded `load-cell-data` aggregation seam, so the next staged helper surface is the adaptive threshold detector at `loadcell_pipeline/thresholds.py`.
+- The migrated repo now has config, IO, and aggregation helpers, but it still lacks the canonical threshold estimator that later event-labeling and workflow seams depend on.
+- This slice should stay threshold-bounded: derivative distribution filtering, robust sigma estimation, and irrigation/drainage threshold output only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell threshold tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for empty-series rejection, valid-mask fallback behavior, minimum sigma fallback, physical sign constraints, and logger diagnostics
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/thresholds.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/aggregation.py`

--- a/docs/architecture/executor/pr-093-load-cell-thresholds.md
+++ b/docs/architecture/executor/pr-093-load-cell-thresholds.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` thresholds seam into the staged `domains/load_cell` package
+- preserve adaptive irrigation/drainage threshold estimation, valid-mask fallback, and sign constraints
+- add seam-level regression tests and update architecture records for slice 049
+
+## Validation
+- poetry run pytest
+- poetry run ruff check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/preprocessing.py`
+
+Closes #93

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed aggregation seam | threshold detection, preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed threshold-detection seam | preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -11,8 +11,12 @@ from stomatal_optimiaztion.domains.load_cell.io import (
     write_multi_resolution_results,
     write_results,
 )
+from stomatal_optimiaztion.domains.load_cell.thresholds import (
+    auto_detect_step_thresholds,
+)
 
 __all__ = [
+    "auto_detect_step_thresholds",
     "daily_summary",
     "PipelineConfig",
     "resample_flux_timeseries",

--- a/src/stomatal_optimiaztion/domains/load_cell/thresholds.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/thresholds.py
@@ -1,0 +1,80 @@
+"""Automatic threshold detection for irrigation and drainage events."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+
+def auto_detect_step_thresholds(
+    d_w_smooth: pd.Series,
+    min_pos_events: int = 5,
+    min_neg_events: int = 5,
+    k_tail: float = 4.0,
+    min_factor: float = 3.0,
+    valid_mask: pd.Series | None = None,
+    logger: logging.Logger | None = None,
+) -> tuple[float, float]:
+    """Estimate irrigation and drainage thresholds from a derivative series."""
+
+    if d_w_smooth is None:
+        raise ValueError("dW_smooth cannot be None.")
+
+    x = pd.Series(d_w_smooth)
+    if valid_mask is not None:
+        vm = pd.Series(valid_mask, index=x.index).fillna(False).astype(bool)
+        filtered = x[vm]
+        x = filtered if filtered.dropna().size > 0 else x
+    x = x.dropna()
+    if x.empty:
+        raise ValueError("Cannot detect thresholds from empty derivative series.")
+
+    p_low, p_high = x.quantile([0.05, 0.95])
+    central = x[(x >= p_low) & (x <= p_high)]
+    if central.empty:
+        central = x
+
+    m0 = central.median()
+    mad = (central - m0).abs().median()
+    if pd.notna(mad) and mad > 0:
+        noise_sigma = float(1.4826 * mad)
+    else:
+        noise_sigma = 0.0
+    if noise_sigma <= 0:
+        candidates = [
+            float(central.std(ddof=0)),
+            float((central - m0).abs().median()),
+            1e-6,
+        ]
+        finite_candidates = [c for c in candidates if np.isfinite(c) and c > 0]
+        noise_sigma = max(finite_candidates) if finite_candidates else 1e-6
+
+    irrigation_threshold = float(m0 + k_tail * noise_sigma)
+    drainage_threshold = float(m0 - k_tail * noise_sigma)
+
+    irrigation_threshold = max(
+        irrigation_threshold, float(m0 + min_factor * noise_sigma)
+    )
+    drainage_threshold = min(
+        drainage_threshold, float(m0 - min_factor * noise_sigma)
+    )
+
+    irrigation_threshold = max(irrigation_threshold, 0.0)
+    drainage_threshold = min(drainage_threshold, 0.0)
+
+    high_pos = x[x >= irrigation_threshold]
+    high_neg = x[x <= drainage_threshold]
+    if logger:
+        logger.info(
+            "Auto thresholds -> m0=%.4g, sigma=%.4g, pos_tail=%d, neg_tail=%d, irrig=%.4g, drain=%.4g",
+            float(m0),
+            noise_sigma,
+            len(high_pos),
+            len(high_neg),
+            irrigation_threshold,
+            drainage_threshold,
+        )
+
+    return float(irrigation_threshold), float(drainage_threshold)

--- a/tests/test_load_cell_thresholds.py
+++ b/tests/test_load_cell_thresholds.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import auto_detect_step_thresholds
+
+
+def test_load_cell_import_surface_exposes_threshold_helper() -> None:
+    assert load_cell.auto_detect_step_thresholds is auto_detect_step_thresholds
+
+
+def test_auto_detect_step_thresholds_rejects_none_and_empty_series() -> None:
+    with pytest.raises(ValueError, match="cannot be None"):
+        auto_detect_step_thresholds(None)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="empty derivative series"):
+        auto_detect_step_thresholds(pd.Series([], dtype=float))
+
+
+def test_auto_detect_step_thresholds_falls_back_when_valid_mask_removes_all() -> None:
+    d_w_smooth = pd.Series([0.0, 0.01, -0.01, 0.02, -0.02])
+    valid_mask = pd.Series([False, False, False, False, False])
+
+    unmasked = auto_detect_step_thresholds(d_w_smooth)
+    masked = auto_detect_step_thresholds(d_w_smooth, valid_mask=valid_mask)
+
+    assert masked == unmasked
+
+
+def test_auto_detect_step_thresholds_uses_minimum_sigma_fallback() -> None:
+    irrigation_threshold, drainage_threshold = auto_detect_step_thresholds(
+        pd.Series([0.0, 0.0, 0.0, 0.0])
+    )
+
+    assert irrigation_threshold == pytest.approx(4e-6)
+    assert drainage_threshold == pytest.approx(-4e-6)
+
+
+def test_auto_detect_step_thresholds_enforces_sign_constraints_and_logs() -> None:
+    d_w_smooth = pd.Series(
+        [-0.3, -0.2, -0.01, 0.0, 0.01, 0.2, 0.3],
+        index=pd.RangeIndex(7),
+    )
+    logger = Mock()
+
+    irrigation_threshold, drainage_threshold = auto_detect_step_thresholds(
+        d_w_smooth,
+        logger=logger,
+    )
+
+    assert irrigation_threshold >= 0.0
+    assert drainage_threshold <= 0.0
+    assert irrigation_threshold > drainage_threshold
+    logger.info.assert_called_once()


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` thresholds seam into the staged `domains/load_cell` package
- preserve adaptive irrigation/drainage threshold estimation, valid-mask fallback, and sign constraints
- add seam-level regression tests and update architecture records for slice 049

## Validation
- poetry run pytest
- poetry run ruff check .

## Next Seam
- `load-cell-data/loadcell_pipeline/preprocessing.py`

Closes #93
