### PR TITLE
[Model Change] Migrate load-cell-data events seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -17,4 +17,5 @@ Current status:
 - Slice 048 migrated: `load-cell-data` aggregation seam
 - Slice 049 migrated: `load-cell-data` threshold-detection seam
 - Slice 050 migrated: `load-cell-data` preprocessing seam
-- Next blocked seam: `load-cell-data` event-detection seam at `loadcell_pipeline/events.py`
+- Slice 051 migrated: `load-cell-data` event-detection seam
+- Next blocked seam: `load-cell-data` flux-decomposition seam at `loadcell_pipeline/fluxes.py`

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ poetry run ruff check .
 - `load-cell-data` aggregation seam is migrated as slice 048.
 - `load-cell-data` threshold-detection seam is migrated as slice 049.
 - `load-cell-data` preprocessing seam is migrated as slice 050.
+- `load-cell-data` event-detection seam is migrated as slice 051.
 
 ## Next validation
-- Audit the `load-cell-data` event-detection seam at `loadcell_pipeline/events.py`.
+- Audit the `load-cell-data` flux-decomposition seam at `loadcell_pipeline/fluxes.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 050
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 050 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 051
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 051 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -347,3 +347,9 @@ Slice 050:
 - target: `src/stomatal_optimiaztion/domains/load_cell/preprocessing.py`, package exports, and `tests/test_load_cell_preprocessing.py`
 - scope: bounded `load-cell-data` preprocessing surface covering impulsive outlier correction, moving-average and Savitzky-Golay smoothing, and derivative reconstruction
 - excluded: `loadcell_pipeline/events.py`, flux decomposition, workflow, CLI, and dashboard entrypoints
+
+Slice 051:
+- source: `load-cell-data/loadcell_pipeline/events.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/events.py`, package exports, and `tests/test_load_cell_events.py`
+- scope: bounded `load-cell-data` event surface covering derivative labeling, hysteresis labeling, event grouping, short-event filtering, and close-event merge semantics
+- excluded: `loadcell_pipeline/fluxes.py`, workflow, CLI, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -444,8 +444,16 @@ The fiftieth slice opens the next bounded `load-cell-data` seam:
 - keep the seam preprocessing-bounded without widening into event detection, flux decomposition, workflow, or CLI surfaces
 - leave `load-cell-data/loadcell_pipeline/events.py` blocked as the next seam
 
+## Slice 051: load-cell-data Events
+
+The fifty-first slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/events.py` into the staged `domains/load_cell` package
+- preserve derivative-based labeling, hysteresis labeling, event grouping, short-event filtering, and close-event merge behavior
+- keep the seam events-bounded without widening into flux decomposition, workflow, or CLI surfaces
+- leave `load-cell-data/loadcell_pipeline/fluxes.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first five `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first six `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/events.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/fluxes.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 050 completed and slice 051 planning
+- Current phase: slice 051 completed and slice 052 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` event-detection seam at `loadcell_pipeline/events.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing package boundary while deciding whether event detection should precede flux decomposition and workflow seams
+1. audit the `load-cell-data` flux-decomposition seam at `loadcell_pipeline/fluxes.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events package boundary while deciding how flux decomposition should precede workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-051-load-cell-events.md
+++ b/docs/architecture/architecture/module_specs/module-051-load-cell-events.md
@@ -1,0 +1,36 @@
+# Module Spec 051: load-cell-data Events
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the event-detection helpers that convert smoothed derivatives into labeled and merged irrigation or drainage events.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/events.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/events.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_events.py`
+
+## Responsibilities
+
+1. preserve derivative-based point labeling and hysteresis labeling behavior
+2. preserve event grouping, short-event filtering, and close-event merge semantics
+3. keep the seam events-bounded without widening into flux decomposition, workflow, or CLI surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/fluxes.py`
+- migrate workflow orchestration or dashboard entrypoints
+- widen into CLI surfaces
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/fluxes.py`

--- a/docs/architecture/executor/issue-051-model-change.md
+++ b/docs/architecture/executor/issue-051-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 050` opened the bounded `load-cell-data` preprocessing seam, so the next staged helper surface is the event-detection module at `loadcell_pipeline/events.py`.
+- The migrated repo now has config, IO, aggregation, thresholds, and preprocessing helpers, but it still lacks the canonical derivative-to-label, event grouping, and event merge functions that downstream flux decomposition expects.
+- This slice should stay events-bounded: point labeling, hysteresis labeling, event grouping, and close-event merge helpers only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell event tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for missing-column rejection, hysteresis validation, short-event filtering, close-event merging, and DataFrame-backed event mass recomputation
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/events.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/preprocessing.py`

--- a/docs/architecture/executor/pr-097-load-cell-events.md
+++ b/docs/architecture/executor/pr-097-load-cell-events.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` events seam into the staged `domains/load_cell` package
+- preserve derivative labeling, hysteresis labeling, event grouping, and close-event merge behavior
+- add seam-level regression tests and update architecture records for slice 051
+
+## Validation
+- .\\.venv\\Scripts\\python.exe -m pytest
+- .\\.venv\\Scripts\\ruff.exe check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/fluxes.py`
+
+Closes #97

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed preprocessing seam | event detection, flux decomposition, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed event-detection seam | flux decomposition, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -6,6 +6,13 @@ from stomatal_optimiaztion.domains.load_cell.config import (
     PipelineConfig,
     load_config,
 )
+from stomatal_optimiaztion.domains.load_cell.events import (
+    group_events,
+    label_points_by_derivative,
+    label_points_by_derivative_hysteresis,
+    merge_close_events,
+    merge_close_events_with_df,
+)
 from stomatal_optimiaztion.domains.load_cell.io import (
     read_load_cell_csv,
     write_multi_resolution_results,
@@ -23,9 +30,14 @@ __all__ = [
     "auto_detect_step_thresholds",
     "daily_summary",
     "detect_and_correct_outliers",
+    "group_events",
     "PipelineConfig",
+    "label_points_by_derivative",
+    "label_points_by_derivative_hysteresis",
     "resample_flux_timeseries",
     "load_config",
+    "merge_close_events",
+    "merge_close_events_with_df",
     "read_load_cell_csv",
     "smooth_weight",
     "write_multi_resolution_results",

--- a/src/stomatal_optimiaztion/domains/load_cell/events.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/events.py
@@ -1,0 +1,308 @@
+"""Event detection utilities for load-cell irrigation and drainage analysis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+def label_points_by_derivative(
+    df: pd.DataFrame,
+    irrigation_threshold: float,
+    drainage_threshold: float,
+) -> pd.DataFrame:
+    """Assign irrigation, drainage, or baseline labels from a derivative series."""
+
+    if "dW_smooth_kg_s" not in df:
+        raise KeyError("Input DataFrame must contain 'dW_smooth_kg_s'.")
+
+    df_out = df.copy()
+    d_w = df_out["dW_smooth_kg_s"].fillna(0.0)
+
+    labels = pd.Series("baseline", index=df_out.index, dtype="object")
+    labels[d_w >= irrigation_threshold] = "irrigation"
+    labels[d_w <= drainage_threshold] = "drainage"
+
+    df_out["label"] = labels
+    return df_out
+
+
+def label_points_by_derivative_hysteresis(
+    df: pd.DataFrame,
+    irrigation_threshold: float,
+    drainage_threshold: float,
+    hysteresis_ratio: float = 0.5,
+    baseline_center: float | None = None,
+) -> pd.DataFrame:
+    """Assign labels using separate start and end thresholds."""
+
+    if "dW_smooth_kg_s" not in df:
+        raise KeyError("Input DataFrame must contain 'dW_smooth_kg_s'.")
+    if hysteresis_ratio <= 0 or hysteresis_ratio > 1:
+        raise ValueError("hysteresis_ratio must be in (0, 1].")
+
+    df_out = df.copy()
+    d_w = df_out["dW_smooth_kg_s"].fillna(0.0).astype(float)
+    m0 = float(d_w.median()) if baseline_center is None else float(baseline_center)
+
+    irrigation_end = m0 + hysteresis_ratio * (float(irrigation_threshold) - m0)
+    drainage_end = m0 + hysteresis_ratio * (float(drainage_threshold) - m0)
+
+    state = "baseline"
+    labels: list[str] = []
+    for value in d_w.to_numpy():
+        if state == "baseline":
+            if value >= irrigation_threshold:
+                state = "irrigation"
+            elif value <= drainage_threshold:
+                state = "drainage"
+        elif state == "irrigation":
+            if value <= irrigation_end:
+                state = "drainage" if value <= drainage_threshold else "baseline"
+        else:
+            if value >= drainage_end:
+                state = "irrigation" if value >= irrigation_threshold else "baseline"
+        labels.append(state)
+
+    df_out["label"] = pd.Series(labels, index=df_out.index, dtype="object")
+    return df_out
+
+
+def group_events(
+    df: pd.DataFrame,
+    min_event_duration_sec: int = 2,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Group consecutive irrigation or drainage labels into event summaries."""
+
+    if "label" not in df:
+        raise KeyError("DataFrame must contain 'label' column before grouping.")
+
+    weight_col = "weight_smooth_kg" if "weight_smooth_kg" in df else "weight_kg"
+    if weight_col not in df:
+        raise KeyError(
+            "DataFrame must contain either 'weight_smooth_kg' or 'weight_kg'."
+        )
+
+    labels = df["label"].fillna("baseline")
+    df_out = df.copy()
+    event_ids = pd.Series(pd.NA, index=df_out.index, dtype="Int64")
+    events: list[dict[str, Any]] = []
+
+    current_type: str | None = None
+    start_idx: int | None = None
+    event_counter = 0
+    timestamps = list(df_out.index)
+    weight_series = df_out[weight_col].astype(float)
+
+    def close_event(end_idx: int) -> None:
+        nonlocal current_type, start_idx, event_counter
+        if start_idx is None or current_type is None:
+            return
+
+        duration = end_idx - start_idx + 1
+        if duration < min_event_duration_sec:
+            current_type = None
+            start_idx = None
+            return
+
+        idx_slice = slice(start_idx, end_idx + 1)
+        event_counter += 1
+        event_ids.iloc[idx_slice] = event_counter
+        ts_start = timestamps[start_idx]
+        ts_end = timestamps[end_idx]
+        weight_before = (
+            weight_series.iloc[start_idx - 1]
+            if start_idx > 0
+            else weight_series.iloc[start_idx]
+        )
+        mass_change = float(weight_series.iloc[end_idx] - weight_before)
+        events.append(
+            {
+                "event_id": event_counter,
+                "event_type": current_type,
+                "start_time": ts_start,
+                "end_time": ts_end,
+                "duration_sec": duration,
+                "mass_change_kg": mass_change,
+            }
+        )
+        current_type = None
+        start_idx = None
+
+    for idx, label in enumerate(labels):
+        normalized = label if label in ("irrigation", "drainage") else "baseline"
+        if normalized == "baseline":
+            if current_type is not None:
+                close_event(idx - 1)
+            continue
+
+        if current_type is None:
+            current_type = normalized
+            start_idx = idx
+        elif normalized != current_type:
+            close_event(idx - 1)
+            current_type = normalized
+            start_idx = idx
+
+    if current_type is not None and start_idx is not None:
+        close_event(len(labels) - 1)
+
+    df_out["event_id"] = event_ids
+    events_df = pd.DataFrame(events)
+    if events_df.empty:
+        events_df = pd.DataFrame(
+            columns=[
+                "event_id",
+                "event_type",
+                "start_time",
+                "end_time",
+                "duration_sec",
+                "mass_change_kg",
+            ]
+        )
+    else:
+        events_df = events_df.sort_values("start_time").reset_index(drop=True)
+
+    return df_out, events_df
+
+
+def merge_close_events(
+    events_df: pd.DataFrame,
+    gap_threshold_sec: int = 30,
+) -> pd.DataFrame:
+    """Merge consecutive irrigation events separated by short gaps."""
+
+    if events_df.empty:
+        return events_df
+
+    events_sorted = events_df.sort_values("start_time").reset_index(drop=True)
+    merged: list[dict[str, Any]] = []
+    current = events_sorted.iloc[0].to_dict()
+
+    def flush_current() -> None:
+        if current:
+            merged.append(current.copy())
+
+    for _, row in events_sorted.iloc[1:].iterrows():
+        if current["event_type"] == "irrigation" and row["event_type"] == "irrigation":
+            gap = (row["start_time"] - current["end_time"]).total_seconds()
+            if gap <= gap_threshold_sec:
+                current["end_time"] = max(current["end_time"], row["end_time"])
+                current["mass_change_kg"] += row["mass_change_kg"]
+                current["duration_sec"] = (
+                    int(
+                        (current["end_time"] - current["start_time"]).total_seconds()
+                    )
+                    + 1
+                )
+                continue
+        flush_current()
+        current = row.to_dict()
+
+    flush_current()
+
+    merged_df = pd.DataFrame(merged).reset_index(drop=True)
+    merged_df["event_id"] = range(1, len(merged_df) + 1)
+    return merged_df
+
+
+def merge_close_events_with_df(
+    df: pd.DataFrame,
+    events_df: pd.DataFrame,
+    gap_threshold_sec: int = 30,
+    event_type: str = "irrigation",
+    weight_col: str | None = None,
+) -> tuple[pd.DataFrame, dict[int, int]]:
+    """Merge close events and recompute their mass change from the weight series."""
+
+    if events_df.empty:
+        return events_df, {}
+    if gap_threshold_sec < 0:
+        raise ValueError("gap_threshold_sec must be >= 0.")
+
+    required_cols = {"event_id", "event_type", "start_time", "end_time"}
+    missing = required_cols - set(events_df.columns)
+    if missing:
+        raise KeyError(f"events_df missing required columns: {missing}")
+
+    if weight_col is None:
+        weight_col = "weight_smooth_kg" if "weight_smooth_kg" in df.columns else "weight_kg"
+    if weight_col not in df.columns:
+        raise KeyError(f"df must contain '{weight_col}' to recompute mass_change_kg.")
+
+    weight_series = df[weight_col].astype(float).ffill()
+    index = weight_series.index
+
+    def position(ts: Any) -> int:
+        loc = index.get_loc(ts)
+        if isinstance(loc, slice):
+            return int(loc.start)
+        if isinstance(loc, (list, tuple, np.ndarray)):
+            return int(loc[0])
+        return int(loc)
+
+    def mass_change(start_time: Any, end_time: Any) -> float:
+        start_pos = position(start_time)
+        end_pos = position(end_time)
+        before = (
+            weight_series.iloc[start_pos - 1]
+            if start_pos > 0
+            else weight_series.iloc[start_pos]
+        )
+        return float(weight_series.iloc[end_pos] - before)
+
+    events_sorted = events_df.sort_values("start_time").reset_index(drop=True)
+
+    merged_groups: list[dict[str, Any]] = []
+    current = events_sorted.iloc[0].to_dict()
+    current_old_ids: list[int] = [int(current["event_id"])]
+
+    def flush() -> None:
+        merged_groups.append(
+            {
+                "event_type": current["event_type"],
+                "start_time": current["start_time"],
+                "end_time": current["end_time"],
+                "source_event_ids": current_old_ids.copy(),
+            }
+        )
+
+    for _, row in events_sorted.iloc[1:].iterrows():
+        row_dict = row.to_dict()
+        can_merge = current["event_type"] == event_type and row_dict["event_type"] == event_type
+        if can_merge:
+            gap = (row_dict["start_time"] - current["end_time"]).total_seconds()
+            if gap <= gap_threshold_sec:
+                current["end_time"] = max(current["end_time"], row_dict["end_time"])
+                current_old_ids.append(int(row_dict["event_id"]))
+                continue
+
+        flush()
+        current = row_dict
+        current_old_ids = [int(current["event_id"])]
+
+    flush()
+
+    merged_rows: list[dict[str, Any]] = []
+    id_map: dict[int, int] = {}
+    for new_id, group in enumerate(merged_groups, start=1):
+        start_time = group["start_time"]
+        end_time = group["end_time"]
+        merged_rows.append(
+            {
+                "event_id": new_id,
+                "event_type": group["event_type"],
+                "start_time": start_time,
+                "end_time": end_time,
+                "duration_sec": int((end_time - start_time).total_seconds()) + 1,
+                "mass_change_kg": mass_change(start_time, end_time),
+                "source_event_ids": group["source_event_ids"],
+            }
+        )
+        for old_id in group["source_event_ids"]:
+            id_map[int(old_id)] = int(new_id)
+
+    merged_df = pd.DataFrame(merged_rows)
+    return merged_df, id_map

--- a/tests/test_load_cell_events.py
+++ b/tests/test_load_cell_events.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import (
+    group_events,
+    label_points_by_derivative,
+    label_points_by_derivative_hysteresis,
+    merge_close_events,
+    merge_close_events_with_df,
+)
+
+
+def test_load_cell_import_surface_exposes_event_helpers() -> None:
+    assert load_cell.label_points_by_derivative is label_points_by_derivative
+    assert (
+        load_cell.label_points_by_derivative_hysteresis
+        is label_points_by_derivative_hysteresis
+    )
+    assert load_cell.group_events is group_events
+    assert load_cell.merge_close_events is merge_close_events
+    assert load_cell.merge_close_events_with_df is merge_close_events_with_df
+
+
+def test_label_points_by_derivative_requires_derivative_column() -> None:
+    with pytest.raises(KeyError, match="dW_smooth_kg_s"):
+        label_points_by_derivative(pd.DataFrame({"x": [1.0, 2.0]}), 0.1, -0.1)
+
+
+def test_label_points_by_derivative_assigns_expected_labels() -> None:
+    df = pd.DataFrame({"dW_smooth_kg_s": [None, 0.5, -0.6, 0.1]})
+
+    out = label_points_by_derivative(df, irrigation_threshold=0.4, drainage_threshold=-0.4)
+
+    assert out["label"].tolist() == ["baseline", "irrigation", "drainage", "baseline"]
+
+
+def test_label_points_by_derivative_hysteresis_validates_ratio() -> None:
+    df = pd.DataFrame({"dW_smooth_kg_s": [0.0, 1.0]})
+
+    with pytest.raises(ValueError, match="must be in"):
+        label_points_by_derivative_hysteresis(
+            df,
+            irrigation_threshold=0.4,
+            drainage_threshold=-0.4,
+            hysteresis_ratio=0.0,
+        )
+
+
+def test_label_points_by_derivative_hysteresis_supports_direct_state_transition() -> None:
+    df = pd.DataFrame({"dW_smooth_kg_s": [0.8, -0.8, 0.0]})
+
+    out = label_points_by_derivative_hysteresis(
+        df,
+        irrigation_threshold=0.6,
+        drainage_threshold=-0.6,
+        hysteresis_ratio=0.5,
+        baseline_center=0.0,
+    )
+
+    assert out["label"].tolist() == ["irrigation", "drainage", "baseline"]
+
+
+def test_group_events_requires_label_and_weight_columns() -> None:
+    with pytest.raises(KeyError, match="label"):
+        group_events(pd.DataFrame({"weight_kg": [1.0, 2.0]}))
+
+    with pytest.raises(KeyError, match="weight_smooth_kg|weight_kg"):
+        group_events(pd.DataFrame({"label": ["baseline", "irrigation"]}))
+
+
+def test_group_events_builds_event_ids_and_summary_rows() -> None:
+    index = pd.date_range("2025-01-01 00:00:00", periods=8, freq="s")
+    df = pd.DataFrame(
+        {
+            "label": [
+                "baseline",
+                "irrigation",
+                "irrigation",
+                "baseline",
+                "drainage",
+                "drainage",
+                "drainage",
+                "baseline",
+            ],
+            "weight_smooth_kg": [10.0, 10.2, 10.5, 10.5, 10.4, 10.2, 10.1, 10.1],
+        },
+        index=index,
+    )
+
+    out, events_df = group_events(df, min_event_duration_sec=2)
+
+    assert pd.isna(out.iloc[0]["event_id"])
+    assert out.iloc[1]["event_id"] == 1
+    assert out.iloc[2]["event_id"] == 1
+    assert pd.isna(out.iloc[3]["event_id"])
+    assert out.iloc[4]["event_id"] == 2
+    assert out.iloc[6]["event_id"] == 2
+    assert events_df.to_dict("records") == [
+        {
+            "event_id": 1,
+            "event_type": "irrigation",
+            "start_time": index[1],
+            "end_time": index[2],
+            "duration_sec": 2,
+            "mass_change_kg": pytest.approx(0.5),
+        },
+        {
+            "event_id": 2,
+            "event_type": "drainage",
+            "start_time": index[4],
+            "end_time": index[6],
+            "duration_sec": 3,
+            "mass_change_kg": pytest.approx(-0.4),
+        },
+    ]
+
+
+def test_group_events_drops_short_events() -> None:
+    index = pd.date_range("2025-01-01 00:00:00", periods=3, freq="s")
+    df = pd.DataFrame(
+        {
+            "label": ["baseline", "irrigation", "baseline"],
+            "weight_kg": [1.0, 1.2, 1.2],
+        },
+        index=index,
+    )
+
+    out, events_df = group_events(df, min_event_duration_sec=2)
+
+    assert out["event_id"].isna().all()
+    assert events_df.empty
+
+
+def test_merge_close_events_merges_nearby_irrigation_events() -> None:
+    events_df = pd.DataFrame(
+        [
+            {
+                "event_id": 10,
+                "event_type": "irrigation",
+                "start_time": pd.Timestamp("2025-01-01 00:00:00"),
+                "end_time": pd.Timestamp("2025-01-01 00:00:02"),
+                "duration_sec": 3,
+                "mass_change_kg": 0.3,
+            },
+            {
+                "event_id": 11,
+                "event_type": "irrigation",
+                "start_time": pd.Timestamp("2025-01-01 00:00:05"),
+                "end_time": pd.Timestamp("2025-01-01 00:00:06"),
+                "duration_sec": 2,
+                "mass_change_kg": 0.2,
+            },
+            {
+                "event_id": 12,
+                "event_type": "drainage",
+                "start_time": pd.Timestamp("2025-01-01 00:00:08"),
+                "end_time": pd.Timestamp("2025-01-01 00:00:09"),
+                "duration_sec": 2,
+                "mass_change_kg": -0.1,
+            },
+        ]
+    )
+
+    merged = merge_close_events(events_df, gap_threshold_sec=3)
+
+    assert merged["event_id"].tolist() == [1, 2]
+    assert merged["event_type"].tolist() == ["irrigation", "drainage"]
+    assert merged.loc[0, "start_time"] == pd.Timestamp("2025-01-01 00:00:00")
+    assert merged.loc[0, "end_time"] == pd.Timestamp("2025-01-01 00:00:06")
+    assert merged.loc[0, "duration_sec"] == 7
+    assert merged.loc[0, "mass_change_kg"] == pytest.approx(0.5)
+
+
+def test_merge_close_events_with_df_validates_inputs() -> None:
+    index = pd.date_range("2025-01-01 00:00:00", periods=3, freq="s")
+    df = pd.DataFrame({"weight_kg": [1.0, 1.1, 1.2]}, index=index)
+    events_df = pd.DataFrame(
+        [
+            {
+                "event_id": 1,
+                "event_type": "irrigation",
+                "start_time": index[1],
+                "end_time": index[2],
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match=">= 0"):
+        merge_close_events_with_df(df, events_df, gap_threshold_sec=-1)
+
+    with pytest.raises(KeyError, match="required columns"):
+        merge_close_events_with_df(
+            df,
+            pd.DataFrame([{"event_id": 1, "event_type": "irrigation"}]),
+        )
+
+
+def test_merge_close_events_with_df_recomputes_mass_change_and_id_map() -> None:
+    index = pd.date_range("2025-01-01 00:00:00", periods=8, freq="s")
+    df = pd.DataFrame(
+        {
+            "weight_smooth_kg": [10.0, 10.0, 10.2, 10.3, 10.3, 10.5, 10.6, 10.4],
+        },
+        index=index,
+    )
+    events_df = pd.DataFrame(
+        [
+            {
+                "event_id": 1,
+                "event_type": "irrigation",
+                "start_time": index[1],
+                "end_time": index[2],
+                "duration_sec": 2,
+                "mass_change_kg": 0.2,
+            },
+            {
+                "event_id": 2,
+                "event_type": "irrigation",
+                "start_time": index[4],
+                "end_time": index[5],
+                "duration_sec": 2,
+                "mass_change_kg": 0.2,
+            },
+            {
+                "event_id": 3,
+                "event_type": "drainage",
+                "start_time": index[7],
+                "end_time": index[7],
+                "duration_sec": 1,
+                "mass_change_kg": -0.2,
+            },
+        ]
+    )
+
+    merged_df, id_map = merge_close_events_with_df(
+        df,
+        events_df,
+        gap_threshold_sec=2,
+    )
+
+    assert merged_df["event_id"].tolist() == [1, 2]
+    assert merged_df.loc[0, "event_type"] == "irrigation"
+    assert merged_df.loc[0, "start_time"] == index[1]
+    assert merged_df.loc[0, "end_time"] == index[5]
+    assert merged_df.loc[0, "duration_sec"] == 5
+    assert merged_df.loc[0, "mass_change_kg"] == pytest.approx(0.5)
+    assert merged_df.loc[0, "source_event_ids"] == [1, 2]
+    assert merged_df.loc[1, "event_type"] == "drainage"
+    assert merged_df.loc[1, "mass_change_kg"] == pytest.approx(-0.2)
+    assert id_map == {1: 1, 2: 1, 3: 2}


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` events seam into the staged `domains/load_cell` package
- preserve derivative labeling, hysteresis labeling, event grouping, and close-event merge behavior
- add seam-level regression tests and update architecture records for slice 051

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\ruff.exe check .

## Next Seam
- `load-cell-data/loadcell_pipeline/fluxes.py`

Closes #97
