### PR TITLE
[Model Change] Migrate load-cell-data raw preprocessing seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -23,4 +23,5 @@ Current status:
 - Slice 054 migrated: `load-cell-data` workflow seam
 - Slice 055 migrated: `load-cell-data` sweep seam
 - Slice 056 migrated: `load-cell-data` end-to-end runner seam
-- Next blocked seam: `load-cell-data` raw preprocessing seam at `loadcell_pipeline/almemo_preprocess.py`
+- Slice 057 migrated: `load-cell-data` raw ALMEMO preprocessing seam
+- Next blocked seam: `load-cell-data` synthetic validation harness seam at `loadcell_pipeline/synthetic_test.py`

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ poetry run ruff check .
 - `load-cell-data` workflow seam is migrated as slice 054.
 - `load-cell-data` sweep seam is migrated as slice 055.
 - `load-cell-data` end-to-end runner seam is migrated as slice 056.
+- `load-cell-data` raw ALMEMO preprocessing seam is migrated as slice 057.
 
 ## Next validation
-- Audit the `load-cell-data` raw preprocessing seam at `loadcell_pipeline/almemo_preprocess.py`.
+- Audit the `load-cell-data` synthetic validation harness seam at `loadcell_pipeline/synthetic_test.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 056
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 056 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 057
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 057 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -383,3 +383,9 @@ Slice 056:
 - target: `src/stomatal_optimiaztion/domains/load_cell/run_all.py`, package exports, and `tests/test_load_cell_run_all.py`
 - scope: bounded `load-cell-data` end-to-end runner surface covering parser construction plus orchestration across raw preprocessing, workflow dispatch, and sweep dispatch
 - excluded: `loadcell_pipeline/almemo_preprocess.py`, raw ALMEMO parsing internals, and dashboard entrypoints
+
+Slice 057:
+- source: `load-cell-data/loadcell_pipeline/almemo_preprocess.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/almemo_preprocess.py`, package exports, `tests/test_load_cell_almemo_preprocess.py`, and `tests/test_load_cell_run_all.py`
+- scope: bounded `load-cell-data` raw preprocessing surface covering ALMEMO semicolon-CSV parsing, canonical channel mapping, duplicate merge, optional 1-second interpolation, and per-day CSV writing
+- excluded: `loadcell_pipeline/synthetic_test.py`, synthetic dataset generation, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -492,8 +492,16 @@ The fifty-sixth slice opens the next bounded `load-cell-data` seam:
 - keep raw preprocessing behind a lazy-or-injected dependency instead of widening into `almemo_preprocess.py` in the same slice
 - leave `load-cell-data/loadcell_pipeline/almemo_preprocess.py` blocked as the next seam
 
+## Slice 057: load-cell-data Raw ALMEMO Preprocessing
+
+The fifty-seventh slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/almemo_preprocess.py` into the staged `domains/load_cell` package
+- preserve raw ALMEMO CSV parsing, canonical channel mapping, duplicate-timestamp merge, optional 1-second interpolation, and precision-aware per-day CSV writing
+- reconnect the migrated `run_all` seam to the concrete preprocessing implementation without widening into synthetic validation harnesses in the same slice
+- leave `load-cell-data/loadcell_pipeline/synthetic_test.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first eleven `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first twelve `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/almemo_preprocess.py`
+3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/synthetic_test.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 056 completed and slice 057 planning
+- Current phase: slice 057 completed and slice 058 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` raw preprocessing seam at `loadcell_pipeline/almemo_preprocess.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner package boundary while deciding how raw ALMEMO ingestion should land behind the migrated orchestration seams
+1. audit the `load-cell-data` synthetic validation harness seam at `loadcell_pipeline/synthetic_test.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess package boundary while deciding how synthetic regression coverage should land on the migrated pipeline
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-057-load-cell-almemo-preprocess.md
+++ b/docs/architecture/architecture/module_specs/module-057-load-cell-almemo-preprocess.md
@@ -1,0 +1,37 @@
+# Module Spec 057: load-cell-data Raw ALMEMO Preprocessing
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the raw ALMEMO CSV preprocessing module that normalizes channel columns and writes per-day daily CSVs.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/almemo_preprocess.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/almemo_preprocess.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_almemo_preprocess.py`
+- `tests/test_load_cell_run_all.py`
+
+## Responsibilities
+
+1. preserve raw ALMEMO semicolon-CSV parsing, DATE/TIME recovery, and canonical channel mapping
+2. preserve duplicate-timestamp merge, optional 1-second interpolation, precision-aware CSV writing, and per-day folder preprocessing
+3. reconnect the migrated `run_all` seam to the concrete preprocessing implementation without widening into synthetic validation harnesses
+
+## Non-Goals
+
+- migrate `load-cell-data/loadcell_pipeline/synthetic_test.py`
+- widen into dashboard or plotting surfaces
+- introduce repo-level wrappers beyond the package-local preprocessing seam
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/loadcell_pipeline/synthetic_test.py`

--- a/docs/architecture/executor/issue-057-model-change.md
+++ b/docs/architecture/executor/issue-057-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 056` opened the bounded `load-cell-data` end-to-end runner seam, so the next staged helper surface is the raw ALMEMO preprocessing module at `loadcell_pipeline/almemo_preprocess.py`.
+- The migrated repo now has a lazy preprocessing hook in `run_all`, but it still lacks the concrete raw CSV reader, channel standardizer, duplicate-timestamp merge, and optional 1-second interpolation seam.
+- This slice should stay preprocessing-bounded: raw ALMEMO ingestion, canonical column mapping, precision-preserving CSV writing, and CLI wiring only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell preprocessing tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for raw header parsing, canonical channel mapping, duplicate-timestamp merge, interpolation behavior, folder preprocessing, and CLI output
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/almemo_preprocess.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/run_all.py`

--- a/docs/architecture/executor/pr-109-load-cell-almemo-preprocess.md
+++ b/docs/architecture/executor/pr-109-load-cell-almemo-preprocess.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the `load-cell-data` raw ALMEMO preprocessing seam into `domains/load_cell/almemo_preprocess.py`
+- preserve raw CSV parsing, canonical channel mapping, duplicate merge, optional 1-second interpolation, and package-local CLI wiring
+- reconnect the migrated `run_all` seam to the concrete preprocessing implementation and keep the next remaining seam at `synthetic_test.py`
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #109

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed end-to-end runner seam | raw ALMEMO preprocessing still remains unmigrated, so the package boundary is explicit but not yet closed end to end | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed raw preprocessing seam | the synthetic validation harness still remains unmigrated, so the package boundary is functionally closed but its legacy end-to-end regression surface is not yet staged | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -1,3 +1,14 @@
+from stomatal_optimiaztion.domains.load_cell.almemo_preprocess import (
+    CANONICAL_COLUMNS,
+    build_parser as build_almemo_preprocess_parser,
+    format_df_with_precision,
+    main as almemo_preprocess_main,
+    merge_duplicate_timestamps,
+    preprocess_raw_folder,
+    read_almemo_raw_csv,
+    resample_and_interpolate_1s,
+    standardize_almemo_columns,
+)
 from stomatal_optimiaztion.domains.load_cell.aggregation import (
     daily_summary,
     resample_flux_timeseries,
@@ -46,17 +57,25 @@ from stomatal_optimiaztion.domains.load_cell.run_all import (
 
 __all__ = [
     "auto_detect_step_thresholds",
+    "almemo_preprocess_main",
     "build_parser",
+    "build_almemo_preprocess_parser",
+    "CANONICAL_COLUMNS",
     "compute_fluxes_per_second",
     "config_signature",
     "daily_summary",
     "detect_and_correct_outliers",
+    "format_df_with_precision",
     "group_events",
     "main",
+    "merge_duplicate_timestamps",
     "PipelineConfig",
     "label_points_by_derivative",
     "label_points_by_derivative_hysteresis",
     "resample_flux_timeseries",
+    "preprocess_raw_folder",
+    "read_almemo_raw_csv",
+    "resample_and_interpolate_1s",
     "load_config",
     "merge_close_events",
     "merge_close_events_with_df",
@@ -66,6 +85,7 @@ __all__ = [
     "run_sweep",
     "run_workflow",
     "smooth_weight",
+    "standardize_almemo_columns",
     "write_multi_resolution_results",
     "write_results",
 ]

--- a/src/stomatal_optimiaztion/domains/load_cell/almemo_preprocess.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/almemo_preprocess.py
@@ -1,0 +1,451 @@
+"""ALMEMO 500 raw CSV preprocessing."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+CANONICAL_COLUMNS: list[str] = [
+    "loadcell_1_kg",
+    "loadcell_2_kg",
+    "loadcell_3_kg",
+    "loadcell_4_kg",
+    "loadcell_5_kg",
+    "loadcell_6_kg",
+    "air_temp_c",
+    "air_rh_percent",
+    "dewpoint_c",
+    "air_pressure_mb",
+    "ec_1_ds",
+    "moisture_1_percent",
+    "ec_2_ds",
+    "moisture_2_percent",
+    "ec_3_ds",
+    "moisture_3_percent",
+    "ec_4_ds",
+    "moisture_4_percent",
+    "ec_5_ds",
+    "moisture_5_percent",
+    "ec_6_ds",
+    "moisture_6_percent",
+    "weather_temp_c",
+    "wind_speed_m_s",
+    "weather_pressure_mb",
+    "tensiometer_4_hp",
+    "tensiometer_5_hp",
+]
+
+RAW_PREFIX_BY_CANONICAL: dict[str, str] = {
+    "loadcell_1_kg": "M000.0",
+    "loadcell_2_kg": "M001.0",
+    "loadcell_3_kg": "M002.0",
+    "loadcell_4_kg": "M003.0",
+    "loadcell_5_kg": "M004.0",
+    "loadcell_6_kg": "M005.0",
+    "air_temp_c": "M006.0",
+    "air_rh_percent": "M006.1",
+    "dewpoint_c": "M006.2",
+    "air_pressure_mb": "M006.3",
+    "ec_1_ds": "M010.0",
+    "moisture_1_percent": "M010.1",
+    "ec_2_ds": "M011.0",
+    "moisture_2_percent": "M011.1",
+    "ec_3_ds": "M012.0",
+    "moisture_3_percent": "M012.1",
+    "ec_4_ds": "M013.0",
+    "moisture_4_percent": "M013.1",
+    "ec_5_ds": "M014.0",
+    "moisture_5_percent": "M014.1",
+    "ec_6_ds": "M015.0",
+    "moisture_6_percent": "M015.1",
+    "weather_temp_c": "M016.0",
+    "wind_speed_m_s": "M016.1",
+    "weather_pressure_mb": "M016.2",
+    "tensiometer_4_hp": "M017.0",
+    "tensiometer_5_hp": "M018.0",
+}
+
+
+def _infer_max_decimals_from_raw_strings(series: pd.Series) -> int:
+    """Infer the maximum number of decimal places used in raw string values."""
+
+    if series.empty:
+        return 0
+
+    max_decimals = 0
+    for value in series.astype(str):
+        text = value.strip()
+        if not text or text.lower() == "nan" or "." not in text:
+            continue
+        decimal_part = text.split(".", 1)[1]
+        match = re.match(r"(\d+)", decimal_part)
+        if not match:
+            continue
+        max_decimals = max(max_decimals, len(match.group(1)))
+    return int(max_decimals)
+
+
+def _update_precision_map_from_raw(
+    df_raw: pd.DataFrame,
+    precision_map: dict[str, int],
+) -> None:
+    """Update per-column decimal precision from a raw ALMEMO frame."""
+
+    columns = [str(column) for column in df_raw.columns]
+    for canonical, prefix in RAW_PREFIX_BY_CANONICAL.items():
+        raw_col = _match_col(columns, prefix)
+        if raw_col is None or raw_col not in df_raw.columns:
+            continue
+        precision_map[canonical] = max(
+            int(precision_map.get(canonical, 0)),
+            _infer_max_decimals_from_raw_strings(df_raw[raw_col]),
+        )
+
+
+def _format_float_value(value: float, decimals: int) -> str:
+    if pd.isna(value):
+        return ""
+    number = float(value)
+    if decimals <= 0:
+        text = f"{number:.0f}"
+    else:
+        text = f"{number:.{decimals}f}".rstrip("0").rstrip(".")
+    return "0" if text == "-0" else text
+
+
+def format_df_with_precision(df: pd.DataFrame, precision_map: dict[str, int]) -> pd.DataFrame:
+    """Format numeric columns as strings using raw-data precision."""
+
+    if df.empty:
+        return df
+
+    formatted = df.copy()
+    for column in formatted.columns:
+        if column not in precision_map:
+            continue
+        decimals = int(precision_map.get(column, 0))
+        formatted[column] = formatted[column].map(
+            lambda value, dec=decimals: _format_float_value(value, dec)
+        )
+    return formatted
+
+
+def _sort_key_almemo_file(path: Path) -> tuple[int, str]:
+    """Sort ALMEMO files numerically by the ``~N`` suffix."""
+
+    stem = path.stem
+    number = -1
+    if "~" in stem:
+        tail = stem.split("~", 1)[1]
+        try:
+            number = int(tail)
+        except ValueError:
+            number = -1
+    return (number, path.name)
+
+
+def _match_col(columns: Iterable[str], prefix: str) -> str | None:
+    """Return the first column name whose string value starts with ``prefix``."""
+
+    for column in columns:
+        column_text = str(column)
+        if column_text.startswith(prefix):
+            return column_text
+    return None
+
+
+def _find_col_like(columns: Iterable[str], startswith: str) -> str | None:
+    for column in columns:
+        column_text = str(column)
+        if column_text.startswith(startswith):
+            return column_text
+    return None
+
+
+def _find_date_time_columns(columns: Iterable[str]) -> tuple[str, str]:
+    columns_list = [str(column) for column in columns]
+    date_col = "DATE:" if "DATE:" in columns_list else _find_col_like(columns_list, "DATE")
+    time_col = "TIME:" if "TIME:" in columns_list else _find_col_like(columns_list, "TIME")
+    if not date_col or not time_col:
+        raise KeyError(
+            "Could not find DATE/TIME columns. Available columns: "
+            + ", ".join(columns_list[:20]),
+        )
+    return date_col, time_col
+
+
+def read_almemo_raw_csv(path: Path, encoding: str = "latin1") -> pd.DataFrame:
+    """Read a raw ALMEMO CSV export into a DataFrame indexed by timestamp."""
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Input CSV not found: {path}")
+
+    header: list[str] | None = None
+    rows: list[list[str]] = []
+
+    with path.open("r", encoding=encoding, errors="replace", newline="") as handle:
+        reader = csv.reader(handle, delimiter=";", quotechar='"')
+        for row in reader:
+            if not row:
+                continue
+            row = [cell.strip() for cell in row]
+
+            if header is None:
+                if len(row) >= 2 and row[0].startswith("DATE") and row[1].startswith("TIME"):
+                    header = row
+                continue
+
+            if all(cell == "" for cell in row):
+                continue
+
+            if len(row) < len(header):
+                row = row + [""] * (len(header) - len(row))
+            elif len(row) > len(header):
+                row = row[: len(header)]
+
+            rows.append(row)
+
+    if header is None:
+        raise ValueError(f"No ALMEMO header row (DATE/TIME) found in file: {path.name}")
+
+    if not rows:
+        return pd.DataFrame(index=pd.DatetimeIndex([], name="timestamp"))
+
+    df = pd.DataFrame(rows, columns=header)
+    date_col, time_col = _find_date_time_columns(df.columns)
+    df[date_col] = df[date_col].replace("", pd.NA).ffill()
+    df[time_col] = df[time_col].replace("", pd.NA)
+
+    dt_text = df[date_col].astype(str).str.strip() + " " + df[time_col].astype(str).str.strip()
+    timestamp = pd.to_datetime(
+        dt_text,
+        format="%d.%m.%y %H:%M:%S.%f",
+        errors="coerce",
+    )
+
+    df.insert(0, "timestamp", timestamp)
+    df = df.dropna(subset=["timestamp"]).set_index("timestamp").sort_index()
+    df.index = pd.DatetimeIndex(df.index, freq=None, name="timestamp")
+    return df
+
+
+def standardize_almemo_columns(df_raw: pd.DataFrame) -> pd.DataFrame:
+    """Map raw ALMEMO channel columns into the standardized 27-column schema."""
+
+    if df_raw.empty:
+        return pd.DataFrame(index=df_raw.index, columns=CANONICAL_COLUMNS, dtype=float)
+
+    columns = [str(column) for column in df_raw.columns]
+
+    def numeric_series(prefix: str) -> pd.Series | None:
+        raw_col = _match_col(columns, prefix)
+        if raw_col is None or raw_col not in df_raw.columns:
+            return None
+        return pd.to_numeric(df_raw[raw_col], errors="coerce")
+
+    standardized = pd.DataFrame(index=df_raw.index)
+
+    mapping_groups = {
+        "loadcell_1_kg": numeric_series("M000.0"),
+        "loadcell_2_kg": numeric_series("M001.0"),
+        "loadcell_3_kg": numeric_series("M002.0"),
+        "loadcell_4_kg": numeric_series("M003.0"),
+        "loadcell_5_kg": numeric_series("M004.0"),
+        "loadcell_6_kg": numeric_series("M005.0"),
+        "air_temp_c": numeric_series("M006.0"),
+        "air_rh_percent": numeric_series("M006.1"),
+        "dewpoint_c": numeric_series("M006.2"),
+        "air_pressure_mb": numeric_series("M006.3"),
+        "ec_1_ds": numeric_series("M010.0"),
+        "moisture_1_percent": numeric_series("M010.1"),
+        "ec_2_ds": numeric_series("M011.0"),
+        "moisture_2_percent": numeric_series("M011.1"),
+        "ec_3_ds": numeric_series("M012.0"),
+        "moisture_3_percent": numeric_series("M012.1"),
+        "ec_4_ds": numeric_series("M013.0"),
+        "moisture_4_percent": numeric_series("M013.1"),
+        "ec_5_ds": numeric_series("M014.0"),
+        "moisture_5_percent": numeric_series("M014.1"),
+        "ec_6_ds": numeric_series("M015.0"),
+        "moisture_6_percent": numeric_series("M015.1"),
+        "weather_temp_c": numeric_series("M016.0"),
+        "wind_speed_m_s": numeric_series("M016.1"),
+        "weather_pressure_mb": numeric_series("M016.2"),
+        "tensiometer_4_hp": numeric_series("M017.0"),
+        "tensiometer_5_hp": numeric_series("M018.0"),
+    }
+
+    for canonical, series in mapping_groups.items():
+        if series is not None:
+            standardized[canonical] = series
+
+    for canonical in CANONICAL_COLUMNS:
+        if canonical not in standardized.columns:
+            standardized[canonical] = np.nan
+
+    return standardized[CANONICAL_COLUMNS].astype(float)
+
+
+def merge_duplicate_timestamps(df: pd.DataFrame) -> pd.DataFrame:
+    """Merge duplicate timestamps by taking the first non-null value per column."""
+
+    if df.empty:
+        return df
+    return df.groupby(df.index).first().sort_index()
+
+
+def resample_and_interpolate_1s(df: pd.DataFrame) -> pd.DataFrame:
+    """Reindex to 1-second frequency and fill gaps using linear interpolation."""
+
+    if df.empty:
+        return df
+
+    start = df.index.min()
+    end = df.index.max()
+    if pd.isna(start) or pd.isna(end):
+        return df
+
+    full_index = pd.date_range(start=start, end=end, freq="1s", name="timestamp")
+    interpolated = df.reindex(full_index)
+    return interpolated.interpolate(method="time", limit_direction="both")
+
+
+def preprocess_raw_folder(
+    input_dir: Path,
+    output_dir: Path,
+    *,
+    pattern: str = "ALMEMO500~*.csv",
+    max_files: int | None = None,
+    overwrite: bool = False,
+    encoding: str = "latin1",
+    interpolate_1s: bool = True,
+) -> list[Path]:
+    """Preprocess all raw ALMEMO files under ``input_dir`` and write per-day CSVs."""
+
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(input_dir.glob(pattern), key=_sort_key_almemo_file)
+    if max_files is not None:
+        files = files[: int(max_files)]
+
+    per_day_parts: dict[pd.Timestamp, list[pd.DataFrame]] = defaultdict(list)
+    precision_map: dict[str, int] = {column: 0 for column in CANONICAL_COLUMNS}
+
+    for path in files:
+        df_raw = read_almemo_raw_csv(path, encoding=encoding)
+        if df_raw.empty:
+            continue
+
+        _update_precision_map_from_raw(df_raw, precision_map)
+        df_standardized = standardize_almemo_columns(df_raw)
+        df_standardized = merge_duplicate_timestamps(df_standardized)
+        if df_standardized.empty:
+            continue
+
+        for day, group in df_standardized.groupby(df_standardized.index.normalize()):
+            per_day_parts[day].append(group)
+
+    written: list[Path] = []
+
+    for day in sorted(per_day_parts.keys()):
+        out_path = output_dir / f"{day.date().isoformat()}.csv"
+        if out_path.exists() and not overwrite:
+            continue
+
+        day_df = pd.concat(per_day_parts[day], axis=0).sort_index()
+        day_df = merge_duplicate_timestamps(day_df)
+        if interpolate_1s:
+            day_df = resample_and_interpolate_1s(day_df)
+
+        formatted = format_df_with_precision(day_df, precision_map)
+        formatted.to_csv(out_path, index_label="timestamp")
+        written.append(out_path)
+
+    return written
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for ALMEMO preprocessing."""
+
+    parser = argparse.ArgumentParser(
+        description="Preprocess ALMEMO500 raw CSVs (merge split rows; optional 1s interpolation).",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path("data/raw"),
+        help="Directory containing raw ALMEMO500~*.csv files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv_interpolated"),
+        help="Directory to write per-day preprocessed CSVs.",
+    )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default="ALMEMO500~*.csv",
+        help="Glob pattern for input files.",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Optional cap on number of files to process (for testing).",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing output CSVs.",
+    )
+    parser.add_argument(
+        "--encoding",
+        type=str,
+        default="latin1",
+        help="Text encoding for raw files (latin1 is safest for ALMEMO exports).",
+    )
+    parser.add_argument(
+        "--no-interpolate",
+        dest="interpolate_1s",
+        action="store_false",
+        help="Do NOT resample/interpolate to 1-second grid (keep original timestamps).",
+    )
+    parser.set_defaults(interpolate_1s=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for command-line execution."""
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    written = preprocess_raw_folder(
+        args.input_dir,
+        args.output_dir,
+        pattern=args.pattern,
+        max_files=args.max_files,
+        overwrite=args.overwrite,
+        encoding=args.encoding,
+        interpolate_1s=args.interpolate_1s,
+    )
+
+    if not written:
+        print("No output files were written.")
+        return 0
+
+    print(f"Wrote {len(written)} file(s) to: {Path(args.output_dir).resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_load_cell_almemo_preprocess.py
+++ b/tests/test_load_cell_almemo_preprocess.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import CANONICAL_COLUMNS
+from stomatal_optimiaztion.domains.load_cell import preprocess_raw_folder
+
+load_cell_almemo_preprocess = importlib.import_module(
+    "stomatal_optimiaztion.domains.load_cell.almemo_preprocess"
+)
+
+
+def _write_raw_file(path: Path, rows: list[str]) -> None:
+    path.write_text("\n".join(rows) + "\n", encoding="latin1")
+
+
+def test_load_cell_import_surface_exposes_almemo_helpers() -> None:
+    assert load_cell.preprocess_raw_folder is preprocess_raw_folder
+    assert load_cell.build_almemo_preprocess_parser is load_cell_almemo_preprocess.build_parser
+
+
+def test_read_almemo_raw_csv_parses_semicolon_export(tmp_path: Path) -> None:
+    raw_path = tmp_path / "ALMEMO500~19.csv"
+    _write_raw_file(
+        raw_path,
+        [
+            "metadata;;;;;;;;",
+            "DATE:;TIME:;M000.0 N;M006.0 C;M006.1 %",
+            "01.01.25;12:00:00.000;10.0;;",
+            ";12:00:00.000;;20.5;60.0",
+            "01.01.25;12:00:02.000;12.5;21.0;61.0",
+        ],
+    )
+
+    df_raw = load_cell_almemo_preprocess.read_almemo_raw_csv(raw_path)
+
+    assert list(df_raw.index.astype(str)) == [
+        "2025-01-01 12:00:00",
+        "2025-01-01 12:00:00",
+        "2025-01-01 12:00:02",
+    ]
+    assert float(df_raw.iloc[0]["M000.0 N"]) == 10.0
+    assert float(df_raw.iloc[1]["M006.0 C"]) == 20.5
+    assert float(df_raw.iloc[1]["M006.1 %"]) == 60.0
+
+
+def test_standardize_almemo_columns_maps_known_channels() -> None:
+    index = pd.DatetimeIndex(["2025-01-01 12:00:00"], name="timestamp")
+    raw = pd.DataFrame(
+        {
+            "M000.0 N": ["10.0"],
+            "M006.0 C": ["22.5"],
+            "M006.1 %": ["70.0"],
+            "M017.0 hP": ["-12.0"],
+        },
+        index=index,
+    )
+
+    standardized = load_cell_almemo_preprocess.standardize_almemo_columns(raw)
+
+    assert list(standardized.columns) == CANONICAL_COLUMNS
+    assert standardized.loc[index[0], "loadcell_1_kg"] == 10.0
+    assert standardized.loc[index[0], "air_temp_c"] == 22.5
+    assert standardized.loc[index[0], "air_rh_percent"] == 70.0
+    assert standardized.loc[index[0], "tensiometer_4_hp"] == -12.0
+    assert pd.isna(standardized.loc[index[0], "loadcell_2_kg"])
+
+
+def test_merge_duplicate_timestamps_uses_first_non_null_values() -> None:
+    index = pd.DatetimeIndex(
+        ["2025-01-01 12:00:00", "2025-01-01 12:00:00"],
+        name="timestamp",
+    )
+    df = pd.DataFrame(
+        {
+            "loadcell_1_kg": [10.0, None],
+            "air_temp_c": [None, 23.0],
+        },
+        index=index,
+    )
+
+    merged = load_cell_almemo_preprocess.merge_duplicate_timestamps(df)
+
+    assert merged.shape == (1, 2)
+    assert merged.iloc[0]["loadcell_1_kg"] == 10.0
+    assert merged.iloc[0]["air_temp_c"] == 23.0
+
+
+def test_resample_and_interpolate_1s_fills_missing_seconds() -> None:
+    index = pd.DatetimeIndex(
+        ["2025-01-01 12:00:00", "2025-01-01 12:00:02"],
+        name="timestamp",
+    )
+    df = pd.DataFrame({"loadcell_1_kg": [10.0, 12.0]}, index=index)
+
+    interpolated = load_cell_almemo_preprocess.resample_and_interpolate_1s(df)
+
+    assert list(interpolated.index.astype(str)) == [
+        "2025-01-01 12:00:00",
+        "2025-01-01 12:00:01",
+        "2025-01-01 12:00:02",
+    ]
+    assert interpolated.iloc[1]["loadcell_1_kg"] == 11.0
+
+
+def test_preprocess_raw_folder_writes_interpolated_daily_csv(tmp_path: Path) -> None:
+    input_dir = tmp_path / "raw"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    _write_raw_file(
+        input_dir / "ALMEMO500~2.csv",
+        [
+            "metadata;;;;;;;;",
+            "DATE:;TIME:;M000.0 N;M006.0 C;M006.1 %",
+            "01.01.25;12:00:00.000;10.0;;",
+            ";12:00:00.000;;20.0;60.0",
+            "01.01.25;12:00:02.000;12.0;22.0;64.0",
+        ],
+    )
+
+    written = load_cell_almemo_preprocess.preprocess_raw_folder(
+        input_dir,
+        output_dir,
+        interpolate_1s=True,
+    )
+
+    assert written == [output_dir / "2025-01-01.csv"]
+    out_df = pd.read_csv(written[0])
+    assert list(out_df["timestamp"]) == [
+        "2025-01-01 12:00:00",
+        "2025-01-01 12:00:01",
+        "2025-01-01 12:00:02",
+    ]
+    assert list(out_df["loadcell_1_kg"]) == [10.0, 11.0, 12.0]
+    assert list(out_df["air_temp_c"]) == [20.0, 21.0, 22.0]
+    assert list(out_df["air_rh_percent"]) == [60.0, 62.0, 64.0]
+
+
+def test_main_parses_cli_and_prints_summary(tmp_path: Path, capsys) -> None:
+    input_dir = tmp_path / "raw"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    _write_raw_file(
+        input_dir / "ALMEMO500~1.csv",
+        [
+            "metadata;;;;;;;;",
+            "DATE:;TIME:;M000.0 N",
+            "01.01.25;12:00:00.000;10.0",
+        ],
+    )
+
+    result = load_cell_almemo_preprocess.main(
+        [
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--no-interpolate",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Wrote 1 file(s) to:" in captured.out
+    assert (output_dir / "2025-01-01.csv").exists()

--- a/tests/test_load_cell_run_all.py
+++ b/tests/test_load_cell_run_all.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
-import pytest
-
 from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import almemo_preprocess
 from stomatal_optimiaztion.domains.load_cell import run_all
 
 load_cell_run_all = importlib.import_module("stomatal_optimiaztion.domains.load_cell.run_all")
@@ -13,11 +12,52 @@ load_cell_run_all = importlib.import_module("stomatal_optimiaztion.domains.load_
 
 def test_load_cell_import_surface_exposes_run_all_helper() -> None:
     assert load_cell.run_all is run_all
+    assert load_cell.preprocess_raw_folder is almemo_preprocess.preprocess_raw_folder
 
 
-def test_run_all_raises_when_preprocess_is_required_but_missing() -> None:
-    with pytest.raises(RuntimeError, match="skip_preprocess=True|inject preprocess_raw_folder"):
-        run_all(raw_input_dir=Path("raw"))
+def test_run_all_resolves_package_preprocess_by_default() -> None:
+    preprocess_calls: list[dict[str, object]] = []
+    captures: dict[str, object] = {}
+
+    def fake_preprocess(
+        input_dir: Path,
+        output_dir: Path,
+        *,
+        pattern: str,
+        max_files: int | None,
+        overwrite: bool,
+        encoding: str,
+        interpolate_1s: bool,
+    ) -> list[Path]:
+        preprocess_calls.append(
+            {
+                "input_dir": input_dir,
+                "output_dir": output_dir,
+                "pattern": pattern,
+                "max_files": max_files,
+                "overwrite": overwrite,
+                "encoding": encoding,
+                "interpolate_1s": interpolate_1s,
+            }
+        )
+        return []
+
+    def fake_run_workflow(**kwargs: object) -> None:
+        captures.update(kwargs)
+
+    original_preprocess = almemo_preprocess.preprocess_raw_folder
+    original_run_workflow = load_cell_run_all.workflow.run_workflow
+    almemo_preprocess.preprocess_raw_folder = fake_preprocess
+    load_cell_run_all.workflow.run_workflow = fake_run_workflow
+    try:
+        run_all(raw_input_dir=Path("raw-data"))
+    finally:
+        almemo_preprocess.preprocess_raw_folder = original_preprocess
+        load_cell_run_all.workflow.run_workflow = original_run_workflow
+
+    assert [call["interpolate_1s"] for call in preprocess_calls] == [False, True]
+    assert captures["raw_dir"] == Path("data/preprocessed_csv")
+    assert captures["interpolated_dir"] == Path("data/preprocessed_csv_interpolated")
 
 
 def test_run_all_preprocesses_then_dispatches_workflow() -> None:


### PR DESCRIPTION
## Summary
- migrate the `load-cell-data` raw ALMEMO preprocessing seam into `domains/load_cell/almemo_preprocess.py`
- preserve raw CSV parsing, canonical channel mapping, duplicate merge, optional 1-second interpolation, and package-local CLI wiring
- reconnect the migrated `run_all` seam to the concrete preprocessing implementation and keep the next remaining seam at `synthetic_test.py`

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #109
