### PR TITLE
[Model Change] Migrate load-cell-data preprocessing seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -16,4 +16,5 @@ Current status:
 - Slice 047 migrated: `load-cell-data` IO seam
 - Slice 048 migrated: `load-cell-data` aggregation seam
 - Slice 049 migrated: `load-cell-data` threshold-detection seam
-- Next blocked seam: `load-cell-data` preprocessing seam at `loadcell_pipeline/preprocessing.py`
+- Slice 050 migrated: `load-cell-data` preprocessing seam
+- Next blocked seam: `load-cell-data` event-detection seam at `loadcell_pipeline/events.py`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ poetry run ruff check .
 - `load-cell-data` IO seam is migrated as slice 047.
 - `load-cell-data` aggregation seam is migrated as slice 048.
 - `load-cell-data` threshold-detection seam is migrated as slice 049.
+- `load-cell-data` preprocessing seam is migrated as slice 050.
 
 ## Next validation
-- Audit the `load-cell-data` preprocessing seam at `loadcell_pipeline/preprocessing.py`.
+- Audit the `load-cell-data` event-detection seam at `loadcell_pipeline/events.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 049
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 049 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 050
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 050 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -341,3 +341,9 @@ Slice 049:
 - target: `src/stomatal_optimiaztion/domains/load_cell/thresholds.py`, package exports, and `tests/test_load_cell_thresholds.py`
 - scope: bounded `load-cell-data` threshold surface covering robust sigma estimation, valid-mask fallback, and irrigation/drainage threshold constraints
 - excluded: `loadcell_pipeline/preprocessing.py`, workflow, CLI, and dashboard entrypoints
+
+Slice 050:
+- source: `load-cell-data/loadcell_pipeline/preprocessing.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/preprocessing.py`, package exports, and `tests/test_load_cell_preprocessing.py`
+- scope: bounded `load-cell-data` preprocessing surface covering impulsive outlier correction, moving-average and Savitzky-Golay smoothing, and derivative reconstruction
+- excluded: `loadcell_pipeline/events.py`, flux decomposition, workflow, CLI, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -436,8 +436,16 @@ The forty-ninth slice opens the next bounded `load-cell-data` seam:
 - keep the seam threshold-bounded without widening into preprocessing, workflow, or CLI surfaces
 - leave `load-cell-data/loadcell_pipeline/preprocessing.py` blocked as the next seam
 
+## Slice 050: load-cell-data Preprocessing
+
+The fiftieth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/preprocessing.py` into the staged `domains/load_cell` package
+- preserve impulsive outlier detection/correction, moving-average and Savitzky-Golay smoothing, and derivative reconstruction behavior
+- keep the seam preprocessing-bounded without widening into event detection, flux decomposition, workflow, or CLI surfaces
+- leave `load-cell-data/loadcell_pipeline/events.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first four `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first five `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/preprocessing.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/events.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 049 completed and slice 050 planning
+- Current phase: slice 050 completed and slice 051 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` preprocessing seam at `loadcell_pipeline/preprocessing.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds package boundary while deciding whether preprocessing should precede workflow seams
+1. audit the `load-cell-data` event-detection seam at `loadcell_pipeline/events.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing package boundary while deciding whether event detection should precede flux decomposition and workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-050-load-cell-preprocessing.md
+++ b/docs/architecture/architecture/module_specs/module-050-load-cell-preprocessing.md
@@ -1,0 +1,36 @@
+# Module Spec 050: load-cell-data Preprocessing
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the signal preprocessing helpers that correct impulsive spikes and smooth weight time series.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/preprocessing.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/preprocessing.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_preprocessing.py`
+
+## Responsibilities
+
+1. preserve impulsive outlier detection, correction, and raw derivative bookkeeping
+2. preserve moving-average and Savitzky-Golay smoothing plus derivative reconstruction modes
+3. keep the seam preprocessing-bounded without widening into event grouping, workflow, or CLI surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/events.py`
+- migrate `load-cell-data/loadcell_pipeline/fluxes.py`
+- widen into dashboard or workflow entrypoints
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/events.py`

--- a/docs/architecture/executor/issue-050-model-change.md
+++ b/docs/architecture/executor/issue-050-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 049` opened the bounded `load-cell-data` threshold-detection seam, so the next staged helper surface is the signal preprocessing module at `loadcell_pipeline/preprocessing.py`.
+- The migrated repo now has config, IO, aggregation, and threshold helpers, but it still lacks the canonical outlier-correction and smoothing functions that upstream event detection depends on.
+- This slice should stay preprocessing-bounded: outlier detection/correction, smoothing, and derivative reconstruction only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell preprocessing tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for missing-column rejection, short-series handling, invalid parameter rejection, Savitzky-Golay fallback/error paths, and derivative modes
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/preprocessing.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/thresholds.py`

--- a/docs/architecture/executor/pr-095-load-cell-preprocessing.md
+++ b/docs/architecture/executor/pr-095-load-cell-preprocessing.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` preprocessing seam into the staged `domains/load_cell` package
+- preserve outlier correction, smoothing, and derivative reconstruction behavior
+- add seam-level regression tests and update architecture records for slice 050
+
+## Validation
+- .\\.venv\\Scripts\\python.exe -m pytest
+- .\\.venv\\Scripts\\ruff.exe check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/events.py`
+
+Closes #95

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed threshold-detection seam | preprocessing, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed preprocessing seam | event detection, flux decomposition, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -11,6 +11,10 @@ from stomatal_optimiaztion.domains.load_cell.io import (
     write_multi_resolution_results,
     write_results,
 )
+from stomatal_optimiaztion.domains.load_cell.preprocessing import (
+    detect_and_correct_outliers,
+    smooth_weight,
+)
 from stomatal_optimiaztion.domains.load_cell.thresholds import (
     auto_detect_step_thresholds,
 )
@@ -18,10 +22,12 @@ from stomatal_optimiaztion.domains.load_cell.thresholds import (
 __all__ = [
     "auto_detect_step_thresholds",
     "daily_summary",
+    "detect_and_correct_outliers",
     "PipelineConfig",
     "resample_flux_timeseries",
     "load_config",
     "read_load_cell_csv",
+    "smooth_weight",
     "write_multi_resolution_results",
     "write_results",
 ]

--- a/src/stomatal_optimiaztion/domains/load_cell/preprocessing.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/preprocessing.py
@@ -1,0 +1,185 @@
+"""Preprocessing utilities for load-cell weight signals."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+try:
+    from scipy.signal import savgol_filter
+except ImportError:  # pragma: no cover - optional dependency
+    savgol_filter = None
+
+
+def detect_and_correct_outliers(
+    df: pd.DataFrame,
+    k_outlier: float = 10.0,
+    max_spike_width_sec: int = 2,
+) -> pd.DataFrame:
+    """Identify derivative spikes and correct suspicious weight samples."""
+
+    if "weight_kg" not in df:
+        raise KeyError("Input DataFrame must contain 'weight_kg'.")
+
+    if len(df) < 3:
+        df_copy = df.copy()
+        df_copy["dW_raw_kg_s"] = df_copy["weight_kg"].diff()
+        df_copy["is_outlier"] = False
+        return df_copy
+
+    if max_spike_width_sec < 1:
+        raise ValueError("max_spike_width_sec must be >= 1.")
+
+    df_out = df.copy()
+    weight = df_out["weight_kg"].astype(float)
+    d_w_raw = weight.diff()
+    df_out["dW_raw_kg_s"] = d_w_raw
+
+    d_w_non_na = d_w_raw.dropna()
+    if d_w_non_na.empty:
+        df_out["is_outlier"] = False
+        return df_out
+
+    q_low, q_high = d_w_non_na.quantile([0.1, 0.9])
+    central = d_w_non_na[(d_w_non_na >= q_low) & (d_w_non_na <= q_high)]
+    if central.empty:
+        central = d_w_non_na
+
+    median = central.median(skipna=True)
+    mad = (central - median).abs().median(skipna=True)
+    noise_sigma = float(1.4826 * mad) if pd.notna(mad) else 0.0
+
+    threshold = k_outlier * noise_sigma
+    if threshold <= 0 or np.isnan(threshold):
+        df_out["is_outlier"] = False
+        return df_out
+
+    candidate = d_w_raw.abs() > threshold
+    candidate = candidate.fillna(False)
+
+    run_id = (candidate != candidate.shift(1)).cumsum()
+    run_lengths = candidate.groupby(run_id).transform("sum")
+    short_run = candidate & (run_lengths <= max_spike_width_sec)
+
+    opposite_next = (d_w_raw * d_w_raw.shift(-1) < 0) & (
+        d_w_raw.shift(-1).abs() > threshold
+    )
+    opposite_prev = (d_w_raw * d_w_raw.shift(1) < 0) & (
+        d_w_raw.shift(1).abs() > threshold
+    )
+    impulsive = opposite_next.fillna(False) | opposite_prev.fillna(False)
+
+    outlier_mask = short_run & (impulsive | (max_spike_width_sec > 1))
+    outlier_mask = outlier_mask.fillna(False)
+    df_out["is_outlier"] = outlier_mask
+
+    if outlier_mask.any():
+        corrected = weight.copy()
+        corrected.loc[outlier_mask] = np.nan
+        corrected = corrected.interpolate(
+            method="linear",
+            limit_direction="both",
+        )
+        df_out["weight_kg"] = corrected
+
+    return df_out
+
+
+def smooth_weight(
+    df: pd.DataFrame,
+    method: str = "savgol",
+    window_sec: int = 31,
+    poly_order: int = 2,
+    derivative_method: str = "central",
+) -> pd.DataFrame:
+    """Smooth weight and compute per-second derivatives."""
+
+    if "weight_kg" not in df:
+        raise KeyError("Input DataFrame must contain 'weight_kg'.")
+
+    if window_sec < 3:
+        raise ValueError("window_sec must be >= 3 seconds.")
+
+    df_out = df.copy()
+    weight = df_out["weight_kg"].astype(float)
+    method = method.lower()
+    derivative_method = derivative_method.lower()
+
+    if method in {"ma", "moving_average"}:
+        smoothed = weight.rolling(window=window_sec, center=True, min_periods=1).mean()
+    elif method == "savgol":
+        if savgol_filter is None:
+            raise RuntimeError(
+                "scipy is required for Savitzky-Golay smoothing but is not installed.",
+            )
+        series_len = len(weight)
+        if series_len < poly_order + 2:
+            raise ValueError(
+                "Time series is too short for requested Savitzky-Golay parameters.",
+            )
+        window_length = window_sec
+        if window_length % 2 == 0:
+            window_length += 1
+        min_window = poly_order + 2
+        if min_window % 2 == 0:
+            min_window += 1
+        window_length = max(window_length, min_window)
+        max_window = series_len if series_len % 2 == 1 else series_len - 1
+        window_length = min(window_length, max_window)
+        smoothed = pd.Series(
+            savgol_filter(
+                weight.to_numpy(),
+                window_length=window_length,
+                polyorder=min(poly_order, window_length - 1),
+                mode="interp",
+            ),
+            index=weight.index,
+        )
+    else:
+        raise ValueError("method must be 'ma' or 'savgol'.")
+
+    df_out["weight_smooth_kg"] = smoothed
+
+    if derivative_method == "diff":
+        d_w = smoothed.diff()
+    elif derivative_method == "central":
+        if len(smoothed) < 2:
+            d_w = smoothed.copy() * 0.0
+        else:
+            d_w = (smoothed.shift(-1) - smoothed.shift(1)) / 2.0
+            d_w.iloc[0] = smoothed.iloc[1] - smoothed.iloc[0]
+            d_w.iloc[-1] = smoothed.iloc[-1] - smoothed.iloc[-2]
+    elif derivative_method == "savgol":
+        if method != "savgol":
+            raise ValueError("derivative_method='savgol' requires method='savgol'.")
+        if savgol_filter is None:
+            raise RuntimeError(
+                "scipy is required for Savitzky-Golay derivative but is not installed.",
+            )
+        series_len = len(weight)
+        window_length = window_sec
+        if window_length % 2 == 0:
+            window_length += 1
+        min_window = poly_order + 2
+        if min_window % 2 == 0:
+            min_window += 1
+        window_length = max(window_length, min_window)
+        max_window = series_len if series_len % 2 == 1 else series_len - 1
+        window_length = min(window_length, max_window)
+        d_w = pd.Series(
+            savgol_filter(
+                weight.to_numpy(),
+                window_length=window_length,
+                polyorder=min(poly_order, window_length - 1),
+                deriv=1,
+                delta=1.0,
+                mode="interp",
+            ),
+            index=weight.index,
+        )
+    else:
+        raise ValueError("derivative_method must be 'diff', 'central', or 'savgol'.")
+
+    df_out["dW_smooth_kg_s"] = pd.Series(d_w, index=smoothed.index).fillna(0.0)
+
+    return df_out

--- a/tests/test_load_cell_preprocessing.py
+++ b/tests/test_load_cell_preprocessing.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import (
+    detect_and_correct_outliers,
+    smooth_weight,
+)
+
+
+def test_load_cell_import_surface_exposes_preprocessing_helpers() -> None:
+    assert load_cell.detect_and_correct_outliers is detect_and_correct_outliers
+    assert load_cell.smooth_weight is smooth_weight
+
+
+def test_detect_and_correct_outliers_requires_weight_column() -> None:
+    with pytest.raises(KeyError, match="weight_kg"):
+        detect_and_correct_outliers(pd.DataFrame({"x": [1.0, 2.0]}))
+
+
+def test_detect_and_correct_outliers_handles_short_series() -> None:
+    df = pd.DataFrame({"weight_kg": [1.0, 1.2]})
+
+    out = detect_and_correct_outliers(df)
+
+    assert "dW_raw_kg_s" in out
+    assert "is_outlier" in out
+    assert out["is_outlier"].tolist() == [False, False]
+    assert pd.isna(out.loc[0, "dW_raw_kg_s"])
+    assert out.loc[1, "dW_raw_kg_s"] == pytest.approx(0.2)
+
+
+def test_detect_and_correct_outliers_validates_max_spike_width() -> None:
+    df = pd.DataFrame({"weight_kg": [1.0, 1.1, 1.2]})
+
+    with pytest.raises(ValueError, match=">= 1"):
+        detect_and_correct_outliers(df, max_spike_width_sec=0)
+
+
+def test_detect_and_correct_outliers_corrects_impulsive_spike() -> None:
+    df = pd.DataFrame(
+        {"weight_kg": [1.0, 1.1, 1.0, 1.1, 1.0, 5.0, 1.0, 1.1, 1.0]}
+    )
+
+    out = detect_and_correct_outliers(df, k_outlier=1.0, max_spike_width_sec=2)
+
+    assert out["is_outlier"].sum() >= 1
+    assert 1.0 <= out.loc[5, "weight_kg"] <= 1.1
+    assert out.loc[5, "weight_kg"] < 5.0
+
+
+def test_smooth_weight_validates_inputs() -> None:
+    with pytest.raises(KeyError, match="weight_kg"):
+        smooth_weight(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+
+    with pytest.raises(ValueError, match=">= 3"):
+        smooth_weight(pd.DataFrame({"weight_kg": [1.0, 2.0, 3.0]}), window_sec=2)
+
+    with pytest.raises(ValueError, match="method must be"):
+        smooth_weight(
+            pd.DataFrame({"weight_kg": [1.0, 2.0, 3.0]}),
+            method="median",
+            window_sec=3,
+        )
+
+
+def test_smooth_weight_supports_moving_average_and_diff_derivative() -> None:
+    df = pd.DataFrame({"weight_kg": [1.0, 2.0, 3.0, 4.0, 5.0]})
+
+    out = smooth_weight(df, method="ma", window_sec=3, derivative_method="diff")
+
+    assert out["weight_smooth_kg"].tolist() == pytest.approx([1.5, 2.0, 3.0, 4.0, 4.5])
+    assert pd.isna(out.loc[0, "dW_smooth_kg_s"]) is False
+    assert out.loc[1, "dW_smooth_kg_s"] == pytest.approx(0.5)
+
+
+def test_smooth_weight_supports_savgol_derivative_mode() -> None:
+    df = pd.DataFrame({"weight_kg": [0.0, 1.0, 2.0, 3.0, 4.0]})
+
+    out = smooth_weight(
+        df,
+        method="savgol",
+        window_sec=5,
+        poly_order=2,
+        derivative_method="savgol",
+    )
+
+    assert out["weight_smooth_kg"].tolist() == pytest.approx([0, 1, 2, 3, 4], abs=1e-6)
+    assert out["dW_smooth_kg_s"].tolist() == pytest.approx([1, 1, 1, 1, 1], abs=1e-6)
+
+
+def test_smooth_weight_requires_savgol_for_savgol_derivative() -> None:
+    df = pd.DataFrame({"weight_kg": [1.0, 2.0, 3.0, 4.0, 5.0]})
+
+    with pytest.raises(ValueError, match="requires method='savgol'"):
+        smooth_weight(df, method="ma", window_sec=5, derivative_method="savgol")
+
+
+def test_smooth_weight_reports_missing_scipy(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"weight_kg": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    monkeypatch.setattr(
+        "stomatal_optimiaztion.domains.load_cell.preprocessing.savgol_filter",
+        None,
+    )
+
+    with pytest.raises(RuntimeError, match="scipy"):
+        smooth_weight(df, method="savgol", window_sec=5)


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` preprocessing seam into the staged `domains/load_cell` package
- preserve outlier correction, smoothing, and derivative reconstruction behavior
- add seam-level regression tests and update architecture records for slice 050

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\ruff.exe check .

## Next Seam
- `load-cell-data/loadcell_pipeline/events.py`

Closes #95
