### PR TITLE
[Model Change] Migrate load-cell-data workflow seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -20,4 +20,5 @@ Current status:
 - Slice 051 migrated: `load-cell-data` event-detection seam
 - Slice 052 migrated: `load-cell-data` flux-decomposition seam
 - Slice 053 migrated: `load-cell-data` pipeline CLI seam
-- Next blocked seam: `load-cell-data` workflow seam at `loadcell_pipeline/workflow.py`
+- Slice 054 migrated: `load-cell-data` workflow seam
+- Next blocked seam: `load-cell-data` sweep seam at `loadcell_pipeline/sweep.py`

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ poetry run ruff check .
 - `load-cell-data` event-detection seam is migrated as slice 051.
 - `load-cell-data` flux-decomposition seam is migrated as slice 052.
 - `load-cell-data` pipeline CLI seam is migrated as slice 053.
+- `load-cell-data` workflow seam is migrated as slice 054.
 
 ## Next validation
-- Audit the `load-cell-data` workflow seam at `loadcell_pipeline/workflow.py`.
+- Audit the `load-cell-data` sweep seam at `loadcell_pipeline/sweep.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 053
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 053 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 054
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 054 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -365,3 +365,9 @@ Slice 053:
 - target: `src/stomatal_optimiaztion/domains/load_cell/cli.py`, package exports, and `tests/test_load_cell_cli.py`
 - scope: bounded `load-cell-data` pipeline CLI surface covering parser construction, override mapping, package-level helper orchestration, event timing fields, and summary stats
 - excluded: `loadcell_pipeline/workflow.py`, sweep, batch runners, and dashboard entrypoints
+
+Slice 054:
+- source: `load-cell-data/loadcell_pipeline/workflow.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/workflow.py`, package exports, and `tests/test_load_cell_workflow.py`
+- scope: bounded `load-cell-data` workflow surface covering config signatures, filename matching, environment export, substrate joins, and per-variant/per-config batch orchestration
+- excluded: `loadcell_pipeline/sweep.py`, `run_all.py`, raw preprocessing, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -468,8 +468,16 @@ The fifty-third slice opens the next bounded `load-cell-data` seam:
 - keep the seam CLI-bounded without widening into batch workflow, sweep, or batch-runner surfaces
 - leave `load-cell-data/loadcell_pipeline/workflow.py` blocked as the next seam
 
+## Slice 054: load-cell-data Workflow
+
+The fifty-fourth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/workflow.py` into the staged `domains/load_cell` package
+- preserve config signatures, filename matching, daily environment export, substrate joins, and per-variant/per-config batch orchestration behavior
+- keep the seam workflow-bounded without widening into sweep, end-to-end batch runners, or raw preprocessing surfaces
+- leave `load-cell-data/loadcell_pipeline/sweep.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first eight `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first nine `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/workflow.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/sweep.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 053 completed and slice 054 planning
+- Current phase: slice 054 completed and slice 055 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` workflow seam at `loadcell_pipeline/workflow.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli package boundary while deciding how batch workflow should build on the migrated package-level pipeline
+1. audit the `load-cell-data` sweep seam at `loadcell_pipeline/sweep.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow package boundary while deciding how parameter search should build on the migrated batch workflow
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-054-load-cell-workflow.md
+++ b/docs/architecture/architecture/module_specs/module-054-load-cell-workflow.md
@@ -1,0 +1,36 @@
+# Module Spec 054: load-cell-data Workflow
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the batch workflow runner that organizes per-day environment exports and per-config result trees across raw and interpolated variants.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/workflow.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/workflow.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_workflow.py`
+
+## Responsibilities
+
+1. preserve stable config signatures, filename matching, and weight-column inference across canonical and legacy daily CSVs
+2. preserve daily environment export, substrate-sensor joins, and per-config/per-loadcell result-tree writing
+3. keep the seam workflow-bounded without widening into sweep, raw preprocessing, or end-to-end batch entrypoints
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/sweep.py`
+- migrate `load-cell-data/loadcell_pipeline/run_all.py`
+- widen into raw ALMEMO preprocessing
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/sweep.py`

--- a/docs/architecture/executor/issue-054-model-change.md
+++ b/docs/architecture/executor/issue-054-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 053` opened the bounded `load-cell-data` pipeline CLI seam, so the next staged helper surface is the batch workflow module at `loadcell_pipeline/workflow.py`.
+- The migrated repo now has package-level pipeline execution, but it still lacks the daily batch runner that organizes environment outputs, per-config result trees, and loadcell-specific artifact writing across interpolated and raw variants.
+- This slice should stay workflow-bounded: config signatures, daily file discovery, environment export, substrate join, and batch orchestration only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell workflow tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for config signature stability, weight-column inference, common-filename filtering, environment export, and workflow orchestration across variants/configs/loadcells
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/workflow.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/cli.py`

--- a/docs/architecture/executor/pr-103-load-cell-workflow.md
+++ b/docs/architecture/executor/pr-103-load-cell-workflow.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` workflow seam into the staged `domains/load_cell` package
+- preserve config signatures, daily environment export, per-variant result-tree writing, and substrate-sensor joins
+- add seam-level regression tests and update architecture records for slice 054
+
+## Validation
+- .\\.venv\\Scripts\\python.exe -m pytest
+- .\\.venv\\Scripts\\ruff.exe check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/sweep.py`
+
+Closes #103

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed pipeline CLI seam | workflow, sweep, and batch-runner surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed workflow seam | sweep and end-to-end batch-runner surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -33,11 +33,16 @@ from stomatal_optimiaztion.domains.load_cell.preprocessing import (
 from stomatal_optimiaztion.domains.load_cell.thresholds import (
     auto_detect_step_thresholds,
 )
+from stomatal_optimiaztion.domains.load_cell.workflow import (
+    config_signature,
+    run_workflow,
+)
 
 __all__ = [
     "auto_detect_step_thresholds",
     "build_parser",
     "compute_fluxes_per_second",
+    "config_signature",
     "daily_summary",
     "detect_and_correct_outliers",
     "group_events",
@@ -51,6 +56,7 @@ __all__ = [
     "merge_close_events_with_df",
     "read_load_cell_csv",
     "run_pipeline",
+    "run_workflow",
     "smooth_weight",
     "write_multi_resolution_results",
     "write_results",

--- a/src/stomatal_optimiaztion/domains/load_cell/workflow.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/workflow.py
@@ -1,0 +1,398 @@
+"""Batch workflow runner for daily load-cell datasets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from . import aggregation
+from . import cli
+from . import config
+from . import io
+
+LOADCELL_MAP_RAW: dict[int, str] = {
+    1: "M000.0 N",
+    2: "M001.0 N",
+    3: "M002.0 N",
+    4: "M003.0 Kg",
+    5: "M004.0 Kg",
+    6: "M005.0 Kg",
+}
+
+ENV_COLUMNS_CANDIDATES = [
+    "air_temp_c",
+    "air_rh_percent",
+    "dewpoint_c",
+    "air_pressure_mb",
+    "weather_temp_c",
+    "wind_speed_m_s",
+    "weather_pressure_mb",
+    "tensiometer_4_hp",
+    "tensiometer_5_hp",
+]
+
+
+def _safe_slug(text: str) -> str:
+    sanitized = text.strip().replace(" ", "")
+    sanitized = sanitized.replace(":", "_").replace("/", "_").replace("\\", "_")
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]+", "_", sanitized)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    return sanitized or "run"
+
+
+def _format_number(value: Any) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.6g}".replace(".", "p")
+    return _safe_slug(str(value))
+
+
+def config_signature(cfg: config.PipelineConfig) -> tuple[str, str]:
+    """Build a human-readable slug and stable short hash for a config."""
+
+    data = cfg.to_dict()
+    for io_key in ["input_path", "output_path", "timestamp_column", "weight_column"]:
+        data.pop(io_key, None)
+
+    blob = json.dumps(data, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    digest = hashlib.sha1(blob).hexdigest()[:8]
+
+    parts = [
+        f"sm{_safe_slug(str(cfg.smooth_method))}",
+        f"w{_format_number(cfg.smooth_window_sec)}",
+        f"po{_format_number(cfg.poly_order)}",
+        f"kout{_format_number(cfg.k_outlier)}",
+        f"sp{_format_number(cfg.max_spike_width_sec)}",
+        f"deriv{_safe_slug(str(cfg.derivative_method))}",
+        f"kt{_format_number(cfg.k_tail)}",
+        f"mf{_format_number(cfg.min_factor)}",
+        f"dur{_format_number(cfg.min_event_duration_sec)}",
+        f"merge{_format_number(cfg.merge_irrigation_gap_sec)}",
+        f"bfix{_format_number(cfg.fix_water_balance)}",
+        f"bmin{_format_number(cfg.water_balance_scale_min)}",
+        f"bmax{_format_number(cfg.water_balance_scale_max)}",
+    ]
+    return "_".join(parts), digest
+
+
+def _read_interpolated_full(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "timestamp" not in df.columns:
+        raise KeyError(f"Missing 'timestamp' column in {path}")
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+    return df.dropna(subset=["timestamp"]).set_index("timestamp").sort_index()
+
+
+def _read_csv_header(path: Path) -> list[str]:
+    path = Path(path)
+    with path.open("r", encoding="utf-8-sig", errors="replace") as handle:
+        header = handle.readline().strip()
+    return [column.strip() for column in header.split(",")] if header else []
+
+
+def _infer_weight_column(
+    path: Path,
+    loadcell: int,
+    *,
+    prefer_canonical: bool = True,
+) -> str:
+    """Infer the weight column name for a given daily CSV and loadcell id."""
+
+    columns = set(_read_csv_header(path))
+    canonical = f"loadcell_{int(loadcell)}_kg"
+    legacy = LOADCELL_MAP_RAW[int(loadcell)]
+
+    if prefer_canonical and canonical in columns:
+        return canonical
+    if legacy in columns:
+        return legacy
+    if canonical in columns:
+        return canonical
+    raise KeyError(
+        f"Could not find weight column for loadcell {loadcell} in {path.name}. "
+        f"Tried: '{canonical}', '{legacy}'."
+    )
+
+
+def _resample_numeric_mean(df_1s: pd.DataFrame, rule: str) -> pd.DataFrame:
+    if df_1s.empty:
+        return pd.DataFrame()
+    grouped = df_1s.resample(rule)
+    out = grouped.mean(numeric_only=True)
+    out.index.name = "timestamp"
+    out["n_samples"] = grouped.size().astype("int64")
+    return out
+
+
+def _write_environment_once(
+    date_dir: Path,
+    df_interpolated_1s: pd.DataFrame,
+    include_excel: bool = False,
+) -> None:
+    env_cols = [
+        column for column in ENV_COLUMNS_CANDIDATES if column in df_interpolated_1s.columns
+    ]
+    if not env_cols:
+        return
+
+    env_1s = df_interpolated_1s[env_cols].copy()
+    env_dir = date_dir / "env"
+    env_dir.mkdir(parents=True, exist_ok=True)
+
+    frames: dict[str, pd.DataFrame] = {"1s": env_1s}
+    frames["10s"] = _resample_numeric_mean(env_1s, "10s")
+    frames["1min"] = _resample_numeric_mean(env_1s, "1min")
+    frames["1h"] = _resample_numeric_mean(env_1s, "1h")
+    frames["daily"] = _resample_numeric_mean(env_1s, "1D")
+    if "daily" in frames and not frames["daily"].empty:
+        frames["daily"].index.name = "day"
+
+    io.write_multi_resolution_results(
+        frames,
+        env_dir / "environment.csv",
+        include_excel=include_excel,
+    )
+
+
+def _join_substrate_sensors(
+    df_result_1s: pd.DataFrame,
+    df_interpolated_1s: pd.DataFrame,
+    loadcell: int,
+) -> pd.DataFrame:
+    df_out = df_result_1s.copy()
+    ec_col = f"ec_{loadcell}_ds"
+    moist_col = f"moisture_{loadcell}_percent"
+
+    if ec_col in df_interpolated_1s.columns:
+        df_out["substrate_ec_ds"] = df_interpolated_1s[ec_col].reindex(df_out.index)
+    if moist_col in df_interpolated_1s.columns:
+        df_out["substrate_moisture_percent"] = df_interpolated_1s[moist_col].reindex(
+            df_out.index
+        )
+    return df_out
+
+
+def _common_filenames(
+    interpolated_dir: Path,
+    raw_dir: Path,
+    variants: str,
+) -> list[str]:
+    files_interpolated = {path.name for path in interpolated_dir.glob("*.csv")}
+    files_raw = {path.name for path in raw_dir.glob("*.csv")}
+
+    if variants == "interpolated":
+        return sorted(files_interpolated)
+    if variants == "raw":
+        return sorted(files_raw)
+    return sorted(files_interpolated & files_raw)
+
+
+def run_workflow(
+    interpolated_dir: Path,
+    raw_dir: Path,
+    out_root: Path,
+    config_paths: list[Path],
+    variants: str = "both",
+    loadcells: Iterable[int] = (1, 2, 3, 4, 5, 6),
+    dates: list[str] | None = None,
+    include_excel: bool = False,
+    log_level: str = "WARNING",
+) -> None:
+    """Run the batch workflow across matched daily files and configs."""
+
+    out_root = Path(out_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.WARNING),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    logger = logging.getLogger("loadcell_workflow")
+
+    configs: list[tuple[Path, config.PipelineConfig, str]] = []
+    for path in config_paths:
+        cfg = config.load_config(path)
+        slug, digest = config_signature(cfg)
+        configs.append((path, cfg, f"{slug}__{digest}"))
+
+    all_files = _common_filenames(interpolated_dir, raw_dir, variants)
+    if dates:
+        wanted = set(dates)
+        all_files = [filename for filename in all_files if filename in wanted]
+
+    if not all_files:
+        raise SystemExit("No input files matched (check directories / --dates).")
+
+    variant_order = ["interpolated", "raw"] if variants == "both" else [variants]
+    for filename in all_files:
+        date_key = Path(filename).stem
+        date_dir = out_root / date_key
+        date_dir.mkdir(parents=True, exist_ok=True)
+
+        interpolated_path = interpolated_dir / filename
+        df_interpolated = (
+            _read_interpolated_full(interpolated_path)
+            if interpolated_path.exists()
+            else pd.DataFrame()
+        )
+        if not df_interpolated.empty:
+            _write_environment_once(
+                date_dir,
+                df_interpolated,
+                include_excel=include_excel,
+            )
+
+        for variant in variant_order:
+            for cfg_path, base_cfg, cfg_id in configs:
+                run_dir = date_dir / "results" / variant / cfg_id
+                run_dir.mkdir(parents=True, exist_ok=True)
+                (run_dir / "config_used.yaml").write_text(
+                    Path(cfg_path).read_text(encoding="utf-8"),
+                    encoding="utf-8",
+                )
+
+                for loadcell in loadcells:
+                    if variant == "interpolated":
+                        input_path = interpolated_dir / filename
+                        weight_column = _infer_weight_column(
+                            input_path,
+                            int(loadcell),
+                            prefer_canonical=True,
+                        )
+                    else:
+                        input_path = raw_dir / filename
+                        weight_column = _infer_weight_column(
+                            input_path,
+                            int(loadcell),
+                            prefer_canonical=True,
+                        )
+
+                    cfg_run = config.PipelineConfig(**asdict(base_cfg))
+                    cfg_run.input_path = input_path
+                    cfg_run.output_path = None
+                    cfg_run.timestamp_column = "timestamp"
+                    cfg_run.weight_column = weight_column
+
+                    df_1s, events_df, metadata = cli.run_pipeline(
+                        cfg_run,
+                        include_excel=False,
+                        write_output=False,
+                        logger=logger,
+                    )
+
+                    if not df_interpolated.empty:
+                        df_1s = _join_substrate_sensors(
+                            df_1s,
+                            df_interpolated,
+                            int(loadcell),
+                        )
+
+                    merged_events_df = metadata.get("events_merged", metadata.get("events", events_df))
+                    frames: dict[str, pd.DataFrame] = {"1s": df_1s}
+                    frames["10s"] = aggregation.resample_flux_timeseries(df_1s, "10s")
+                    frames["1min"] = aggregation.resample_flux_timeseries(df_1s, "1min")
+                    frames["1h"] = aggregation.resample_flux_timeseries(df_1s, "1h")
+                    frames["daily"] = aggregation.daily_summary(
+                        df_1s,
+                        events_df=merged_events_df,
+                        metadata={
+                            "irrigation_threshold": metadata.get("irrigation_threshold"),
+                            "drainage_threshold": metadata.get("drainage_threshold"),
+                        },
+                    )
+
+                    io.write_multi_resolution_results(
+                        frames,
+                        run_dir / f"loadcell_{int(loadcell)}.csv",
+                        include_excel=include_excel,
+                    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Batch workflow: per-day env once + per-config results for loadcells.",
+    )
+    parser.add_argument(
+        "--interpolated-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv_interpolated"),
+        help="Directory containing interpolated daily CSVs.",
+    )
+    parser.add_argument(
+        "--raw-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv"),
+        help="Directory containing raw (non-interpolated) daily CSVs.",
+    )
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=Path("runs"),
+        help="Root output directory.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        action="append",
+        default=[],
+        help="Config YAML (repeatable). Default: ./config.yaml",
+    )
+    parser.add_argument(
+        "--variants",
+        choices=["interpolated", "raw", "both"],
+        default="both",
+        help="Which datasets to process.",
+    )
+    parser.add_argument(
+        "--loadcells",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3, 4, 5, 6],
+        help="Loadcell ids to process.",
+    )
+    parser.add_argument(
+        "--dates",
+        nargs="*",
+        help="Optional list of filenames (e.g., 2025-06-17.csv). If omitted, process all matched files.",
+    )
+    parser.add_argument("--excel", action="store_true", help="Also write Excel outputs.")
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        help="Logging level (DEBUG, INFO, WARNING, ...).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for batch workflow execution."""
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    config_paths = args.config if args.config else [Path("config.yaml")]
+    run_workflow(
+        interpolated_dir=args.interpolated_dir,
+        raw_dir=args.raw_dir,
+        out_root=args.out_root,
+        config_paths=config_paths,
+        variants=args.variants,
+        loadcells=args.loadcells,
+        dates=args.dates,
+        include_excel=args.excel,
+        log_level=args.log_level,
+    )
+    return 0

--- a/tests/test_load_cell_workflow.py
+++ b/tests/test_load_cell_workflow.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import stomatal_optimiaztion.domains.load_cell.workflow as load_cell_workflow
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import (
+    PipelineConfig,
+    config_signature,
+    run_workflow,
+)
+
+
+def test_load_cell_import_surface_exposes_workflow_helpers() -> None:
+    assert load_cell.config_signature is config_signature
+    assert load_cell.run_workflow is run_workflow
+
+
+def test_config_signature_is_stable_across_io_fields_only() -> None:
+    base = PipelineConfig(
+        input_path=Path("input-a.csv"),
+        output_path=Path("out-a.csv"),
+        timestamp_column="timestamp",
+        weight_column="weight_kg",
+        smooth_window_sec=31,
+    )
+    same_model = PipelineConfig(
+        input_path=Path("input-b.csv"),
+        output_path=Path("out-b.csv"),
+        timestamp_column="ts",
+        weight_column="mass",
+        smooth_window_sec=31,
+    )
+    changed_model = PipelineConfig(smooth_window_sec=41)
+
+    base_slug, base_hash = config_signature(base)
+    same_slug, same_hash = config_signature(same_model)
+    changed_slug, changed_hash = config_signature(changed_model)
+
+    assert base_slug == same_slug
+    assert base_hash == same_hash
+    assert changed_slug != base_slug
+    assert changed_hash != base_hash
+
+
+def test_infer_weight_column_supports_canonical_and_legacy_headers(
+    tmp_path: Path,
+) -> None:
+    canonical = tmp_path / "canonical.csv"
+    canonical.write_text(
+        "timestamp,loadcell_1_kg,M000.0 N\n2025-01-01 00:00:00,1.0,2.0\n",
+        encoding="utf-8",
+    )
+    legacy = tmp_path / "legacy.csv"
+    legacy.write_text(
+        "timestamp,M000.0 N\n2025-01-01 00:00:00,2.0\n",
+        encoding="utf-8",
+    )
+
+    assert load_cell_workflow._infer_weight_column(canonical, 1) == "loadcell_1_kg"
+    assert load_cell_workflow._infer_weight_column(legacy, 1) == "M000.0 N"
+
+    missing = tmp_path / "missing.csv"
+    missing.write_text("timestamp,other\n2025-01-01 00:00:00,3.0\n", encoding="utf-8")
+
+    with pytest.raises(KeyError, match="Could not find weight column"):
+        load_cell_workflow._infer_weight_column(missing, 1)
+
+
+def test_common_filenames_filters_by_variant(tmp_path: Path) -> None:
+    interpolated_dir = tmp_path / "interpolated"
+    raw_dir = tmp_path / "raw"
+    interpolated_dir.mkdir()
+    raw_dir.mkdir()
+    for path in [
+        interpolated_dir / "2025-01-01.csv",
+        interpolated_dir / "2025-01-02.csv",
+        raw_dir / "2025-01-02.csv",
+        raw_dir / "2025-01-03.csv",
+    ]:
+        path.write_text("timestamp,weight\n", encoding="utf-8")
+
+    assert load_cell_workflow._common_filenames(interpolated_dir, raw_dir, "interpolated") == [
+        "2025-01-01.csv",
+        "2025-01-02.csv",
+    ]
+    assert load_cell_workflow._common_filenames(interpolated_dir, raw_dir, "raw") == [
+        "2025-01-02.csv",
+        "2025-01-03.csv",
+    ]
+    assert load_cell_workflow._common_filenames(interpolated_dir, raw_dir, "both") == [
+        "2025-01-02.csv"
+    ]
+
+
+def test_run_workflow_requires_matching_files(tmp_path: Path) -> None:
+    interpolated_dir = tmp_path / "interpolated"
+    raw_dir = tmp_path / "raw"
+    out_root = tmp_path / "runs"
+    interpolated_dir.mkdir()
+    raw_dir.mkdir()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("smooth_window_sec: 31\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="No input files matched"):
+        run_workflow(
+            interpolated_dir=interpolated_dir,
+            raw_dir=raw_dir,
+            out_root=out_root,
+            config_paths=[config_path],
+            variants="both",
+        )
+
+
+def test_run_workflow_writes_environment_and_variant_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpolated_dir = tmp_path / "interpolated"
+    raw_dir = tmp_path / "raw"
+    out_root = tmp_path / "runs"
+    interpolated_dir.mkdir()
+    raw_dir.mkdir()
+    filename = "2025-01-02.csv"
+    (interpolated_dir / filename).write_text(
+        "timestamp,loadcell_1_kg,ec_1_ds,moisture_1_percent\n"
+        "2025-01-02 00:00:00,10.0,1.2,55.0\n",
+        encoding="utf-8",
+    )
+    (raw_dir / filename).write_text(
+        "timestamp,M000.0 N\n2025-01-02 00:00:00,10.0\n",
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "config.yaml"
+    config_text = "smooth_window_sec: 15\nmerge_irrigation_gap_sec: 5\n"
+    config_path.write_text(config_text, encoding="utf-8")
+    base_cfg = PipelineConfig(smooth_window_sec=15, merge_irrigation_gap_sec=5)
+    slug, digest = config_signature(base_cfg)
+    cfg_id = f"{slug}__{digest}"
+
+    index = pd.date_range("2025-01-02 00:00:00", periods=2, freq="s", name="timestamp")
+    df_interpolated = pd.DataFrame(
+        {
+            "loadcell_1_kg": [10.0, 10.1],
+            "ec_1_ds": [1.2, 1.3],
+            "moisture_1_percent": [55.0, 56.0],
+            "air_temp_c": [22.0, 22.1],
+        },
+        index=index,
+    )
+    events_df = pd.DataFrame(
+        [
+            {
+                "event_id": 1,
+                "event_type": "irrigation",
+                "start_time": index[0],
+                "end_time": index[0],
+                "duration_sec": 1,
+                "mass_change_kg": 0.1,
+            }
+        ]
+    )
+    merged_events_df = events_df.copy()
+    df_result = pd.DataFrame(
+        {
+            "irrigation_kg_s": [0.1, 0.0],
+            "drainage_kg_s": [0.0, 0.0],
+            "transpiration_kg_s": [0.0, 0.1],
+            "cum_irrigation_kg": [0.1, 0.1],
+            "cum_drainage_kg": [0.0, 0.0],
+            "cum_transpiration_kg": [0.0, 0.1],
+            "water_balance_error_kg": [0.0, 0.0],
+        },
+        index=index,
+    )
+
+    calls: list[dict[str, object]] = []
+    writes: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        load_cell_workflow,
+        "_read_interpolated_full",
+        lambda path: df_interpolated.copy(),
+    )
+
+    def fake_run_pipeline(
+        cfg: PipelineConfig,
+        include_excel: bool,
+        write_output: bool,
+        logger,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, object]]:
+        calls.append(
+            {
+                "input_path": cfg.input_path,
+                "output_path": cfg.output_path,
+                "timestamp_column": cfg.timestamp_column,
+                "weight_column": cfg.weight_column,
+                "include_excel": include_excel,
+                "write_output": write_output,
+                "logger_name": logger.name,
+            }
+        )
+        return (
+            df_result.copy(),
+            events_df.copy(),
+            {
+                "irrigation_threshold": 0.4,
+                "drainage_threshold": -0.3,
+                "events_merged": merged_events_df.copy(),
+            },
+        )
+
+    monkeypatch.setattr(load_cell_workflow.cli, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(
+        load_cell_workflow.aggregation,
+        "resample_flux_timeseries",
+        lambda df, rule: pd.DataFrame({"rule": [rule]}),
+    )
+    monkeypatch.setattr(
+        load_cell_workflow.aggregation,
+        "daily_summary",
+        lambda df, events_df, metadata: pd.DataFrame({"day": [1]}),
+    )
+
+    def fake_write_multi_resolution_results(
+        frames: dict[str, pd.DataFrame],
+        output_path: Path,
+        include_excel: bool = False,
+    ) -> None:
+        writes.append(
+            {
+                "frames": frames,
+                "output_path": output_path,
+                "include_excel": include_excel,
+            }
+        )
+
+    monkeypatch.setattr(
+        load_cell_workflow.io,
+        "write_multi_resolution_results",
+        fake_write_multi_resolution_results,
+    )
+
+    run_workflow(
+        interpolated_dir=interpolated_dir,
+        raw_dir=raw_dir,
+        out_root=out_root,
+        config_paths=[config_path],
+        variants="both",
+        loadcells=[1],
+        include_excel=True,
+    )
+
+    assert len(writes) == 3
+    assert writes[0]["output_path"] == out_root / "2025-01-02" / "env" / "environment.csv"
+    assert writes[1]["output_path"] == (
+        out_root / "2025-01-02" / "results" / "interpolated" / cfg_id / "loadcell_1.csv"
+    )
+    assert writes[2]["output_path"] == (
+        out_root / "2025-01-02" / "results" / "raw" / cfg_id / "loadcell_1.csv"
+    )
+    assert writes[0]["include_excel"] is True
+    assert writes[1]["include_excel"] is True
+    assert writes[2]["include_excel"] is True
+    assert "air_temp_c" in writes[0]["frames"]["1s"].columns
+    assert "substrate_ec_ds" in writes[1]["frames"]["1s"].columns
+    assert "substrate_moisture_percent" in writes[2]["frames"]["1s"].columns
+
+    assert calls == [
+        {
+            "input_path": interpolated_dir / filename,
+            "output_path": None,
+            "timestamp_column": "timestamp",
+            "weight_column": "loadcell_1_kg",
+            "include_excel": False,
+            "write_output": False,
+            "logger_name": "loadcell_workflow",
+        },
+        {
+            "input_path": raw_dir / filename,
+            "output_path": None,
+            "timestamp_column": "timestamp",
+            "weight_column": "M000.0 N",
+            "include_excel": False,
+            "write_output": False,
+            "logger_name": "loadcell_workflow",
+        },
+    ]
+    assert (
+        out_root / "2025-01-02" / "results" / "interpolated" / cfg_id / "config_used.yaml"
+    ).read_text(encoding="utf-8") == config_text
+    assert (
+        out_root / "2025-01-02" / "results" / "raw" / cfg_id / "config_used.yaml"
+    ).read_text(encoding="utf-8") == config_text
+
+
+def test_workflow_main_dispatches_with_default_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captures: dict[str, object] = {}
+
+    def fake_run_workflow(**kwargs: object) -> None:
+        captures.update(kwargs)
+
+    monkeypatch.setattr(load_cell_workflow, "run_workflow", fake_run_workflow)
+
+    result = load_cell_workflow.main(
+        [
+            "--interpolated-dir",
+            "interp",
+            "--raw-dir",
+            "raw",
+            "--out-root",
+            "runs-out",
+            "--variants",
+            "raw",
+            "--loadcells",
+            "2",
+            "4",
+            "--dates",
+            "2025-01-01.csv",
+            "--excel",
+            "--log-level",
+            "INFO",
+        ]
+    )
+
+    assert result == 0
+    assert captures == {
+        "interpolated_dir": Path("interp"),
+        "raw_dir": Path("raw"),
+        "out_root": Path("runs-out"),
+        "config_paths": [Path("config.yaml")],
+        "variants": "raw",
+        "loadcells": [2, 4],
+        "dates": ["2025-01-01.csv"],
+        "include_excel": True,
+        "log_level": "INFO",
+    }


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` workflow seam into the staged `domains/load_cell` package
- preserve config signatures, daily environment export, per-variant result-tree writing, and substrate-sensor joins
- add seam-level regression tests and update architecture records for slice 054

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\ruff.exe check .

## Next Seam
- `load-cell-data/loadcell_pipeline/sweep.py`

Closes #103
