### PR TITLE
[Model Change] Migrate load-cell-data flux decomposition seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -18,4 +18,5 @@ Current status:
 - Slice 049 migrated: `load-cell-data` threshold-detection seam
 - Slice 050 migrated: `load-cell-data` preprocessing seam
 - Slice 051 migrated: `load-cell-data` event-detection seam
-- Next blocked seam: `load-cell-data` flux-decomposition seam at `loadcell_pipeline/fluxes.py`
+- Slice 052 migrated: `load-cell-data` flux-decomposition seam
+- Next blocked seam: `load-cell-data` pipeline CLI seam at `loadcell_pipeline/cli.py`

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ poetry run ruff check .
 - `load-cell-data` threshold-detection seam is migrated as slice 049.
 - `load-cell-data` preprocessing seam is migrated as slice 050.
 - `load-cell-data` event-detection seam is migrated as slice 051.
+- `load-cell-data` flux-decomposition seam is migrated as slice 052.
 
 ## Next validation
-- Audit the `load-cell-data` flux-decomposition seam at `loadcell_pipeline/fluxes.py`.
+- Audit the `load-cell-data` pipeline CLI seam at `loadcell_pipeline/cli.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 051
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 051 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 052
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 052 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -353,3 +353,9 @@ Slice 051:
 - target: `src/stomatal_optimiaztion/domains/load_cell/events.py`, package exports, and `tests/test_load_cell_events.py`
 - scope: bounded `load-cell-data` event surface covering derivative labeling, hysteresis labeling, event grouping, short-event filtering, and close-event merge semantics
 - excluded: `loadcell_pipeline/fluxes.py`, workflow, CLI, and dashboard entrypoints
+
+Slice 052:
+- source: `load-cell-data/loadcell_pipeline/fluxes.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/fluxes.py`, package exports, and `tests/test_load_cell_fluxes.py`
+- scope: bounded `load-cell-data` flux surface covering per-second irrigation/drainage/transpiration decomposition, optional event-gap transpiration interpolation, and water-balance scaling
+- excluded: `loadcell_pipeline/cli.py`, workflow, batch runners, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -452,8 +452,16 @@ The fifty-first slice opens the next bounded `load-cell-data` seam:
 - keep the seam events-bounded without widening into flux decomposition, workflow, or CLI surfaces
 - leave `load-cell-data/loadcell_pipeline/fluxes.py` blocked as the next seam
 
+## Slice 052: load-cell-data Fluxes
+
+The fifty-second slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/fluxes.py` into the staged `domains/load_cell` package
+- preserve irrigation/drainage/transpiration decomposition, event-gap transpiration interpolation, cumulative sums, and water-balance scaling behavior
+- keep the seam flux-bounded without widening into package-level pipeline orchestration, workflow, or batch-runner surfaces
+- leave `load-cell-data/loadcell_pipeline/cli.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first six `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first seven `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/fluxes.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/cli.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 051 completed and slice 052 planning
+- Current phase: slice 052 completed and slice 053 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` flux-decomposition seam at `loadcell_pipeline/fluxes.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events package boundary while deciding how flux decomposition should precede workflow seams
+1. audit the `load-cell-data` pipeline CLI seam at `loadcell_pipeline/cli.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes package boundary while deciding how the package-level pipeline should precede workflow seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-052-load-cell-fluxes.md
+++ b/docs/architecture/architecture/module_specs/module-052-load-cell-fluxes.md
@@ -1,0 +1,36 @@
+# Module Spec 052: load-cell-data Fluxes
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the flux-decomposition helper that converts labeled derivatives into irrigation, drainage, and transpiration fluxes.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/fluxes.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/fluxes.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_fluxes.py`
+
+## Responsibilities
+
+1. preserve per-second irrigation, drainage, and transpiration decomposition from smoothed derivatives and labels
+2. preserve optional transpiration interpolation during non-baseline segments plus cumulative-sum reporting
+3. keep the seam flux-bounded without widening into pipeline orchestration, workflow, or CLI surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/cli.py`
+- migrate workflow orchestration or batch-runner entrypoints
+- widen into dashboard surfaces
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/cli.py`

--- a/docs/architecture/executor/issue-052-model-change.md
+++ b/docs/architecture/executor/issue-052-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 051` opened the bounded `load-cell-data` events seam, so the next staged helper surface is the flux-decomposition module at `loadcell_pipeline/fluxes.py`.
+- The migrated repo now has config, IO, aggregation, thresholds, preprocessing, and events helpers, but it still lacks the canonical irrigation/drainage/transpiration split and water-balance reconstruction that the pipeline surface depends on.
+- This slice should stay flux-bounded: per-second flux decomposition, event-gap transpiration interpolation, cumulative sums, and water-balance scaling only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell flux tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for required-column rejection, baseline/event flux splitting, optional transpiration interpolation, and min/max water-balance scale guardrails
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/fluxes.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/events.py`

--- a/docs/architecture/executor/pr-099-load-cell-fluxes.md
+++ b/docs/architecture/executor/pr-099-load-cell-fluxes.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` flux-decomposition seam into the staged `domains/load_cell` package
+- preserve irrigation/drainage/transpiration splitting, event-gap transpiration interpolation, and water-balance scaling behavior
+- add seam-level regression tests and update architecture records for slice 052
+
+## Validation
+- .\\.venv\\Scripts\\python.exe -m pytest
+- .\\.venv\\Scripts\\ruff.exe check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/cli.py`
+
+Closes #99

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed event-detection seam | flux decomposition, workflow, and CLI surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed flux-decomposition seam | pipeline CLI, workflow, and batch-runner surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -13,6 +13,9 @@ from stomatal_optimiaztion.domains.load_cell.events import (
     merge_close_events,
     merge_close_events_with_df,
 )
+from stomatal_optimiaztion.domains.load_cell.fluxes import (
+    compute_fluxes_per_second,
+)
 from stomatal_optimiaztion.domains.load_cell.io import (
     read_load_cell_csv,
     write_multi_resolution_results,
@@ -28,6 +31,7 @@ from stomatal_optimiaztion.domains.load_cell.thresholds import (
 
 __all__ = [
     "auto_detect_step_thresholds",
+    "compute_fluxes_per_second",
     "daily_summary",
     "detect_and_correct_outliers",
     "group_events",

--- a/src/stomatal_optimiaztion/domains/load_cell/fluxes.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/fluxes.py
@@ -1,0 +1,93 @@
+"""Flux decomposition helpers for greenhouse load-cell signals."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_fluxes_per_second(
+    df: pd.DataFrame,
+    interpolate_transpiration_during_events: bool = True,
+    fix_water_balance: bool = True,
+    min_transpiration_scale: float = 0.0,
+    max_transpiration_scale: float | None = 3.0,
+) -> pd.DataFrame:
+    """Split smoothed derivatives into irrigation, drainage, and transpiration."""
+
+    required_cols = {"dW_smooth_kg_s", "label", "weight_smooth_kg"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        raise KeyError(f"Missing required columns for flux computation: {missing}")
+
+    df_out = df.copy()
+    d_w = df_out["dW_smooth_kg_s"].fillna(0.0)
+    labels = df_out["label"].fillna("baseline")
+
+    irrigation = pd.Series(0.0, index=df_out.index, dtype="float64")
+    drainage = pd.Series(0.0, index=df_out.index, dtype="float64")
+    transpiration = pd.Series(0.0, index=df_out.index, dtype="float64")
+
+    irrigation_mask = labels == "irrigation"
+    drainage_mask = labels == "drainage"
+    baseline_mask = labels == "baseline"
+
+    irrigation.loc[irrigation_mask] = d_w.loc[irrigation_mask].clip(lower=0.0)
+    drainage.loc[drainage_mask] = (-d_w.loc[drainage_mask]).clip(lower=0.0)
+    transp_mask = baseline_mask & (d_w <= 0)
+    transpiration.loc[transp_mask] = -d_w.loc[transp_mask]
+
+    if interpolate_transpiration_during_events and transpiration.gt(0).sum() >= 2:
+        interp_series = transpiration.copy()
+        event_segments = (labels != "baseline") & (interp_series <= 0)
+        interp_series = interp_series.mask(event_segments, float("nan"))
+        interp_series = interp_series.interpolate(limit_area="inside")
+        transpiration = interp_series.fillna(transpiration)
+
+    df_out["irrigation_kg_s"] = irrigation
+    df_out["drainage_kg_s"] = drainage
+    df_out["transpiration_kg_s"] = transpiration
+
+    df_out["cum_irrigation_kg"] = irrigation.cumsum()
+    df_out["cum_drainage_kg"] = drainage.cumsum()
+    df_out["cum_transpiration_kg"] = transpiration.cumsum()
+
+    weight_series = df_out["weight_smooth_kg"].ffill()
+    initial_weight = weight_series.iloc[0]
+    reconstructed = (
+        initial_weight
+        + df_out["cum_irrigation_kg"]
+        - df_out["cum_drainage_kg"]
+        - df_out["cum_transpiration_kg"]
+    )
+    balance_error = weight_series - reconstructed
+    df_out["water_balance_error_before_fix_kg"] = balance_error
+
+    scale_applied = 1.0
+    if fix_water_balance and not balance_error.empty:
+        final_bias = balance_error.iloc[-1]
+        if abs(final_bias) > 1e-6:
+            transp_total = transpiration.sum()
+            if transp_total > 0:
+                scale = float(1 - final_bias / transp_total)
+                if not pd.notna(scale):
+                    scale = 1.0
+                if max_transpiration_scale is not None:
+                    scale = min(scale, float(max_transpiration_scale))
+                scale = max(scale, float(min_transpiration_scale))
+                scale_applied = scale
+                transpiration = (transpiration * scale).clip(lower=0.0)
+                df_out["transpiration_kg_s"] = transpiration
+                df_out["cum_transpiration_kg"] = transpiration.cumsum()
+                reconstructed = (
+                    initial_weight
+                    + df_out["cum_irrigation_kg"]
+                    - df_out["cum_drainage_kg"]
+                    - df_out["cum_transpiration_kg"]
+                )
+                balance_error = weight_series - reconstructed
+
+    df_out["transpiration_scale"] = float(scale_applied)
+    df_out["reconstructed_weight_kg"] = reconstructed
+    df_out["water_balance_error_kg"] = balance_error
+
+    return df_out

--- a/tests/test_load_cell_fluxes.py
+++ b/tests/test_load_cell_fluxes.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import compute_fluxes_per_second
+
+
+def test_load_cell_import_surface_exposes_flux_helper() -> None:
+    assert load_cell.compute_fluxes_per_second is compute_fluxes_per_second
+
+
+def test_compute_fluxes_per_second_requires_expected_columns() -> None:
+    with pytest.raises(KeyError, match="Missing required columns"):
+        compute_fluxes_per_second(
+            pd.DataFrame({"dW_smooth_kg_s": [0.0], "label": ["baseline"]})
+        )
+
+
+def test_compute_fluxes_per_second_splits_fluxes_and_preserves_balance() -> None:
+    df = pd.DataFrame(
+        {
+            "dW_smooth_kg_s": [0.0, 0.4, -0.3, -0.2],
+            "label": ["baseline", "irrigation", "drainage", "baseline"],
+            "weight_smooth_kg": [10.0, 10.4, 10.1, 9.9],
+        }
+    )
+
+    out = compute_fluxes_per_second(df, fix_water_balance=False)
+
+    assert out["irrigation_kg_s"].tolist() == pytest.approx([0.0, 0.4, 0.0, 0.0])
+    assert out["drainage_kg_s"].tolist() == pytest.approx([0.0, 0.0, 0.3, 0.0])
+    assert out["transpiration_kg_s"].tolist() == pytest.approx([0.0, 0.0, 0.0, 0.2])
+    assert out["cum_irrigation_kg"].tolist() == pytest.approx([0.0, 0.4, 0.4, 0.4])
+    assert out["cum_drainage_kg"].tolist() == pytest.approx([0.0, 0.0, 0.3, 0.3])
+    assert out["cum_transpiration_kg"].tolist() == pytest.approx(
+        [0.0, 0.0, 0.0, 0.2]
+    )
+    assert out["reconstructed_weight_kg"].tolist() == pytest.approx(
+        [10.0, 10.4, 10.1, 9.9]
+    )
+    assert out["water_balance_error_before_fix_kg"].tolist() == pytest.approx(
+        [0.0, 0.0, 0.0, 0.0]
+    )
+    assert out["water_balance_error_kg"].tolist() == pytest.approx([0.0, 0.0, 0.0, 0.0])
+    assert out["transpiration_scale"].tolist() == pytest.approx([1.0, 1.0, 1.0, 1.0])
+
+
+def test_compute_fluxes_per_second_interpolates_transpiration_through_events() -> None:
+    df = pd.DataFrame(
+        {
+            "dW_smooth_kg_s": [-0.1, 0.3, 0.3, -0.1],
+            "label": ["baseline", "irrigation", "irrigation", "baseline"],
+            "weight_smooth_kg": [10.0, 10.3, 10.6, 10.5],
+        }
+    )
+
+    out = compute_fluxes_per_second(df, fix_water_balance=False)
+
+    assert out["transpiration_kg_s"].tolist() == pytest.approx([0.1, 0.1, 0.1, 0.1])
+    assert out["cum_transpiration_kg"].tolist() == pytest.approx([0.1, 0.2, 0.3, 0.4])
+
+
+def test_compute_fluxes_per_second_can_disable_transpiration_interpolation() -> None:
+    df = pd.DataFrame(
+        {
+            "dW_smooth_kg_s": [-0.1, 0.3, 0.3, -0.1],
+            "label": ["baseline", "irrigation", "irrigation", "baseline"],
+            "weight_smooth_kg": [10.0, 10.3, 10.6, 10.5],
+        }
+    )
+
+    out = compute_fluxes_per_second(
+        df,
+        interpolate_transpiration_during_events=False,
+        fix_water_balance=False,
+    )
+
+    assert out["transpiration_kg_s"].tolist() == pytest.approx([0.1, 0.0, 0.0, 0.1])
+
+
+def test_compute_fluxes_per_second_clamps_upper_water_balance_scale() -> None:
+    df = pd.DataFrame(
+        {
+            "dW_smooth_kg_s": [0.0, -0.1, -0.1],
+            "label": ["baseline", "baseline", "baseline"],
+            "weight_smooth_kg": [10.0, 9.85, 9.7],
+        }
+    )
+
+    out = compute_fluxes_per_second(
+        df,
+        max_transpiration_scale=1.2,
+    )
+
+    assert out["water_balance_error_before_fix_kg"].iloc[-1] == pytest.approx(-0.1)
+    assert out["transpiration_scale"].iloc[-1] == pytest.approx(1.2)
+    assert out["transpiration_kg_s"].tolist() == pytest.approx([0.0, 0.12, 0.12])
+    assert out["cum_transpiration_kg"].iloc[-1] == pytest.approx(0.24)
+    assert out["water_balance_error_kg"].iloc[-1] == pytest.approx(-0.06)
+
+
+def test_compute_fluxes_per_second_clamps_lower_water_balance_scale() -> None:
+    df = pd.DataFrame(
+        {
+            "dW_smooth_kg_s": [0.0, -0.1, -0.1],
+            "label": ["baseline", "baseline", "baseline"],
+            "weight_smooth_kg": [10.0, 9.95, 9.95],
+        }
+    )
+
+    out = compute_fluxes_per_second(
+        df,
+        min_transpiration_scale=0.5,
+    )
+
+    assert out["water_balance_error_before_fix_kg"].iloc[-1] == pytest.approx(0.15)
+    assert out["transpiration_scale"].iloc[-1] == pytest.approx(0.5)
+    assert out["transpiration_kg_s"].tolist() == pytest.approx([0.0, 0.05, 0.05])
+    assert out["cum_transpiration_kg"].iloc[-1] == pytest.approx(0.1)
+    assert out["water_balance_error_kg"].iloc[-1] == pytest.approx(0.05)


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` flux-decomposition seam into the staged `domains/load_cell` package
- preserve irrigation/drainage/transpiration splitting, event-gap transpiration interpolation, and water-balance scaling behavior
- add seam-level regression tests and update architecture records for slice 052

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\ruff.exe check .

## Next Seam
- `load-cell-data/loadcell_pipeline/cli.py`

Closes #99
