### PR TITLE
[Model Change] Migrate load-cell-data sweep seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -21,4 +21,5 @@ Current status:
 - Slice 052 migrated: `load-cell-data` flux-decomposition seam
 - Slice 053 migrated: `load-cell-data` pipeline CLI seam
 - Slice 054 migrated: `load-cell-data` workflow seam
-- Next blocked seam: `load-cell-data` sweep seam at `loadcell_pipeline/sweep.py`
+- Slice 055 migrated: `load-cell-data` sweep seam
+- Next blocked seam: `load-cell-data` end-to-end runner seam at `loadcell_pipeline/run_all.py`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ poetry run ruff check .
 - `load-cell-data` flux-decomposition seam is migrated as slice 052.
 - `load-cell-data` pipeline CLI seam is migrated as slice 053.
 - `load-cell-data` workflow seam is migrated as slice 054.
+- `load-cell-data` sweep seam is migrated as slice 055.
 
 ## Next validation
-- Audit the `load-cell-data` sweep seam at `loadcell_pipeline/sweep.py`.
+- Audit the `load-cell-data` end-to-end runner seam at `loadcell_pipeline/run_all.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 054
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 054 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 055
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 055 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -371,3 +371,9 @@ Slice 054:
 - target: `src/stomatal_optimiaztion/domains/load_cell/workflow.py`, package exports, and `tests/test_load_cell_workflow.py`
 - scope: bounded `load-cell-data` workflow surface covering config signatures, filename matching, environment export, substrate joins, and per-variant/per-config batch orchestration
 - excluded: `loadcell_pipeline/sweep.py`, `run_all.py`, raw preprocessing, and dashboard entrypoints
+
+Slice 055:
+- source: `load-cell-data/loadcell_pipeline/sweep.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/sweep.py`, package exports, and `tests/test_load_cell_sweep.py`
+- scope: bounded `load-cell-data` sweep surface covering grid parsing, generated config emission, workflow dispatch, run collection, and ranking outputs
+- excluded: `loadcell_pipeline/run_all.py`, raw preprocessing, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -476,8 +476,16 @@ The fifty-fourth slice opens the next bounded `load-cell-data` seam:
 - keep the seam workflow-bounded without widening into sweep, end-to-end batch runners, or raw preprocessing surfaces
 - leave `load-cell-data/loadcell_pipeline/sweep.py` blocked as the next seam
 
+## Slice 055: load-cell-data Sweep
+
+The fifty-fifth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/sweep.py` into the staged `domains/load_cell` package
+- preserve grid parsing, generated config emission, workflow dispatch, run collection, and ranking behavior
+- keep the seam sweep-bounded without widening into raw preprocessing or end-to-end runner surfaces
+- leave `load-cell-data/loadcell_pipeline/run_all.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first nine `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first ten `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/sweep.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/run_all.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 054 completed and slice 055 planning
+- Current phase: slice 055 completed and slice 056 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` sweep seam at `loadcell_pipeline/sweep.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow package boundary while deciding how parameter search should build on the migrated batch workflow
+1. audit the `load-cell-data` end-to-end runner seam at `loadcell_pipeline/run_all.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep package boundary while deciding how the top-level runner should compose raw preprocessing and migrated orchestration seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-055-load-cell-sweep.md
+++ b/docs/architecture/architecture/module_specs/module-055-load-cell-sweep.md
@@ -1,0 +1,36 @@
+# Module Spec 055: load-cell-data Sweep
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the parameter-sweep runner that generates config variants, dispatches batch workflows, and ranks resulting runs.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/sweep.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/sweep.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_sweep.py`
+
+## Responsibilities
+
+1. preserve grid parsing, generated config validation, and YAML/config CSV emission
+2. preserve workflow dispatch, run collection, and per-variant ranking outputs
+3. keep the seam sweep-bounded without widening into raw preprocessing or end-to-end runner surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/run_all.py`
+- widen into raw ALMEMO preprocessing
+- widen into dashboard surfaces
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/run_all.py`

--- a/docs/architecture/executor/issue-055-model-change.md
+++ b/docs/architecture/executor/issue-055-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 054` opened the bounded `load-cell-data` workflow seam, so the next staged helper surface is the parameter-sweep module at `loadcell_pipeline/sweep.py`.
+- The migrated repo now has batch workflow execution, but it still lacks the canonical grid parser, generated-config writer, run collection, and ranking surface used to compare pipeline settings.
+- This slice should stay sweep-bounded: grid parsing, config generation, workflow dispatch, run collection, and ranking only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell sweep tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for grid parsing, generated config validation, run collection, ranking, and sweep orchestration outputs
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/sweep.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/workflow.py`

--- a/docs/architecture/executor/pr-105-load-cell-sweep.md
+++ b/docs/architecture/executor/pr-105-load-cell-sweep.md
@@ -1,0 +1,13 @@
+## Summary
+- migrate the bounded `load-cell-data` sweep seam into the staged `domains/load_cell` package
+- preserve grid parsing, generated config emission, workflow dispatch, run collection, and ranking behavior
+- add seam-level regression tests and update architecture records for slice 055
+
+## Validation
+- .\\.venv\\Scripts\\python.exe -m pytest
+- .\\.venv\\Scripts\\ruff.exe check .
+
+## Next Seam
+- `load-cell-data/loadcell_pipeline/run_all.py`
+
+Closes #105

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed workflow seam | sweep and end-to-end batch-runner surfaces remain unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed sweep seam | the end-to-end batch-runner surface still remains unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -33,6 +33,9 @@ from stomatal_optimiaztion.domains.load_cell.preprocessing import (
 from stomatal_optimiaztion.domains.load_cell.thresholds import (
     auto_detect_step_thresholds,
 )
+from stomatal_optimiaztion.domains.load_cell.sweep import (
+    run_sweep,
+)
 from stomatal_optimiaztion.domains.load_cell.workflow import (
     config_signature,
     run_workflow,
@@ -56,6 +59,7 @@ __all__ = [
     "merge_close_events_with_df",
     "read_load_cell_csv",
     "run_pipeline",
+    "run_sweep",
     "run_workflow",
     "smooth_weight",
     "write_multi_resolution_results",

--- a/src/stomatal_optimiaztion/domains/load_cell/sweep.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/sweep.py
@@ -1,0 +1,348 @@
+"""Parameter sweep helpers for load-cell workflow comparison."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import logging
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from . import config
+from . import workflow
+
+
+def _parse_value(raw: str) -> Any:
+    text = raw.strip()
+    if text == "":
+        return text
+
+    lowered = text.lower()
+    if lowered in {"none", "null"}:
+        return None
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+
+    try:
+        if lowered.startswith("0") and len(lowered) > 1 and lowered[1].isdigit():
+            raise ValueError
+        return int(text)
+    except ValueError:
+        pass
+
+    try:
+        return float(text)
+    except ValueError:
+        return text
+
+
+def _parse_grid_arg(arg: str) -> tuple[str, list[Any]]:
+    if "=" not in arg:
+        raise ValueError(f"Invalid --grid '{arg}'. Expected KEY=V1,V2,...")
+
+    key, values_str = arg.split("=", 1)
+    key = key.strip()
+    if not key:
+        raise ValueError(f"Invalid --grid '{arg}'. Empty key.")
+
+    values = [_parse_value(value) for value in values_str.split(",")]
+    values = [value for value in values if not (isinstance(value, str) and value == "")]
+    if not values:
+        raise ValueError(f"Invalid --grid '{arg}'. No values.")
+    return key, values
+
+
+def _generate_configs(
+    base_cfg: config.PipelineConfig,
+    grid: dict[str, list[Any]],
+) -> list[tuple[config.PipelineConfig, dict[str, Any]]]:
+    keys = list(grid.keys())
+    values = [grid[key] for key in keys]
+
+    base_dict = asdict(base_cfg)
+    out: list[tuple[config.PipelineConfig, dict[str, Any]]] = []
+    for combo in itertools.product(*values):
+        overrides = dict(zip(keys, combo))
+        cfg = config.PipelineConfig(**base_dict)
+        for key, value in overrides.items():
+            if not hasattr(cfg, key):
+                raise KeyError(f"PipelineConfig has no field '{key}' (from --grid).")
+            setattr(cfg, key, value)
+        out.append((cfg, overrides))
+    return out
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    try:
+        import yaml  # type: ignore
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(
+            "PyYAML is required for sweep config generation. Install 'pyyaml'."
+        ) from exc
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False, allow_unicode=True)
+
+
+def _collect_runs(out_root: Path) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    cfg_cache: dict[str, dict[str, Any]] = {}
+
+    for date_dir in sorted(path for path in out_root.iterdir() if path.is_dir()):
+        results_dir = date_dir / "results"
+        if not results_dir.exists():
+            continue
+        date_key = date_dir.name
+
+        for variant_dir in sorted(path for path in results_dir.iterdir() if path.is_dir()):
+            variant = variant_dir.name
+            for cfg_dir in sorted(path for path in variant_dir.iterdir() if path.is_dir()):
+                cfg_id = cfg_dir.name
+
+                if cfg_id not in cfg_cache:
+                    cfg_used = cfg_dir / "config_used.yaml"
+                    if cfg_used.exists():
+                        try:
+                            loaded_cfg = config.load_config(cfg_used)
+                            cfg_cache[cfg_id] = loaded_cfg.to_dict()
+                        except Exception:  # noqa: BLE001
+                            cfg_cache[cfg_id] = {}
+                    else:
+                        cfg_cache[cfg_id] = {}
+
+                for daily_path in sorted(cfg_dir.glob("loadcell_*_daily.csv")):
+                    df = pd.read_csv(daily_path)
+                    loadcell = int(daily_path.stem.split("_")[1])
+                    for _, row in df.iterrows():
+                        out_row = {
+                            "date": date_key,
+                            "variant": variant,
+                            "config_id": cfg_id,
+                            "loadcell": loadcell,
+                        }
+                        out_row.update(row.to_dict())
+
+                        cfg_dict = cfg_cache.get(cfg_id, {})
+                        for cfg_key in [
+                            "smooth_method",
+                            "smooth_window_sec",
+                            "poly_order",
+                            "k_outlier",
+                            "max_spike_width_sec",
+                            "derivative_method",
+                            "use_auto_thresholds",
+                            "k_tail",
+                            "min_factor",
+                            "min_event_duration_sec",
+                            "merge_irrigation_gap_sec",
+                            "exclude_interpolated_from_thresholds",
+                            "use_hysteresis_labels",
+                            "hysteresis_ratio",
+                            "fix_water_balance",
+                            "water_balance_scale_min",
+                            "water_balance_scale_max",
+                        ]:
+                            if cfg_key in cfg_dict:
+                                out_row[f"cfg_{cfg_key}"] = cfg_dict[cfg_key]
+
+                        rows.append(out_row)
+
+    return pd.DataFrame(rows)
+
+
+def _rank_configs(df_runs: pd.DataFrame) -> pd.DataFrame:
+    if df_runs.empty:
+        return pd.DataFrame()
+
+    df = df_runs.copy()
+    for column in [
+        "mean_abs_balance_error_kg",
+        "final_balance_error_kg",
+        "transpiration_scale",
+        "irrigation_event_count",
+        "drainage_event_count",
+    ]:
+        if column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+
+    df["abs_final_balance_error_kg"] = df.get("final_balance_error_kg", 0.0).abs()
+    df["abs_transpiration_scale_minus1"] = (
+        df.get("transpiration_scale", 1.0) - 1.0
+    ).abs()
+    df["event_count"] = df.get("irrigation_event_count", 0.0).fillna(0.0) + df.get(
+        "drainage_event_count", 0.0
+    ).fillna(0.0)
+
+    grouped = df.groupby(["variant", "config_id"], dropna=False)
+    aggregated = grouped.agg(
+        n_rows=("date", "count"),
+        n_days=("date", "nunique"),
+        n_loadcells=("loadcell", "nunique"),
+        mean_abs_balance_error_kg_mean=("mean_abs_balance_error_kg", "mean"),
+        abs_final_balance_error_kg_mean=("abs_final_balance_error_kg", "mean"),
+        abs_transpiration_scale_minus1_mean=("abs_transpiration_scale_minus1", "mean"),
+        event_count_mean=("event_count", "mean"),
+        total_irrigation_kg_mean=("total_irrigation_kg", "mean"),
+        total_drainage_kg_mean=("total_drainage_kg", "mean"),
+        total_transpiration_kg_mean=("total_transpiration_kg", "mean"),
+    ).reset_index()
+
+    aggregated["score"] = (
+        aggregated["mean_abs_balance_error_kg_mean"].fillna(0.0)
+        + 0.1 * aggregated["abs_final_balance_error_kg_mean"].fillna(0.0)
+        + 0.02 * aggregated["abs_transpiration_scale_minus1_mean"].fillna(0.0)
+        + 0.00001 * aggregated["event_count_mean"].fillna(0.0)
+    )
+    aggregated = aggregated.sort_values(
+        [
+            "variant",
+            "score",
+            "mean_abs_balance_error_kg_mean",
+            "abs_final_balance_error_kg_mean",
+            "abs_transpiration_scale_minus1_mean",
+            "event_count_mean",
+        ],
+        ascending=[True, True, True, True, True, True],
+    )
+    aggregated["rank"] = aggregated.groupby("variant").cumcount() + 1
+    return aggregated
+
+
+def run_sweep(
+    out_root: Path,
+    interpolated_dir: Path,
+    raw_dir: Path,
+    base_config_path: Path,
+    grid_args: list[str],
+    variants: str,
+    loadcells: list[int],
+    dates: list[str] | None,
+    include_excel: bool,
+    log_level: str,
+) -> None:
+    """Generate config variants, run the workflow, and rank results."""
+
+    out_root = Path(out_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.WARNING),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    base_cfg = config.load_config(base_config_path)
+
+    grid: dict[str, list[Any]] = {}
+    for grid_arg in grid_args:
+        key, values = _parse_grid_arg(grid_arg)
+        grid[key] = values
+
+    if not grid:
+        grid = {
+            "smooth_window_sec": [11, 14, 17],
+            "k_tail": [4.0, 4.5, 5.0],
+        }
+
+    generated = _generate_configs(base_cfg, grid)
+
+    cfg_dir = out_root / "_sweep" / "configs"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_paths: list[Path] = []
+    cfg_rows: list[dict[str, Any]] = []
+
+    for cfg, overrides in generated:
+        slug, digest = workflow.config_signature(cfg)
+        cfg_id = f"{slug}__{digest}"
+        cfg_path = cfg_dir / f"{cfg_id}.yaml"
+        _write_yaml(cfg_path, cfg.to_dict())
+        cfg_paths.append(cfg_path)
+        cfg_rows.append({"config_id": cfg_id, "path": str(cfg_path), **overrides})
+
+    sweep_dir = out_root / "_sweep"
+    sweep_dir.mkdir(parents=True, exist_ok=True)
+    (sweep_dir / "grid.json").write_text(
+        json.dumps(
+            {"base_config": str(base_config_path), "grid": grid},
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    pd.DataFrame(cfg_rows).to_csv(sweep_dir / "configs.csv", index=False)
+
+    workflow.run_workflow(
+        interpolated_dir=interpolated_dir,
+        raw_dir=raw_dir,
+        out_root=out_root,
+        config_paths=cfg_paths,
+        variants=variants,
+        loadcells=loadcells,
+        dates=dates,
+        include_excel=include_excel,
+        log_level=log_level,
+    )
+
+    runs = _collect_runs(out_root)
+    runs.to_csv(out_root / "summary_runs.csv", index=False)
+
+    ranking = _rank_configs(runs)
+    ranking.to_csv(out_root / "ranking.csv", index=False)
+
+    if not ranking.empty:
+        top = ranking.sort_values(["variant", "rank"]).groupby("variant").head(20)
+        top.to_csv(out_root / "ranking_top20.csv", index=False)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Grid sweep runner + ranking.")
+    parser.add_argument("--out-root", type=Path, default=Path("runs_sweep"))
+    parser.add_argument(
+        "--interpolated-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv_interpolated"),
+    )
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/preprocessed_csv"))
+    parser.add_argument("--base-config", type=Path, default=Path("config.yaml"))
+    parser.add_argument(
+        "--grid",
+        action="append",
+        default=[],
+        help="Grid spec KEY=V1,V2,... (repeatable). Example: --grid smooth_window_sec=11,14,17",
+    )
+    parser.add_argument(
+        "--variants",
+        choices=["interpolated", "raw", "both"],
+        default="both",
+    )
+    parser.add_argument("--loadcells", type=int, nargs="+", default=[1, 2, 3, 4, 5, 6])
+    parser.add_argument(
+        "--dates", nargs="*", help="Optional list of filenames (YYYY-MM-DD.csv)"
+    )
+    parser.add_argument("--excel", action="store_true")
+    parser.add_argument("--log-level", type=str, default="WARNING")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for sweep execution."""
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    run_sweep(
+        out_root=args.out_root,
+        interpolated_dir=args.interpolated_dir,
+        raw_dir=args.raw_dir,
+        base_config_path=args.base_config,
+        grid_args=args.grid,
+        variants=args.variants,
+        loadcells=args.loadcells,
+        dates=args.dates,
+        include_excel=args.excel,
+        log_level=args.log_level,
+    )
+    return 0

--- a/tests/test_load_cell_sweep.py
+++ b/tests/test_load_cell_sweep.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import stomatal_optimiaztion.domains.load_cell.sweep as load_cell_sweep
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import PipelineConfig, run_sweep
+
+
+def test_load_cell_import_surface_exposes_run_sweep() -> None:
+    assert load_cell.run_sweep is run_sweep
+
+
+def test_parse_value_and_grid_arg_cover_scalar_cases() -> None:
+    assert load_cell_sweep._parse_value(" none ") is None
+    assert load_cell_sweep._parse_value("TRUE") is True
+    assert load_cell_sweep._parse_value("7") == 7
+    assert load_cell_sweep._parse_value("3.5") == pytest.approx(3.5)
+    assert load_cell_sweep._parse_value("07") == pytest.approx(7.0)
+    assert load_cell_sweep._parse_value("text") == "text"
+
+    assert load_cell_sweep._parse_grid_arg("smooth_window_sec=11,14,17") == (
+        "smooth_window_sec",
+        [11, 14, 17],
+    )
+
+    with pytest.raises(ValueError, match="Expected KEY"):
+        load_cell_sweep._parse_grid_arg("bad-grid")
+
+    with pytest.raises(ValueError, match="Empty key"):
+        load_cell_sweep._parse_grid_arg(" =1,2")
+
+
+def test_generate_configs_validates_unknown_fields() -> None:
+    base_cfg = PipelineConfig()
+
+    generated = load_cell_sweep._generate_configs(
+        base_cfg,
+        {"smooth_window_sec": [11, 14], "k_tail": [4.0]},
+    )
+
+    assert len(generated) == 2
+    assert generated[0][0].smooth_window_sec == 11
+    assert generated[1][0].smooth_window_sec == 14
+    assert generated[0][1] == {"smooth_window_sec": 11, "k_tail": 4.0}
+
+    with pytest.raises(KeyError, match="has no field"):
+        load_cell_sweep._generate_configs(base_cfg, {"bad_field": [1]})
+
+
+def test_collect_runs_reads_daily_outputs_and_attaches_config_fields(
+    tmp_path: Path,
+) -> None:
+    out_root = tmp_path / "runs"
+    cfg_dir = out_root / "2025-01-01" / "results" / "raw" / "cfg-a"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config_used.yaml").write_text(
+        "\n".join(
+            [
+                "smooth_method: savgol",
+                "smooth_window_sec: 31",
+                "k_tail: 4.5",
+                "min_factor: 3.0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pd.DataFrame(
+        [
+            {
+                "day": "2025-01-01",
+                "mean_abs_balance_error_kg": 0.02,
+                "final_balance_error_kg": -0.01,
+                "transpiration_scale": 1.1,
+                "irrigation_event_count": 2,
+                "drainage_event_count": 1,
+                "total_irrigation_kg": 1.2,
+                "total_drainage_kg": 0.6,
+                "total_transpiration_kg": 0.5,
+            }
+        ]
+    ).to_csv(cfg_dir / "loadcell_1_daily.csv", index=False)
+
+    collected = load_cell_sweep._collect_runs(out_root)
+
+    assert collected.shape[0] == 1
+    row = collected.iloc[0]
+    assert row["date"] == "2025-01-01"
+    assert row["variant"] == "raw"
+    assert row["config_id"] == "cfg-a"
+    assert row["loadcell"] == 1
+    assert row["cfg_smooth_method"] == "savgol"
+    assert row["cfg_smooth_window_sec"] == 31
+    assert row["cfg_k_tail"] == pytest.approx(4.5)
+
+
+def test_rank_configs_scores_and_orders_by_variant() -> None:
+    df_runs = pd.DataFrame(
+        [
+            {
+                "date": "2025-01-01",
+                "variant": "raw",
+                "config_id": "cfg-good",
+                "loadcell": 1,
+                "mean_abs_balance_error_kg": 0.01,
+                "final_balance_error_kg": 0.0,
+                "transpiration_scale": 1.0,
+                "irrigation_event_count": 1,
+                "drainage_event_count": 1,
+                "total_irrigation_kg": 1.0,
+                "total_drainage_kg": 0.5,
+                "total_transpiration_kg": 0.4,
+            },
+            {
+                "date": "2025-01-02",
+                "variant": "raw",
+                "config_id": "cfg-bad",
+                "loadcell": 1,
+                "mean_abs_balance_error_kg": 0.2,
+                "final_balance_error_kg": 0.1,
+                "transpiration_scale": 1.5,
+                "irrigation_event_count": 4,
+                "drainage_event_count": 3,
+                "total_irrigation_kg": 1.2,
+                "total_drainage_kg": 0.7,
+                "total_transpiration_kg": 0.5,
+            },
+        ]
+    )
+
+    ranking = load_cell_sweep._rank_configs(df_runs)
+
+    assert ranking["config_id"].tolist() == ["cfg-good", "cfg-bad"]
+    assert ranking["rank"].tolist() == [1, 2]
+    assert ranking.iloc[0]["score"] < ranking.iloc[1]["score"]
+
+
+def test_run_sweep_writes_generated_configs_and_rankings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out_root = tmp_path / "runs_sweep"
+    base_config_path = tmp_path / "base.yaml"
+    base_config_path.write_text("smooth_window_sec: 31\nk_tail: 4.0\n", encoding="utf-8")
+
+    workflow_calls: dict[str, object] = {}
+
+    def fake_run_workflow(**kwargs: object) -> None:
+        workflow_calls.update(kwargs)
+        for cfg_path in kwargs["config_paths"]:
+            cfg_file = Path(cfg_path)
+            cfg_id = cfg_file.stem
+            result_dir = out_root / "2025-01-01" / "results" / "raw" / cfg_id
+            result_dir.mkdir(parents=True, exist_ok=True)
+            (result_dir / "config_used.yaml").write_text(
+                cfg_file.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            pd.DataFrame(
+                [
+                    {
+                        "day": "2025-01-01",
+                        "mean_abs_balance_error_kg": 0.05 if "w11" in cfg_id else 0.02,
+                        "final_balance_error_kg": 0.01 if "w11" in cfg_id else 0.0,
+                        "transpiration_scale": 1.2 if "w11" in cfg_id else 1.0,
+                        "irrigation_event_count": 2,
+                        "drainage_event_count": 1,
+                        "total_irrigation_kg": 1.0,
+                        "total_drainage_kg": 0.4,
+                        "total_transpiration_kg": 0.5,
+                    }
+                ]
+            ).to_csv(result_dir / "loadcell_1_daily.csv", index=False)
+
+    monkeypatch.setattr(load_cell_sweep.workflow, "run_workflow", fake_run_workflow)
+
+    run_sweep(
+        out_root=out_root,
+        interpolated_dir=Path("interp"),
+        raw_dir=Path("raw"),
+        base_config_path=base_config_path,
+        grid_args=["smooth_window_sec=11,14"],
+        variants="raw",
+        loadcells=[1],
+        dates=["2025-01-01.csv"],
+        include_excel=False,
+        log_level="INFO",
+    )
+
+    sweep_dir = out_root / "_sweep"
+    assert (sweep_dir / "grid.json").exists()
+    assert json.loads((sweep_dir / "grid.json").read_text(encoding="utf-8")) == {
+        "base_config": str(base_config_path),
+        "grid": {"smooth_window_sec": [11, 14]},
+    }
+    configs_csv = pd.read_csv(sweep_dir / "configs.csv")
+    assert len(configs_csv) == 2
+    assert set(configs_csv["smooth_window_sec"].tolist()) == {11, 14}
+    generated_config_paths = workflow_calls["config_paths"]
+    assert len(generated_config_paths) == 2
+    assert workflow_calls["variants"] == "raw"
+    assert workflow_calls["loadcells"] == [1]
+    assert workflow_calls["dates"] == ["2025-01-01.csv"]
+    summary = pd.read_csv(out_root / "summary_runs.csv")
+    ranking = pd.read_csv(out_root / "ranking.csv")
+    top20 = pd.read_csv(out_root / "ranking_top20.csv")
+    assert summary.shape[0] == 2
+    assert ranking.shape[0] == 2
+    assert top20.shape[0] == 2
+    assert ranking.iloc[0]["rank"] == 1
+    assert ranking.iloc[0]["score"] <= ranking.iloc[1]["score"]
+
+
+def test_sweep_main_dispatches_expected_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captures: dict[str, object] = {}
+
+    def fake_run_sweep(**kwargs: object) -> None:
+        captures.update(kwargs)
+
+    monkeypatch.setattr(load_cell_sweep, "run_sweep", fake_run_sweep)
+
+    result = load_cell_sweep.main(
+        [
+            "--out-root",
+            "runs",
+            "--interpolated-dir",
+            "interp",
+            "--raw-dir",
+            "raw",
+            "--base-config",
+            "base.yaml",
+            "--grid",
+            "smooth_window_sec=11,14",
+            "--variants",
+            "interpolated",
+            "--loadcells",
+            "1",
+            "3",
+            "--dates",
+            "2025-01-01.csv",
+            "--excel",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+
+    assert result == 0
+    assert captures == {
+        "out_root": Path("runs"),
+        "interpolated_dir": Path("interp"),
+        "raw_dir": Path("raw"),
+        "base_config_path": Path("base.yaml"),
+        "grid_args": ["smooth_window_sec=11,14"],
+        "variants": "interpolated",
+        "loadcells": [1, 3],
+        "dates": ["2025-01-01.csv"],
+        "include_excel": True,
+        "log_level": "DEBUG",
+    }


### PR DESCRIPTION
## Summary
- migrate the bounded `load-cell-data` sweep seam into the staged `domains/load_cell` package
- preserve grid parsing, generated config emission, workflow dispatch, run collection, and ranking behavior
- add seam-level regression tests and update architecture records for slice 055

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\ruff.exe check .

## Next Seam
- `load-cell-data/loadcell_pipeline/run_all.py`

Closes #105
