### PR TITLE
[Model Change] Migrate load-cell-data pipeline CLI seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -19,4 +19,5 @@ Current status:
 - Slice 050 migrated: `load-cell-data` preprocessing seam
 - Slice 051 migrated: `load-cell-data` event-detection seam
 - Slice 052 migrated: `load-cell-data` flux-decomposition seam
-- Next blocked seam: `load-cell-data` pipeline CLI seam at `loadcell_pipeline/cli.py`
+- Slice 053 migrated: `load-cell-data` pipeline CLI seam
+- Next blocked seam: `load-cell-data` workflow seam at `loadcell_pipeline/workflow.py`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ poetry run ruff check .
 - `load-cell-data` preprocessing seam is migrated as slice 050.
 - `load-cell-data` event-detection seam is migrated as slice 051.
 - `load-cell-data` flux-decomposition seam is migrated as slice 052.
+- `load-cell-data` pipeline CLI seam is migrated as slice 053.
 
 ## Next validation
-- Audit the `load-cell-data` pipeline CLI seam at `loadcell_pipeline/cli.py`.
+- Audit the `load-cell-data` workflow seam at `loadcell_pipeline/workflow.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 052
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 052 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 053
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 053 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -359,3 +359,9 @@ Slice 052:
 - target: `src/stomatal_optimiaztion/domains/load_cell/fluxes.py`, package exports, and `tests/test_load_cell_fluxes.py`
 - scope: bounded `load-cell-data` flux surface covering per-second irrigation/drainage/transpiration decomposition, optional event-gap transpiration interpolation, and water-balance scaling
 - excluded: `loadcell_pipeline/cli.py`, workflow, batch runners, and dashboard entrypoints
+
+Slice 053:
+- source: `load-cell-data/loadcell_pipeline/cli.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/cli.py`, package exports, and `tests/test_load_cell_cli.py`
+- scope: bounded `load-cell-data` pipeline CLI surface covering parser construction, override mapping, package-level helper orchestration, event timing fields, and summary stats
+- excluded: `loadcell_pipeline/workflow.py`, sweep, batch runners, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -460,8 +460,16 @@ The fifty-second slice opens the next bounded `load-cell-data` seam:
 - keep the seam flux-bounded without widening into package-level pipeline orchestration, workflow, or batch-runner surfaces
 - leave `load-cell-data/loadcell_pipeline/cli.py` blocked as the next seam
 
+## Slice 053: load-cell-data CLI
+
+The fifty-third slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/cli.py` into the staged `domains/load_cell` package
+- preserve parser construction, CLI override mapping, package-level helper orchestration, event timing fields, and summary stats behavior
+- keep the seam CLI-bounded without widening into batch workflow, sweep, or batch-runner surfaces
+- leave `load-cell-data/loadcell_pipeline/workflow.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first seven `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first eight `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/cli.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/workflow.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 052 completed and slice 053 planning
+- Current phase: slice 053 completed and slice 054 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` pipeline CLI seam at `loadcell_pipeline/cli.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes package boundary while deciding how the package-level pipeline should precede workflow seams
+1. audit the `load-cell-data` workflow seam at `loadcell_pipeline/workflow.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli package boundary while deciding how batch workflow should build on the migrated package-level pipeline
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-053-load-cell-cli.md
+++ b/docs/architecture/architecture/module_specs/module-053-load-cell-cli.md
@@ -1,0 +1,36 @@
+# Module Spec 053: load-cell-data CLI
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the package-level pipeline CLI that ties config loading, migrated helpers, and multi-resolution output writing together.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/cli.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/cli.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_cli.py`
+
+## Responsibilities
+
+1. preserve parser construction and CLI-to-config override mapping
+2. preserve package-level pipeline orchestration, event timing fields, summary stats, and multi-resolution output writing
+3. keep the seam CLI-bounded without widening into batch workflow, sweep, or dashboard surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/workflow.py`
+- migrate batch-runner or sweep entrypoints
+- widen into dashboard surfaces
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/workflow.py`

--- a/docs/architecture/executor/issue-053-model-change.md
+++ b/docs/architecture/executor/issue-053-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 052` opened the bounded `load-cell-data` flux-decomposition seam, so the next staged helper surface is the package-level pipeline CLI at `loadcell_pipeline/cli.py`.
+- The migrated repo now has config, IO, aggregation, thresholds, preprocessing, events, and flux helpers, but it still lacks the canonical parser, override mapping, and pipeline orchestration surface that ties those seams together.
+- This slice should stay CLI-bounded: parser construction, CLI override mapping, pipeline execution, summary stats, and entrypoint behavior only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell CLI tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for parser overrides, input/output validation, pipeline orchestration, summary stats, and CLI entrypoint wiring
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/cli.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/fluxes.py`

--- a/docs/architecture/executor/pr-101-load-cell-cli.md
+++ b/docs/architecture/executor/pr-101-load-cell-cli.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` pipeline CLI seam into the staged `domains/load_cell` package
+- preserve parser construction, override mapping, package-level pipeline orchestration, and summary stats behavior
+- add seam-level regression tests and update architecture records for slice 053
+
+## Validation
+- .\\.venv\\Scripts\\python.exe -m pytest
+- .\\.venv\\Scripts\\ruff.exe check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/workflow.py`
+
+Closes #101

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed flux-decomposition seam | pipeline CLI, workflow, and batch-runner surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed pipeline CLI seam | workflow, sweep, and batch-runner surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -2,6 +2,11 @@ from stomatal_optimiaztion.domains.load_cell.aggregation import (
     daily_summary,
     resample_flux_timeseries,
 )
+from stomatal_optimiaztion.domains.load_cell.cli import (
+    build_parser,
+    main,
+    run_pipeline,
+)
 from stomatal_optimiaztion.domains.load_cell.config import (
     PipelineConfig,
     load_config,
@@ -31,10 +36,12 @@ from stomatal_optimiaztion.domains.load_cell.thresholds import (
 
 __all__ = [
     "auto_detect_step_thresholds",
+    "build_parser",
     "compute_fluxes_per_second",
     "daily_summary",
     "detect_and_correct_outliers",
     "group_events",
+    "main",
     "PipelineConfig",
     "label_points_by_derivative",
     "label_points_by_derivative_hysteresis",
@@ -43,6 +50,7 @@ __all__ = [
     "merge_close_events",
     "merge_close_events_with_df",
     "read_load_cell_csv",
+    "run_pipeline",
     "smooth_weight",
     "write_multi_resolution_results",
     "write_results",

--- a/src/stomatal_optimiaztion/domains/load_cell/cli.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/cli.py
@@ -1,0 +1,423 @@
+"""Command-line interface for the load-cell processing pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from . import aggregation
+from . import config as load_cell_config
+from . import events
+from . import fluxes
+from . import io
+from . import preprocessing
+from . import thresholds
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Process greenhouse load-cell data to estimate fluxes.",
+    )
+    parser.add_argument("--config", type=Path, help="Path to YAML configuration file.")
+    parser.add_argument(
+        "--input", type=Path, help="Input CSV file with load-cell data."
+    )
+    parser.add_argument(
+        "--output", type=Path, help="Output CSV path for per-second fluxes."
+    )
+    parser.add_argument(
+        "--excel", action="store_true", help="Also write an Excel workbook."
+    )
+    parser.add_argument(
+        "--smooth-method",
+        choices=["ma", "savgol"],
+        help="Smoothing method for weight signal.",
+    )
+    parser.add_argument(
+        "--smooth-window", type=int, help="Smoothing window length in seconds."
+    )
+    parser.add_argument(
+        "--poly-order", type=int, help="Savitzky-Golay polynomial order."
+    )
+    parser.add_argument("--k-outlier", type=float, help="Outlier MAD multiplier.")
+    parser.add_argument(
+        "--max-spike-width",
+        type=int,
+        help="Max spike width (s) to correct as outliers (guards real events).",
+    )
+    parser.add_argument(
+        "--derivative-method",
+        choices=["diff", "central", "savgol"],
+        help="Derivative method for dW (diff|central|savgol).",
+    )
+    parser.add_argument(
+        "--use-auto-thresholds", dest="use_auto_thresholds", action="store_true"
+    )
+    parser.add_argument(
+        "--no-auto-thresholds", dest="use_auto_thresholds", action="store_false"
+    )
+    parser.set_defaults(use_auto_thresholds=None)
+    parser.add_argument(
+        "--irrigation-threshold", type=float, help="Manual irrigation step threshold."
+    )
+    parser.add_argument(
+        "--drainage-threshold", type=float, help="Manual drainage step threshold."
+    )
+    parser.add_argument(
+        "--min-event-duration", type=int, help="Minimum event duration in seconds."
+    )
+    parser.add_argument(
+        "--merge-irrigation-gap",
+        type=int,
+        help="Gap (s) to merge irrigation events; omit to disable.",
+    )
+    parser.add_argument(
+        "--min-pos-events", type=int, help="Minimum positive tail points."
+    )
+    parser.add_argument(
+        "--min-neg-events", type=int, help="Minimum negative tail points."
+    )
+    parser.add_argument("--k-tail", type=float, help="Tail sigma multiplier.")
+    parser.add_argument(
+        "--min-factor", type=float, help="Minimum sigma distance from baseline."
+    )
+    parser.add_argument(
+        "--exclude-interpolated-for-thresholds",
+        dest="exclude_interpolated_from_thresholds",
+        action="store_true",
+        help="Exclude interpolated (forward-filled) samples when auto-detecting thresholds.",
+    )
+    parser.add_argument(
+        "--include-interpolated-for-thresholds",
+        dest="exclude_interpolated_from_thresholds",
+        action="store_false",
+        help="Include interpolated samples when auto-detecting thresholds.",
+    )
+    parser.set_defaults(exclude_interpolated_from_thresholds=None)
+    parser.add_argument(
+        "--use-hysteresis",
+        dest="use_hysteresis_labels",
+        action="store_true",
+        help="Enable hysteresis labeling (reduces label flicker).",
+    )
+    parser.add_argument(
+        "--no-hysteresis",
+        dest="use_hysteresis_labels",
+        action="store_false",
+        help="Disable hysteresis labeling.",
+    )
+    parser.set_defaults(use_hysteresis_labels=None)
+    parser.add_argument(
+        "--hysteresis-ratio", type=float, help="Hysteresis ratio in (0, 1]."
+    )
+    parser.add_argument("--timestamp-column", type=str, help="Timestamp column name.")
+    parser.add_argument("--weight-column", type=str, help="Weight column name.")
+    parser.add_argument(
+        "--no-transp-interp",
+        dest="interpolate_transpiration_during_events",
+        action="store_false",
+        help="Disable transpiration interpolation during events.",
+    )
+    parser.add_argument(
+        "--no-balance-fix",
+        dest="fix_water_balance",
+        action="store_false",
+        help="Disable water balance bias correction.",
+    )
+    parser.add_argument(
+        "--balance-scale-min",
+        type=float,
+        help="Minimum transpiration scale applied by water-balance fix.",
+    )
+    parser.add_argument(
+        "--balance-scale-max",
+        type=float,
+        help="Maximum transpiration scale applied by water-balance fix (omit to disable).",
+    )
+    parser.set_defaults(
+        interpolate_transpiration_during_events=None,
+        fix_water_balance=None,
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ...).",
+    )
+    return parser
+
+
+def _apply_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    """Convert CLI arguments into config overrides."""
+
+    overrides: dict[str, Any] = {}
+    if args.input:
+        overrides["input_path"] = args.input
+    if args.output:
+        overrides["output_path"] = args.output
+    if args.smooth_method:
+        overrides["smooth_method"] = args.smooth_method
+    if args.smooth_window:
+        overrides["smooth_window_sec"] = args.smooth_window
+    if args.poly_order is not None:
+        overrides["poly_order"] = args.poly_order
+    if args.k_outlier is not None:
+        overrides["k_outlier"] = args.k_outlier
+    if args.max_spike_width is not None:
+        overrides["max_spike_width_sec"] = args.max_spike_width
+    if args.derivative_method:
+        overrides["derivative_method"] = args.derivative_method
+    if args.use_auto_thresholds is not None:
+        overrides["use_auto_thresholds"] = args.use_auto_thresholds
+    if args.irrigation_threshold is not None:
+        overrides["irrigation_step_threshold_kg"] = args.irrigation_threshold
+    if args.drainage_threshold is not None:
+        overrides["drainage_step_threshold_kg"] = args.drainage_threshold
+    if args.min_event_duration is not None:
+        overrides["min_event_duration_sec"] = args.min_event_duration
+    if args.merge_irrigation_gap is not None:
+        overrides["merge_irrigation_gap_sec"] = args.merge_irrigation_gap
+    if args.min_pos_events is not None:
+        overrides["min_pos_events"] = args.min_pos_events
+    if args.min_neg_events is not None:
+        overrides["min_neg_events"] = args.min_neg_events
+    if args.k_tail is not None:
+        overrides["k_tail"] = args.k_tail
+    if args.min_factor is not None:
+        overrides["min_factor"] = args.min_factor
+    if args.exclude_interpolated_from_thresholds is not None:
+        overrides["exclude_interpolated_from_thresholds"] = (
+            args.exclude_interpolated_from_thresholds
+        )
+    if args.use_hysteresis_labels is not None:
+        overrides["use_hysteresis_labels"] = args.use_hysteresis_labels
+    if args.hysteresis_ratio is not None:
+        overrides["hysteresis_ratio"] = args.hysteresis_ratio
+    if args.timestamp_column:
+        overrides["timestamp_column"] = args.timestamp_column
+    if args.weight_column:
+        overrides["weight_column"] = args.weight_column
+    if args.interpolate_transpiration_during_events is not None:
+        overrides["interpolate_transpiration_during_events"] = (
+            args.interpolate_transpiration_during_events
+        )
+    if args.fix_water_balance is not None:
+        overrides["fix_water_balance"] = args.fix_water_balance
+    if args.balance_scale_min is not None:
+        overrides["water_balance_scale_min"] = args.balance_scale_min
+    if args.balance_scale_max is not None:
+        overrides["water_balance_scale_max"] = args.balance_scale_max
+    return overrides
+
+
+def run_pipeline(
+    cfg: load_cell_config.PipelineConfig,
+    include_excel: bool = False,
+    write_output: bool = True,
+    logger: logging.Logger | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any]]:
+    """Execute the load-cell pipeline and optionally persist outputs."""
+
+    log = logger or logging.getLogger(__name__)
+    if cfg.input_path is None:
+        raise ValueError("input_path must be specified.")
+    if write_output and cfg.output_path is None:
+        raise ValueError("output_path must be specified to write results.")
+
+    df = io.read_load_cell_csv(
+        cfg.input_path,
+        timestamp_column=cfg.timestamp_column,
+        weight_column=cfg.weight_column,
+    )
+
+    df = preprocessing.detect_and_correct_outliers(
+        df,
+        k_outlier=cfg.k_outlier,
+        max_spike_width_sec=cfg.max_spike_width_sec,
+    )
+    df = preprocessing.smooth_weight(
+        df,
+        method=cfg.smooth_method,
+        window_sec=cfg.smooth_window_sec,
+        poly_order=cfg.poly_order,
+        derivative_method=cfg.derivative_method,
+    )
+
+    use_auto = (
+        cfg.use_auto_thresholds
+        or cfg.irrigation_step_threshold_kg is None
+        or cfg.drainage_step_threshold_kg is None
+    )
+    if use_auto:
+        valid_mask = None
+        if cfg.exclude_interpolated_from_thresholds and "is_interpolated" in df.columns:
+            valid_mask = ~df["is_interpolated"].fillna(False)
+        irrigation_threshold, drainage_threshold = thresholds.auto_detect_step_thresholds(
+            df["dW_smooth_kg_s"],
+            min_pos_events=cfg.min_pos_events,
+            min_neg_events=cfg.min_neg_events,
+            k_tail=cfg.k_tail,
+            min_factor=cfg.min_factor,
+            valid_mask=valid_mask,
+            logger=log,
+        )
+    else:
+        irrigation_threshold = float(cfg.irrigation_step_threshold_kg)
+        drainage_threshold = float(cfg.drainage_step_threshold_kg)
+
+    if cfg.use_hysteresis_labels:
+        df = events.label_points_by_derivative_hysteresis(
+            df,
+            irrigation_threshold,
+            drainage_threshold,
+            hysteresis_ratio=cfg.hysteresis_ratio,
+        )
+    else:
+        df = events.label_points_by_derivative(
+            df,
+            irrigation_threshold,
+            drainage_threshold,
+        )
+    df, events_df = events.group_events(
+        df,
+        min_event_duration_sec=cfg.min_event_duration_sec,
+    )
+
+    if "label" in df.columns:
+        labels = df["label"].fillna("baseline").astype(str)
+        df["irrigation_time_sec_raw"] = (labels == "irrigation").astype("int64")
+        df["drainage_time_sec_raw"] = (labels == "drainage").astype("int64")
+        if "event_id" in df.columns:
+            is_event = df["event_id"].notna()
+            df["irrigation_time_sec"] = ((labels == "irrigation") & is_event).astype(
+                "int64"
+            )
+            df["drainage_time_sec"] = ((labels == "drainage") & is_event).astype(
+                "int64"
+            )
+
+    merged_events_df = events_df
+    event_id_map: dict[int, int] = {}
+    if cfg.merge_irrigation_gap_sec is not None:
+        merged_events_df, event_id_map = events.merge_close_events_with_df(
+            df,
+            events_df,
+            gap_threshold_sec=cfg.merge_irrigation_gap_sec,
+            event_type="irrigation",
+        )
+        if "event_id" in df.columns:
+            df["event_id_merged"] = df["event_id"].map(event_id_map).astype("Int64")
+
+    df = fluxes.compute_fluxes_per_second(
+        df,
+        interpolate_transpiration_during_events=(
+            cfg.interpolate_transpiration_during_events
+        ),
+        fix_water_balance=cfg.fix_water_balance,
+        min_transpiration_scale=cfg.water_balance_scale_min,
+        max_transpiration_scale=cfg.water_balance_scale_max,
+    )
+
+    if write_output and cfg.output_path:
+        frames: dict[str, pd.DataFrame] = {"1s": df}
+        frames["10s"] = aggregation.resample_flux_timeseries(df, "10s")
+        frames["1min"] = aggregation.resample_flux_timeseries(df, "1min")
+        frames["1h"] = aggregation.resample_flux_timeseries(df, "1h")
+        frames["daily"] = aggregation.daily_summary(
+            df,
+            events_df=merged_events_df,
+            metadata={
+                "irrigation_threshold": irrigation_threshold,
+                "drainage_threshold": drainage_threshold,
+            },
+        )
+        io.write_multi_resolution_results(
+            frames,
+            cfg.output_path,
+            include_excel=include_excel,
+        )
+
+    stats = _summarize_stats(df, merged_events_df)
+    log.info("Processed %d samples (%s to %s)", len(df), df.index.min(), df.index.max())
+    log.info(
+        "Irrigation events: %d (%.3f kg total)",
+        stats["irrigation_event_count"],
+        stats["total_irrigation_kg"],
+    )
+    log.info(
+        "Drainage events: %d (%.3f kg total)",
+        stats["drainage_event_count"],
+        stats["total_drainage_kg"],
+    )
+    log.info("Total transpiration: %.3f kg", stats["total_transpiration_kg"])
+    log.info("Final water balance error: %.4f kg", stats["final_balance_error_kg"])
+
+    metadata = {
+        "irrigation_threshold": irrigation_threshold,
+        "drainage_threshold": drainage_threshold,
+        "stats": stats,
+        "events": merged_events_df,
+        "events_merged": merged_events_df,
+        "events_raw": events_df,
+        "event_id_map": event_id_map,
+    }
+    return df, events_df, metadata
+
+
+def _summarize_stats(df: pd.DataFrame, events_df: pd.DataFrame) -> dict[str, Any]:
+    """Compute aggregate statistics for reporting."""
+
+    irrigation_events = (
+        events_df[events_df["event_type"] == "irrigation"]
+        if not events_df.empty
+        else events_df
+    )
+    drainage_events = (
+        events_df[events_df["event_type"] == "drainage"]
+        if not events_df.empty
+        else events_df
+    )
+
+    def safe_tail(series: pd.Series) -> float:
+        return float(series.iloc[-1]) if not series.empty else 0.0
+
+    return {
+        "irrigation_event_count": int(len(irrigation_events)) if not events_df.empty else 0,
+        "drainage_event_count": int(len(drainage_events)) if not events_df.empty else 0,
+        "total_irrigation_kg": safe_tail(df.get("cum_irrigation_kg", pd.Series(dtype=float))),
+        "total_drainage_kg": safe_tail(df.get("cum_drainage_kg", pd.Series(dtype=float))),
+        "total_transpiration_kg": safe_tail(
+            df.get("cum_transpiration_kg", pd.Series(dtype=float))
+        ),
+        "final_balance_error_kg": float(
+            df["water_balance_error_kg"].iloc[-1]
+            if "water_balance_error_kg" in df.columns
+            else 0.0
+        ),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for command-line execution."""
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    overrides = _apply_overrides(args)
+    cfg = load_cell_config.load_config(args.config, overrides=overrides)
+    run_pipeline(
+        cfg,
+        include_excel=args.excel,
+        write_output=True,
+        logger=logging.getLogger("loadcell_pipeline"),
+    )
+    return 0

--- a/tests/test_load_cell_cli.py
+++ b/tests/test_load_cell_cli.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import stomatal_optimiaztion.domains.load_cell.cli as load_cell_cli
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import (
+    PipelineConfig,
+    build_parser,
+    main as load_cell_main,
+    run_pipeline,
+)
+
+
+def test_load_cell_import_surface_exposes_cli_helpers() -> None:
+    assert load_cell.build_parser is build_parser
+    assert load_cell.run_pipeline is run_pipeline
+    assert load_cell.main is load_cell_main
+
+
+def test_apply_overrides_maps_cli_arguments_to_config_fields() -> None:
+    args = build_parser().parse_args(
+        [
+            "--input",
+            "input.csv",
+            "--output",
+            "out.csv",
+            "--smooth-method",
+            "ma",
+            "--smooth-window",
+            "5",
+            "--poly-order",
+            "3",
+            "--k-outlier",
+            "2.5",
+            "--max-spike-width",
+            "4",
+            "--derivative-method",
+            "diff",
+            "--no-auto-thresholds",
+            "--irrigation-threshold",
+            "0.4",
+            "--drainage-threshold",
+            "-0.3",
+            "--min-event-duration",
+            "6",
+            "--merge-irrigation-gap",
+            "7",
+            "--min-pos-events",
+            "8",
+            "--min-neg-events",
+            "9",
+            "--k-tail",
+            "4.5",
+            "--min-factor",
+            "3.5",
+            "--include-interpolated-for-thresholds",
+            "--use-hysteresis",
+            "--hysteresis-ratio",
+            "0.25",
+            "--timestamp-column",
+            "ts",
+            "--weight-column",
+            "w",
+            "--no-transp-interp",
+            "--no-balance-fix",
+            "--balance-scale-min",
+            "0.1",
+            "--balance-scale-max",
+            "2.2",
+        ]
+    )
+
+    overrides = load_cell_cli._apply_overrides(args)
+
+    assert overrides == {
+        "input_path": Path("input.csv"),
+        "output_path": Path("out.csv"),
+        "smooth_method": "ma",
+        "smooth_window_sec": 5,
+        "poly_order": 3,
+        "k_outlier": 2.5,
+        "max_spike_width_sec": 4,
+        "derivative_method": "diff",
+        "use_auto_thresholds": False,
+        "irrigation_step_threshold_kg": 0.4,
+        "drainage_step_threshold_kg": -0.3,
+        "min_event_duration_sec": 6,
+        "merge_irrigation_gap_sec": 7,
+        "min_pos_events": 8,
+        "min_neg_events": 9,
+        "k_tail": 4.5,
+        "min_factor": 3.5,
+        "exclude_interpolated_from_thresholds": False,
+        "use_hysteresis_labels": True,
+        "hysteresis_ratio": 0.25,
+        "timestamp_column": "ts",
+        "weight_column": "w",
+        "interpolate_transpiration_during_events": False,
+        "fix_water_balance": False,
+        "water_balance_scale_min": 0.1,
+        "water_balance_scale_max": 2.2,
+    }
+
+
+def test_run_pipeline_validates_input_and_output_paths(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="input_path"):
+        run_pipeline(PipelineConfig())
+
+    with pytest.raises(ValueError, match="output_path"):
+        run_pipeline(
+            PipelineConfig(input_path=tmp_path / "input.csv"),
+            write_output=True,
+        )
+
+
+def test_run_pipeline_orchestrates_auto_threshold_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    index = pd.date_range("2025-01-01 00:00:00", periods=3, freq="s", name="timestamp")
+    raw_df = pd.DataFrame(
+        {
+            "weight_raw_kg": [10.0, 10.2, 10.0],
+            "is_interpolated": [False, True, False],
+            "weight_kg": [10.0, 10.2, 10.0],
+        },
+        index=index,
+    )
+    smoothed_df = raw_df.copy()
+    smoothed_df["dW_smooth_kg_s"] = [0.0, 0.5, -0.2]
+    labeled_df = smoothed_df.copy()
+    labeled_df["label"] = ["baseline", "irrigation", "drainage"]
+    grouped_df = labeled_df.copy()
+    grouped_df["event_id"] = pd.Series([pd.NA, 1, 2], index=index, dtype="Int64")
+    events_df = pd.DataFrame(
+        [
+            {
+                "event_id": 1,
+                "event_type": "irrigation",
+                "start_time": index[1],
+                "end_time": index[1],
+                "duration_sec": 1,
+                "mass_change_kg": 0.2,
+            },
+            {
+                "event_id": 2,
+                "event_type": "drainage",
+                "start_time": index[2],
+                "end_time": index[2],
+                "duration_sec": 1,
+                "mass_change_kg": -0.2,
+            },
+        ]
+    )
+    merged_events_df = events_df.copy()
+    flux_df = grouped_df.copy()
+    flux_df["event_id_merged"] = pd.Series([pd.NA, 1, 2], index=index, dtype="Int64")
+    flux_df["irrigation_kg_s"] = [0.0, 0.2, 0.0]
+    flux_df["drainage_kg_s"] = [0.0, 0.0, 0.2]
+    flux_df["transpiration_kg_s"] = [0.0, 0.0, 0.1]
+    flux_df["cum_irrigation_kg"] = [0.0, 0.2, 0.2]
+    flux_df["cum_drainage_kg"] = [0.0, 0.0, 0.2]
+    flux_df["cum_transpiration_kg"] = [0.0, 0.0, 0.1]
+    flux_df["water_balance_error_kg"] = [0.0, 0.0, 0.0]
+
+    captures: dict[str, object] = {}
+
+    monkeypatch.setattr(load_cell_cli.io, "read_load_cell_csv", lambda *args, **kwargs: raw_df.copy())
+    monkeypatch.setattr(
+        load_cell_cli.preprocessing,
+        "detect_and_correct_outliers",
+        lambda df, **kwargs: df.copy(),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.preprocessing,
+        "smooth_weight",
+        lambda df, **kwargs: smoothed_df.copy(),
+    )
+
+    def fake_thresholds(series: pd.Series, **kwargs: object) -> tuple[float, float]:
+        captures["valid_mask"] = kwargs["valid_mask"]
+        captures["threshold_logger"] = kwargs["logger"]
+        assert series.equals(smoothed_df["dW_smooth_kg_s"])
+        return 0.4, -0.3
+
+    monkeypatch.setattr(
+        load_cell_cli.thresholds,
+        "auto_detect_step_thresholds",
+        fake_thresholds,
+    )
+    monkeypatch.setattr(
+        load_cell_cli.events,
+        "label_points_by_derivative",
+        lambda df, irrigation_threshold, drainage_threshold: labeled_df.copy(),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.events,
+        "group_events",
+        lambda df, min_event_duration_sec: (grouped_df.copy(), events_df.copy()),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.events,
+        "merge_close_events_with_df",
+        lambda df, events_df, gap_threshold_sec, event_type: (
+            merged_events_df.copy(),
+            {1: 1, 2: 2},
+        ),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.fluxes,
+        "compute_fluxes_per_second",
+        lambda df, **kwargs: flux_df.copy(),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.aggregation,
+        "resample_flux_timeseries",
+        lambda df, rule: pd.DataFrame({"rule": [rule]}),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.aggregation,
+        "daily_summary",
+        lambda df, events_df, metadata: pd.DataFrame({"day": [1]}),
+    )
+
+    def fake_write(
+        frames: dict[str, pd.DataFrame],
+        output_path: Path,
+        include_excel: bool,
+    ) -> None:
+        captures["frames"] = frames
+        captures["output_path"] = output_path
+        captures["include_excel"] = include_excel
+
+    monkeypatch.setattr(
+        load_cell_cli.io,
+        "write_multi_resolution_results",
+        fake_write,
+    )
+
+    cfg = PipelineConfig(
+        input_path=Path("input.csv"),
+        output_path=Path("artifacts/out.csv"),
+        merge_irrigation_gap_sec=3,
+    )
+    logger = logging.getLogger("load-cell-cli-test")
+
+    out_df, out_events, metadata = run_pipeline(
+        cfg,
+        include_excel=True,
+        logger=logger,
+    )
+
+    assert captures["valid_mask"].tolist() == [True, False, True]
+    assert captures["threshold_logger"] is logger
+    assert out_df.equals(flux_df)
+    assert out_events.equals(events_df)
+    assert metadata["irrigation_threshold"] == pytest.approx(0.4)
+    assert metadata["drainage_threshold"] == pytest.approx(-0.3)
+    assert metadata["events"].equals(merged_events_df)
+    assert metadata["events_merged"].equals(merged_events_df)
+    assert metadata["events_raw"].equals(events_df)
+    assert metadata["event_id_map"] == {1: 1, 2: 2}
+    assert metadata["stats"] == {
+        "irrigation_event_count": 1,
+        "drainage_event_count": 1,
+        "total_irrigation_kg": 0.2,
+        "total_drainage_kg": 0.2,
+        "total_transpiration_kg": 0.1,
+        "final_balance_error_kg": 0.0,
+    }
+    assert list(captures["frames"].keys()) == ["1s", "10s", "1min", "1h", "daily"]
+    assert captures["output_path"] == Path("artifacts/out.csv")
+    assert captures["include_excel"] is True
+
+
+def test_run_pipeline_supports_manual_thresholds_and_hysteresis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    index = pd.date_range("2025-01-01 00:00:00", periods=2, freq="s", name="timestamp")
+    raw_df = pd.DataFrame(
+        {
+            "weight_raw_kg": [10.0, 10.1],
+            "is_interpolated": [False, False],
+            "weight_kg": [10.0, 10.1],
+        },
+        index=index,
+    )
+    smoothed_df = raw_df.copy()
+    smoothed_df["dW_smooth_kg_s"] = [0.0, 0.1]
+    labeled_df = smoothed_df.copy()
+    labeled_df["label"] = ["baseline", "irrigation"]
+    grouped_df = labeled_df.copy()
+    grouped_df["event_id"] = pd.Series([pd.NA, 1], index=index, dtype="Int64")
+    flux_df = grouped_df.copy()
+    flux_df["irrigation_kg_s"] = [0.0, 0.1]
+    flux_df["drainage_kg_s"] = [0.0, 0.0]
+    flux_df["transpiration_kg_s"] = [0.0, 0.0]
+    flux_df["cum_irrigation_kg"] = [0.0, 0.1]
+    flux_df["cum_drainage_kg"] = [0.0, 0.0]
+    flux_df["cum_transpiration_kg"] = [0.0, 0.0]
+    flux_df["water_balance_error_kg"] = [0.0, 0.0]
+
+    monkeypatch.setattr(load_cell_cli.io, "read_load_cell_csv", lambda *args, **kwargs: raw_df.copy())
+    monkeypatch.setattr(
+        load_cell_cli.preprocessing,
+        "detect_and_correct_outliers",
+        lambda df, **kwargs: df.copy(),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.preprocessing,
+        "smooth_weight",
+        lambda df, **kwargs: smoothed_df.copy(),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.thresholds,
+        "auto_detect_step_thresholds",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not auto-detect")),
+    )
+
+    captures: dict[str, object] = {}
+
+    def fake_hysteresis(
+        df: pd.DataFrame,
+        irrigation_threshold: float,
+        drainage_threshold: float,
+        hysteresis_ratio: float,
+    ) -> pd.DataFrame:
+        captures["thresholds"] = (irrigation_threshold, drainage_threshold)
+        captures["hysteresis_ratio"] = hysteresis_ratio
+        return labeled_df.copy()
+
+    monkeypatch.setattr(
+        load_cell_cli.events,
+        "label_points_by_derivative_hysteresis",
+        fake_hysteresis,
+    )
+    monkeypatch.setattr(
+        load_cell_cli.events,
+        "group_events",
+        lambda df, min_event_duration_sec: (grouped_df.copy(), pd.DataFrame()),
+    )
+    monkeypatch.setattr(
+        load_cell_cli.fluxes,
+        "compute_fluxes_per_second",
+        lambda df, **kwargs: flux_df.copy(),
+    )
+
+    cfg = PipelineConfig(
+        input_path=Path("input.csv"),
+        output_path=None,
+        use_auto_thresholds=False,
+        irrigation_step_threshold_kg=0.4,
+        drainage_step_threshold_kg=-0.2,
+        use_hysteresis_labels=True,
+        hysteresis_ratio=0.3,
+    )
+
+    out_df, out_events, metadata = run_pipeline(
+        cfg,
+        write_output=False,
+    )
+
+    assert captures["thresholds"] == (0.4, -0.2)
+    assert captures["hysteresis_ratio"] == pytest.approx(0.3)
+    assert out_df.equals(flux_df)
+    assert out_events.empty
+    assert metadata["irrigation_threshold"] == pytest.approx(0.4)
+    assert metadata["drainage_threshold"] == pytest.approx(-0.2)
+    assert metadata["event_id_map"] == {}
+
+
+def test_summarize_stats_uses_event_counts_and_cumulative_tails() -> None:
+    df = pd.DataFrame(
+        {
+            "cum_irrigation_kg": [0.0, 0.3],
+            "cum_drainage_kg": [0.0, 0.1],
+            "cum_transpiration_kg": [0.0, 0.2],
+            "water_balance_error_kg": [0.0, -0.05],
+        }
+    )
+    events_df = pd.DataFrame(
+        [
+            {"event_type": "irrigation"},
+            {"event_type": "drainage"},
+            {"event_type": "irrigation"},
+        ]
+    )
+
+    stats = load_cell_cli._summarize_stats(df, events_df)
+
+    assert stats == {
+        "irrigation_event_count": 2,
+        "drainage_event_count": 1,
+        "total_irrigation_kg": 0.3,
+        "total_drainage_kg": 0.1,
+        "total_transpiration_kg": 0.2,
+        "final_balance_error_kg": -0.05,
+    }
+
+
+def test_main_loads_config_and_dispatches_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    captures: dict[str, object] = {}
+    cfg = PipelineConfig(input_path=Path("input.csv"), output_path=Path("out.csv"))
+
+    def fake_load_config(
+        path: Path | None,
+        overrides: dict[str, object] | None = None,
+    ) -> PipelineConfig:
+        captures["config_path"] = path
+        captures["overrides"] = overrides
+        return cfg
+
+    def fake_run_pipeline(
+        run_cfg: PipelineConfig,
+        include_excel: bool,
+        write_output: bool,
+        logger: logging.Logger,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, object]]:
+        captures["run_cfg"] = run_cfg
+        captures["include_excel"] = include_excel
+        captures["write_output"] = write_output
+        captures["logger_name"] = logger.name
+        return pd.DataFrame(), pd.DataFrame(), {}
+
+    monkeypatch.setattr(load_cell_cli.load_cell_config, "load_config", fake_load_config)
+    monkeypatch.setattr(load_cell_cli, "run_pipeline", fake_run_pipeline)
+
+    result = load_cell_main(
+        [
+            "--config",
+            "cfg.yaml",
+            "--output",
+            "out.csv",
+            "--excel",
+            "--no-balance-fix",
+        ]
+    )
+
+    assert result == 0
+    assert captures["config_path"] == Path("cfg.yaml")
+    assert captures["overrides"]["output_path"] == Path("out.csv")
+    assert captures["overrides"]["fix_water_balance"] is False
+    assert captures["run_cfg"] is cfg
+    assert captures["include_excel"] is True
+    assert captures["write_output"] is True
+    assert captures["logger_name"] == "loadcell_pipeline"


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` pipeline CLI seam into the staged `domains/load_cell` package
- preserve parser construction, override mapping, package-level pipeline orchestration, and summary stats behavior
- add seam-level regression tests and update architecture records for slice 053

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\ruff.exe check .

## Next Seam
- `load-cell-data/loadcell_pipeline/workflow.py`

Closes #101
