### PR TITLE
[Model Change] Migrate load-cell-data end-to-end runner seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -22,4 +22,5 @@ Current status:
 - Slice 053 migrated: `load-cell-data` pipeline CLI seam
 - Slice 054 migrated: `load-cell-data` workflow seam
 - Slice 055 migrated: `load-cell-data` sweep seam
-- Next blocked seam: `load-cell-data` end-to-end runner seam at `loadcell_pipeline/run_all.py`
+- Slice 056 migrated: `load-cell-data` end-to-end runner seam
+- Next blocked seam: `load-cell-data` raw preprocessing seam at `loadcell_pipeline/almemo_preprocess.py`

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ poetry run ruff check .
 - `load-cell-data` pipeline CLI seam is migrated as slice 053.
 - `load-cell-data` workflow seam is migrated as slice 054.
 - `load-cell-data` sweep seam is migrated as slice 055.
+- `load-cell-data` end-to-end runner seam is migrated as slice 056.
 
 ## Next validation
-- Audit the `load-cell-data` end-to-end runner seam at `loadcell_pipeline/run_all.py`.
+- Audit the `load-cell-data` raw preprocessing seam at `loadcell_pipeline/almemo_preprocess.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 055
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 055 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 056
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 056 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -377,3 +377,9 @@ Slice 055:
 - target: `src/stomatal_optimiaztion/domains/load_cell/sweep.py`, package exports, and `tests/test_load_cell_sweep.py`
 - scope: bounded `load-cell-data` sweep surface covering grid parsing, generated config emission, workflow dispatch, run collection, and ranking outputs
 - excluded: `loadcell_pipeline/run_all.py`, raw preprocessing, and dashboard entrypoints
+
+Slice 056:
+- source: `load-cell-data/loadcell_pipeline/run_all.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/run_all.py`, package exports, and `tests/test_load_cell_run_all.py`
+- scope: bounded `load-cell-data` end-to-end runner surface covering parser construction plus orchestration across raw preprocessing, workflow dispatch, and sweep dispatch
+- excluded: `loadcell_pipeline/almemo_preprocess.py`, raw ALMEMO parsing internals, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -484,8 +484,16 @@ The fifty-fifth slice opens the next bounded `load-cell-data` seam:
 - keep the seam sweep-bounded without widening into raw preprocessing or end-to-end runner surfaces
 - leave `load-cell-data/loadcell_pipeline/run_all.py` blocked as the next seam
 
+## Slice 056: load-cell-data End-to-End Runner
+
+The fifty-sixth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/run_all.py` into the staged `domains/load_cell` package
+- preserve parser construction plus orchestration across raw preprocessing, workflow dispatch, and sweep dispatch
+- keep raw preprocessing behind a lazy-or-injected dependency instead of widening into `almemo_preprocess.py` in the same slice
+- leave `load-cell-data/loadcell_pipeline/almemo_preprocess.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first ten `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first eleven `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/run_all.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/almemo_preprocess.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 055 completed and slice 056 planning
+- Current phase: slice 056 completed and slice 057 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` end-to-end runner seam at `loadcell_pipeline/run_all.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep package boundary while deciding how the top-level runner should compose raw preprocessing and migrated orchestration seams
+1. audit the `load-cell-data` raw preprocessing seam at `loadcell_pipeline/almemo_preprocess.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner package boundary while deciding how raw ALMEMO ingestion should land behind the migrated orchestration seams
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-056-load-cell-run-all.md
+++ b/docs/architecture/architecture/module_specs/module-056-load-cell-run-all.md
@@ -1,0 +1,36 @@
+# Module Spec 056: load-cell-data End-to-End Runner
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the top-level runner that composes raw preprocessing with workflow or sweep execution.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/run_all.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/run_all.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_run_all.py`
+
+## Responsibilities
+
+1. preserve CLI parser construction and end-to-end orchestration across preprocessing plus workflow-or-sweep dispatch
+2. preserve the dual daily-output preprocessing contract for raw and 1-second-interpolated CSV directories
+3. keep the seam bounded by lazily resolving or injecting raw preprocessing until `almemo_preprocess.py` is migrated
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/almemo_preprocess.py`
+- widen into dashboard or reporting surfaces
+- introduce repo-level wrappers beyond the package-local runner seam
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/almemo_preprocess.py`

--- a/docs/architecture/executor/issue-056-model-change.md
+++ b/docs/architecture/executor/issue-056-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 055` opened the bounded `load-cell-data` sweep seam, so the next staged helper surface is the end-to-end runner at `loadcell_pipeline/run_all.py`.
+- The migrated repo now has workflow and sweep orchestration, but it still lacks the top-level entrypoint that decides whether to preprocess raw ALMEMO files, run workflow, or run sweep from one command.
+- This slice should stay runner-bounded: parser construction, preprocess dispatch, workflow-or-sweep branching, and lazy missing-preprocessor error handling only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell run-all tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for preprocess dispatch, skip-preprocess mode, workflow vs sweep branching, parser wiring, and missing-preprocessor failure path
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/run_all.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/{workflow.py,sweep.py}`

--- a/docs/architecture/executor/pr-107-load-cell-run-all.md
+++ b/docs/architecture/executor/pr-107-load-cell-run-all.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the `load-cell-data` end-to-end runner seam into `domains/load_cell/run_all.py`
+- preserve package-local parser and orchestration across preprocessing, workflow, and sweep dispatch
+- keep raw preprocessing as a lazy or injected dependency until `almemo_preprocess.py` migrates
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #107

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed sweep seam | the end-to-end batch-runner surface still remains unmigrated, so the third domain boundary is only partially explicit in the staged repo | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed end-to-end runner seam | raw ALMEMO preprocessing still remains unmigrated, so the package boundary is explicit but not yet closed end to end | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -40,6 +40,9 @@ from stomatal_optimiaztion.domains.load_cell.workflow import (
     config_signature,
     run_workflow,
 )
+from stomatal_optimiaztion.domains.load_cell.run_all import (
+    run_all,
+)
 
 __all__ = [
     "auto_detect_step_thresholds",
@@ -58,6 +61,7 @@ __all__ = [
     "merge_close_events",
     "merge_close_events_with_df",
     "read_load_cell_csv",
+    "run_all",
     "run_pipeline",
     "run_sweep",
     "run_workflow",

--- a/src/stomatal_optimiaztion/domains/load_cell/run_all.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/run_all.py
@@ -1,0 +1,252 @@
+"""End-to-end runner for load-cell preprocessing plus workflow or sweep."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from . import sweep
+from . import workflow
+
+PreprocessRawFolderFn = Callable[..., object]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for the end-to-end runner."""
+
+    parser = argparse.ArgumentParser(
+        description="End-to-end: raw ALMEMO -> daily CSVs -> workflow/sweep results.",
+    )
+    parser.add_argument(
+        "--raw-input-dir",
+        type=Path,
+        default=Path("data/raw"),
+        help="Directory containing raw ALMEMO500~*.csv files.",
+    )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default="ALMEMO500~*.csv",
+        help="Glob pattern for raw input files.",
+    )
+    parser.add_argument(
+        "--encoding",
+        type=str,
+        default="latin1",
+        help="Encoding for raw ALMEMO files (latin1 is safest).",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Optional cap on number of raw files to preprocess (for testing).",
+    )
+    parser.add_argument(
+        "--skip-preprocess",
+        action="store_true",
+        help="Skip raw->daily preprocessing step (assume daily CSVs already exist).",
+    )
+    parser.add_argument(
+        "--overwrite-preprocess",
+        action="store_true",
+        help="Overwrite existing daily CSVs during preprocessing.",
+    )
+    parser.add_argument(
+        "--daily-raw-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv"),
+        help="Output dir for per-day raw CSVs (no 1s interpolation).",
+    )
+    parser.add_argument(
+        "--daily-interpolated-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv_interpolated"),
+        help="Output dir for per-day interpolated CSVs (1s interpolation).",
+    )
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=Path("runs"),
+        help="Output root directory for final results (workflow/sweep).",
+    )
+    parser.add_argument(
+        "--variants",
+        choices=["interpolated", "raw", "both"],
+        default="both",
+        help="Which datasets to process in the workflow stage.",
+    )
+    parser.add_argument(
+        "--loadcells",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3, 4, 5, 6],
+        help="Loadcell ids to process.",
+    )
+    parser.add_argument(
+        "--dates",
+        nargs="*",
+        help="Optional list of daily filenames (YYYY-MM-DD.csv). If omitted, process all matched days.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        action="append",
+        default=[],
+        help="Config YAML for workflow (repeatable). Default: ./config.yaml",
+    )
+    parser.add_argument(
+        "--excel",
+        action="store_true",
+        help="Also write Excel outputs (multi-sheet) for each result.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        help="Logging level (DEBUG, INFO, WARNING, ...).",
+    )
+    parser.add_argument(
+        "--base-config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Base config used when running sweep (and default config for workflow).",
+    )
+    parser.add_argument(
+        "--grid",
+        action="append",
+        default=[],
+        help="Grid spec KEY=V1,V2,... (repeatable). If provided, runs sweep instead of workflow.",
+    )
+    return parser
+
+
+def _resolve_preprocess_raw_folder(
+    preprocess_raw_folder: PreprocessRawFolderFn | None = None,
+) -> PreprocessRawFolderFn:
+    if preprocess_raw_folder is not None:
+        return preprocess_raw_folder
+
+    try:
+        from stomatal_optimiaztion.domains.load_cell.almemo_preprocess import (  # type: ignore[attr-defined]
+            preprocess_raw_folder as resolved_preprocess_raw_folder,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "load-cell raw preprocessing is not available yet. "
+            "Pass skip_preprocess=True or inject preprocess_raw_folder."
+        ) from exc
+
+    return resolved_preprocess_raw_folder
+
+
+def run_all(
+    *,
+    raw_input_dir: Path,
+    pattern: str = "ALMEMO500~*.csv",
+    encoding: str = "latin1",
+    max_files: int | None = None,
+    skip_preprocess: bool = False,
+    overwrite_preprocess: bool = False,
+    daily_raw_dir: Path = Path("data/preprocessed_csv"),
+    daily_interpolated_dir: Path = Path("data/preprocessed_csv_interpolated"),
+    out_root: Path = Path("runs"),
+    variants: str = "both",
+    loadcells: Sequence[int] = (1, 2, 3, 4, 5, 6),
+    dates: list[str] | None = None,
+    config_paths: Sequence[Path] | None = None,
+    include_excel: bool = False,
+    log_level: str = "WARNING",
+    base_config: Path = Path("config.yaml"),
+    grid_args: Sequence[str] | None = None,
+    preprocess_raw_folder: PreprocessRawFolderFn | None = None,
+) -> None:
+    """Run raw preprocessing plus workflow or sweep from one entrypoint."""
+
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.WARNING),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    grid_args_list = list(grid_args or [])
+
+    if not skip_preprocess:
+        preprocess = _resolve_preprocess_raw_folder(preprocess_raw_folder)
+        preprocess(
+            raw_input_dir,
+            daily_raw_dir,
+            pattern=pattern,
+            max_files=max_files,
+            overwrite=overwrite_preprocess,
+            encoding=encoding,
+            interpolate_1s=False,
+        )
+        preprocess(
+            raw_input_dir,
+            daily_interpolated_dir,
+            pattern=pattern,
+            max_files=max_files,
+            overwrite=overwrite_preprocess,
+            encoding=encoding,
+            interpolate_1s=True,
+        )
+
+    if grid_args_list:
+        sweep.run_sweep(
+            out_root=out_root,
+            interpolated_dir=daily_interpolated_dir,
+            raw_dir=daily_raw_dir,
+            base_config_path=base_config,
+            grid_args=grid_args_list,
+            variants=variants,
+            loadcells=list(loadcells),
+            dates=list(dates) if dates else None,
+            include_excel=bool(include_excel),
+            log_level=log_level,
+        )
+        return
+
+    resolved_config_paths = list(config_paths) if config_paths else [base_config]
+    workflow.run_workflow(
+        interpolated_dir=daily_interpolated_dir,
+        raw_dir=daily_raw_dir,
+        out_root=out_root,
+        config_paths=resolved_config_paths,
+        variants=variants,
+        loadcells=list(loadcells),
+        dates=list(dates) if dates else None,
+        include_excel=include_excel,
+        log_level=log_level,
+    )
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    preprocess_raw_folder: PreprocessRawFolderFn | None = None,
+) -> int:
+    """Entry point for command-line execution."""
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    run_all(
+        raw_input_dir=args.raw_input_dir,
+        pattern=args.pattern,
+        encoding=args.encoding,
+        max_files=args.max_files,
+        skip_preprocess=args.skip_preprocess,
+        overwrite_preprocess=args.overwrite_preprocess,
+        daily_raw_dir=args.daily_raw_dir,
+        daily_interpolated_dir=args.daily_interpolated_dir,
+        out_root=args.out_root,
+        variants=args.variants,
+        loadcells=args.loadcells,
+        dates=list(args.dates) if args.dates else None,
+        config_paths=args.config if args.config else [args.base_config],
+        include_excel=args.excel,
+        log_level=args.log_level,
+        base_config=args.base_config,
+        grid_args=args.grid,
+        preprocess_raw_folder=preprocess_raw_folder,
+    )
+    return 0

--- a/tests/test_load_cell_run_all.py
+++ b/tests/test_load_cell_run_all.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import run_all
+
+load_cell_run_all = importlib.import_module("stomatal_optimiaztion.domains.load_cell.run_all")
+
+
+def test_load_cell_import_surface_exposes_run_all_helper() -> None:
+    assert load_cell.run_all is run_all
+
+
+def test_run_all_raises_when_preprocess_is_required_but_missing() -> None:
+    with pytest.raises(RuntimeError, match="skip_preprocess=True|inject preprocess_raw_folder"):
+        run_all(raw_input_dir=Path("raw"))
+
+
+def test_run_all_preprocesses_then_dispatches_workflow() -> None:
+    preprocess_calls: list[dict[str, object]] = []
+    captures: dict[str, object] = {}
+
+    def fake_preprocess(
+        input_dir: Path,
+        output_dir: Path,
+        *,
+        pattern: str,
+        max_files: int | None,
+        overwrite: bool,
+        encoding: str,
+        interpolate_1s: bool,
+    ) -> None:
+        preprocess_calls.append(
+            {
+                "input_dir": input_dir,
+                "output_dir": output_dir,
+                "pattern": pattern,
+                "max_files": max_files,
+                "overwrite": overwrite,
+                "encoding": encoding,
+                "interpolate_1s": interpolate_1s,
+            }
+        )
+
+    def fake_run_workflow(**kwargs: object) -> None:
+        captures.update(kwargs)
+
+    original_run_workflow = load_cell_run_all.workflow.run_workflow
+    load_cell_run_all.workflow.run_workflow = fake_run_workflow
+    try:
+        run_all(
+            raw_input_dir=Path("raw-data"),
+            pattern="demo*.csv",
+            encoding="cp949",
+            max_files=3,
+            overwrite_preprocess=True,
+            daily_raw_dir=Path("daily-raw"),
+            daily_interpolated_dir=Path("daily-interp"),
+            out_root=Path("runs"),
+            variants="both",
+            loadcells=[1, 4],
+            dates=["2025-01-01.csv"],
+            config_paths=[Path("cfg-a.yaml"), Path("cfg-b.yaml")],
+            include_excel=True,
+            log_level="INFO",
+            base_config=Path("base.yaml"),
+            preprocess_raw_folder=fake_preprocess,
+        )
+    finally:
+        load_cell_run_all.workflow.run_workflow = original_run_workflow
+
+    assert preprocess_calls == [
+        {
+            "input_dir": Path("raw-data"),
+            "output_dir": Path("daily-raw"),
+            "pattern": "demo*.csv",
+            "max_files": 3,
+            "overwrite": True,
+            "encoding": "cp949",
+            "interpolate_1s": False,
+        },
+        {
+            "input_dir": Path("raw-data"),
+            "output_dir": Path("daily-interp"),
+            "pattern": "demo*.csv",
+            "max_files": 3,
+            "overwrite": True,
+            "encoding": "cp949",
+            "interpolate_1s": True,
+        },
+    ]
+    assert captures == {
+        "interpolated_dir": Path("daily-interp"),
+        "raw_dir": Path("daily-raw"),
+        "out_root": Path("runs"),
+        "config_paths": [Path("cfg-a.yaml"), Path("cfg-b.yaml")],
+        "variants": "both",
+        "loadcells": [1, 4],
+        "dates": ["2025-01-01.csv"],
+        "include_excel": True,
+        "log_level": "INFO",
+    }
+
+
+def test_run_all_skips_preprocess_and_dispatches_sweep() -> None:
+    captures: dict[str, object] = {}
+
+    def fake_run_sweep(**kwargs: object) -> None:
+        captures.update(kwargs)
+
+    original_run_sweep = load_cell_run_all.sweep.run_sweep
+    load_cell_run_all.sweep.run_sweep = fake_run_sweep
+    try:
+        run_all(
+            raw_input_dir=Path("raw-data"),
+            skip_preprocess=True,
+            daily_raw_dir=Path("daily-raw"),
+            daily_interpolated_dir=Path("daily-interp"),
+            out_root=Path("runs-sweep"),
+            variants="raw",
+            loadcells=[2],
+            dates=["2025-01-02.csv"],
+            include_excel=False,
+            log_level="DEBUG",
+            base_config=Path("base.yaml"),
+            grid_args=["smooth_window_sec=11,14"],
+        )
+    finally:
+        load_cell_run_all.sweep.run_sweep = original_run_sweep
+
+    assert captures == {
+        "out_root": Path("runs-sweep"),
+        "interpolated_dir": Path("daily-interp"),
+        "raw_dir": Path("daily-raw"),
+        "base_config_path": Path("base.yaml"),
+        "grid_args": ["smooth_window_sec=11,14"],
+        "variants": "raw",
+        "loadcells": [2],
+        "dates": ["2025-01-02.csv"],
+        "include_excel": False,
+        "log_level": "DEBUG",
+    }
+
+
+def test_main_parses_cli_and_delegates_to_run_all() -> None:
+    captures: dict[str, object] = {}
+
+    def fake_run_all(**kwargs: object) -> None:
+        captures.update(kwargs)
+
+    original_run_all = load_cell_run_all.run_all
+    load_cell_run_all.run_all = fake_run_all
+    try:
+        result = load_cell_run_all.main(
+            [
+                "--raw-input-dir",
+                "raw",
+                "--pattern",
+                "ALM*.csv",
+                "--encoding",
+                "utf-8",
+                "--max-files",
+                "2",
+                "--overwrite-preprocess",
+                "--daily-raw-dir",
+                "daily-raw",
+                "--daily-interpolated-dir",
+                "daily-interp",
+                "--out-root",
+                "runs",
+                "--variants",
+                "interpolated",
+                "--loadcells",
+                "1",
+                "5",
+                "--dates",
+                "2025-01-03.csv",
+                "--config",
+                "cfg.yaml",
+                "--excel",
+                "--log-level",
+                "INFO",
+                "--base-config",
+                "base.yaml",
+                "--grid",
+                "k_tail=4.0,4.5",
+            ]
+        )
+    finally:
+        load_cell_run_all.run_all = original_run_all
+
+    assert result == 0
+    assert captures == {
+        "raw_input_dir": Path("raw"),
+        "pattern": "ALM*.csv",
+        "encoding": "utf-8",
+        "max_files": 2,
+        "skip_preprocess": False,
+        "overwrite_preprocess": True,
+        "daily_raw_dir": Path("daily-raw"),
+        "daily_interpolated_dir": Path("daily-interp"),
+        "out_root": Path("runs"),
+        "variants": "interpolated",
+        "loadcells": [1, 5],
+        "dates": ["2025-01-03.csv"],
+        "config_paths": [Path("cfg.yaml")],
+        "include_excel": True,
+        "log_level": "INFO",
+        "base_config": Path("base.yaml"),
+        "grid_args": ["k_tail=4.0,4.5"],
+        "preprocess_raw_folder": None,
+    }


### PR DESCRIPTION
## Summary
- migrate the `load-cell-data` end-to-end runner seam into `domains/load_cell/run_all.py`
- preserve package-local parser and orchestration across preprocessing, workflow, and sweep dispatch
- keep raw preprocessing as a lazy or injected dependency until `almemo_preprocess.py` migrates

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #107
