### PR TITLE
[Model Change] Migrate load-cell-data synthetic validation harness seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -24,4 +24,5 @@ Current status:
 - Slice 055 migrated: `load-cell-data` sweep seam
 - Slice 056 migrated: `load-cell-data` end-to-end runner seam
 - Slice 057 migrated: `load-cell-data` raw ALMEMO preprocessing seam
-- Next blocked seam: `load-cell-data` synthetic validation harness seam at `loadcell_pipeline/synthetic_test.py`
+- Slice 058 migrated: `load-cell-data` synthetic validation harness seam
+- Next blocked seam: `load-cell-data` real-data benchmark harness seam at `real_data_benchmark.py`

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ poetry run ruff check .
 - `load-cell-data` sweep seam is migrated as slice 055.
 - `load-cell-data` end-to-end runner seam is migrated as slice 056.
 - `load-cell-data` raw ALMEMO preprocessing seam is migrated as slice 057.
+- `load-cell-data` synthetic validation harness seam is migrated as slice 058.
 
 ## Next validation
-- Audit the `load-cell-data` synthetic validation harness seam at `loadcell_pipeline/synthetic_test.py`.
+- Audit the `load-cell-data` real-data benchmark harness seam at `real_data_benchmark.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 057
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 057 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 058
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 058 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -389,3 +389,9 @@ Slice 057:
 - target: `src/stomatal_optimiaztion/domains/load_cell/almemo_preprocess.py`, package exports, `tests/test_load_cell_almemo_preprocess.py`, and `tests/test_load_cell_run_all.py`
 - scope: bounded `load-cell-data` raw preprocessing surface covering ALMEMO semicolon-CSV parsing, canonical channel mapping, duplicate merge, optional 1-second interpolation, and per-day CSV writing
 - excluded: `loadcell_pipeline/synthetic_test.py`, synthetic dataset generation, and dashboard entrypoints
+
+Slice 058:
+- source: `load-cell-data/loadcell_pipeline/synthetic_test.py`
+- target: `src/stomatal_optimiaztion/domains/load_cell/synthetic_test.py`, package exports, and `tests/test_load_cell_synthetic_test.py`
+- scope: bounded `load-cell-data` synthetic validation harness covering deterministic dataset generation, truth totals, end-to-end pipeline validation, and tolerance checks
+- excluded: `real_data_benchmark.py`, dashboard entrypoints, and viewer/reporting artifacts

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -500,8 +500,16 @@ The fifty-seventh slice opens the next bounded `load-cell-data` seam:
 - reconnect the migrated `run_all` seam to the concrete preprocessing implementation without widening into synthetic validation harnesses in the same slice
 - leave `load-cell-data/loadcell_pipeline/synthetic_test.py` blocked as the next seam
 
+## Slice 058: load-cell-data Synthetic Validation Harness
+
+The fifty-eighth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/loadcell_pipeline/synthetic_test.py` into the staged `domains/load_cell` package
+- preserve deterministic synthetic dataset generation, truth totals, and end-to-end tolerance checks over the migrated `run_pipeline()` surface
+- keep the seam validation-harness-bounded without widening into repo-level real-data benchmarks in the same slice
+- leave `load-cell-data/real_data_benchmark.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first twelve `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first thirteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `loadcell_pipeline/synthetic_test.py`
+3. prepare the next `load-cell-data` source audit for `real_data_benchmark.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 057 completed and slice 058 planning
+- Current phase: slice 058 completed and slice 059 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` synthetic validation harness seam at `loadcell_pipeline/synthetic_test.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess package boundary while deciding how synthetic regression coverage should land on the migrated pipeline
+1. audit the `load-cell-data` real-data benchmark harness seam at `real_data_benchmark.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess-plus-synthetic-harness boundary while deciding how real-data batch benchmarking should land on the migrated pipeline
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-058-load-cell-synthetic-validation-harness.md
+++ b/docs/architecture/architecture/module_specs/module-058-load-cell-synthetic-validation-harness.md
@@ -1,0 +1,36 @@
+# Module Spec 058: load-cell-data Synthetic Validation Harness
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the synthetic dataset generator and end-to-end validation harness that exercises the migrated pipeline without external greenhouse files.
+
+## Source Inputs
+
+- `load-cell-data/loadcell_pipeline/synthetic_test.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/load_cell/synthetic_test.py`
+- `src/stomatal_optimiaztion/domains/load_cell/__init__.py`
+- `tests/test_load_cell_synthetic_test.py`
+
+## Responsibilities
+
+1. preserve deterministic synthetic dataset generation and ground-truth irrigation, drainage, and transpiration totals
+2. preserve full-pipeline execution via `run_pipeline()` plus tolerance-based validation of estimates and water-balance bias
+3. keep the seam validation-harness-bounded without widening into repo-level real-data benchmarks or dashboard surfaces
+
+## Non-Goals
+
+- migrate `load-cell-data/real_data_benchmark.py`
+- widen into dashboard or viewer artifacts
+- introduce new physics or pipeline behavior beyond the legacy synthetic harness
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/real_data_benchmark.py`

--- a/docs/architecture/executor/issue-058-model-change.md
+++ b/docs/architecture/executor/issue-058-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 057` migrated the raw ALMEMO preprocessing seam, so the next remaining bounded `load-cell-data` surface inside `loadcell_pipeline/` is the synthetic validation harness at `synthetic_test.py`.
+- The migrated repo now has the full processing pipeline, but it still lacks the legacy synthetic dataset generator and end-to-end mass-balance validation helper that exercises the pipeline without external files.
+- This slice should stay validation-harness-bounded: synthetic timeseries generation, pipeline execution against `run_pipeline`, tolerance checks, and package-local export only.
+
+## Affected model
+- `load-cell-data`
+- `src/stomatal_optimiaztion/domains/load_cell/`
+- related load-cell synthetic harness tests and package exports
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for deterministic synthetic dataset generation, truth totals, end-to-end synthetic pipeline validation, and package import surface
+
+## Comparison target
+- legacy `load-cell-data/loadcell_pipeline/synthetic_test.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/{cli.py,config.py}`

--- a/docs/architecture/executor/pr-111-load-cell-synthetic-validation-harness.md
+++ b/docs/architecture/executor/pr-111-load-cell-synthetic-validation-harness.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the `load-cell-data` synthetic validation harness seam into `domains/load_cell/synthetic_test.py`
+- preserve deterministic synthetic dataset generation, truth totals, and end-to-end tolerance checks over the migrated pipeline
+- mark the next remaining `load-cell-data` seam at the repo-level real-data benchmark harness
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #111

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed raw preprocessing seam | the synthetic validation harness still remains unmigrated, so the package boundary is functionally closed but its legacy end-to-end regression surface is not yet staged | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed synthetic validation harness seam | the repo-level real-data benchmark surface still remains unmigrated, so the domain has bounded package coverage but not yet its legacy batch benchmark harness | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/load_cell/__init__.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/__init__.py
@@ -47,6 +47,11 @@ from stomatal_optimiaztion.domains.load_cell.thresholds import (
 from stomatal_optimiaztion.domains.load_cell.sweep import (
     run_sweep,
 )
+from stomatal_optimiaztion.domains.load_cell.synthetic_test import (
+    generate_synthetic_dataset,
+    main as synthetic_test_main,
+    run_synthetic_pipeline,
+)
 from stomatal_optimiaztion.domains.load_cell.workflow import (
     config_signature,
     run_workflow,
@@ -70,6 +75,7 @@ __all__ = [
     "main",
     "merge_duplicate_timestamps",
     "PipelineConfig",
+    "generate_synthetic_dataset",
     "label_points_by_derivative",
     "label_points_by_derivative_hysteresis",
     "resample_flux_timeseries",
@@ -83,9 +89,11 @@ __all__ = [
     "run_all",
     "run_pipeline",
     "run_sweep",
+    "run_synthetic_pipeline",
     "run_workflow",
     "smooth_weight",
     "standardize_almemo_columns",
+    "synthetic_test_main",
     "write_multi_resolution_results",
     "write_results",
 ]

--- a/src/stomatal_optimiaztion/domains/load_cell/synthetic_test.py
+++ b/src/stomatal_optimiaztion/domains/load_cell/synthetic_test.py
@@ -1,0 +1,131 @@
+"""Synthetic validation harness for the load-cell processing pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .cli import run_pipeline
+from .config import PipelineConfig
+
+
+def generate_synthetic_dataset(
+    duration_hours: float = 6.0,
+    base_weight_kg: float = 100.0,
+    transpiration_rate_kg_s: float = 1e-4,
+    noise_std: float = 0.01,
+) -> tuple[pd.DataFrame, dict[str, float]]:
+    """Create a synthetic 1-second weight series with irrigation and drainage pulses."""
+
+    total_seconds = int(duration_hours * 3600)
+    time_index = pd.date_range("2024-07-01 06:00:00", periods=total_seconds, freq="1s")
+    flux = np.full(total_seconds, -transpiration_rate_kg_s, dtype=float)
+
+    irrigation_pulses = [
+        (900, 5, 0.12),
+        (3600, 6, 0.15),
+        (5400, 5, 0.12),
+    ]
+    drainage_pulses = [
+        (900 + 120, 120, 0.01),
+        (3600 + 180, 150, 0.012),
+        (5400 + 150, 120, 0.011),
+    ]
+
+    total_irrigation = 0.0
+    total_drainage = 0.0
+    for start, duration, rate in irrigation_pulses:
+        flux[start : start + duration] += rate
+        total_irrigation += rate * duration
+    for start, duration, rate in drainage_pulses:
+        flux[start : start + duration] -= rate
+        total_drainage += rate * duration
+
+    weight = np.empty(total_seconds)
+    weight[0] = base_weight_kg
+    for idx in range(1, total_seconds):
+        weight[idx] = weight[idx - 1] + flux[idx - 1]
+
+    rng = np.random.default_rng(42)
+    noisy_weight = weight + rng.normal(0.0, noise_std, size=total_seconds)
+
+    df = pd.DataFrame({"timestamp": time_index, "weight_kg": noisy_weight})
+    truth = {
+        "irrigation_kg": total_irrigation,
+        "drainage_kg": total_drainage,
+        "transpiration_kg": transpiration_rate_kg_s * (total_seconds - 1),
+    }
+    return df, truth
+
+
+def run_synthetic_pipeline(tmp_path: Path) -> dict[str, dict[str, float]]:
+    """Execute the full pipeline on synthetic data for validation."""
+
+    tmp_path = Path(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    data, truth = generate_synthetic_dataset()
+    input_path = tmp_path / "synthetic_loadcell.csv"
+    data.to_csv(input_path, index=False)
+
+    cfg = PipelineConfig(
+        input_path=input_path,
+        output_path=tmp_path / "synthetic_results.csv",
+        smooth_method="ma",
+        smooth_window_sec=14,
+        poly_order=2,
+        merge_irrigation_gap_sec=60,
+    )
+
+    processed_df, _events_df, metadata = run_pipeline(
+        cfg,
+        include_excel=False,
+        write_output=False,
+    )
+
+    estimates = {
+        "irrigation_kg": float(processed_df["cum_irrigation_kg"].iloc[-1]),
+        "drainage_kg": float(processed_df["cum_drainage_kg"].iloc[-1]),
+        "transpiration_kg": float(processed_df["cum_transpiration_kg"].iloc[-1]),
+    }
+    errors = {key: estimates[key] - truth[key] for key in truth}
+
+    tolerances = {
+        "irrigation_kg": 0.05,
+        "drainage_kg": 0.05,
+        "transpiration_kg": 0.02,
+    }
+    for key, tolerance in tolerances.items():
+        if abs(errors[key]) > tolerance:
+            raise AssertionError(
+                f"{key} estimate deviates by {errors[key]:.4f} kg "
+                f"(tolerance {tolerance} kg)."
+            )
+
+    final_balance = metadata["stats"]["final_balance_error_kg"]
+    if abs(final_balance) > 0.05:
+        raise AssertionError(f"Water balance bias too high: {final_balance:.4f} kg")
+
+    print("Synthetic test passed.")
+    print("Truth:", truth)
+    print("Estimates:", estimates)
+    print("Errors:", errors)
+
+    return {
+        "truth": truth,
+        "estimates": estimates,
+        "errors": errors,
+    }
+
+
+def main(output_dir: Path | str = Path("./synthetic_output")) -> int:
+    """Run the synthetic validation harness with the legacy default output dir."""
+
+    run_synthetic_pipeline(Path(output_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_load_cell_synthetic_test.py
+++ b/tests/test_load_cell_synthetic_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from stomatal_optimiaztion.domains import load_cell
+from stomatal_optimiaztion.domains.load_cell import generate_synthetic_dataset
+from stomatal_optimiaztion.domains.load_cell import run_synthetic_pipeline
+
+load_cell_synthetic_test = importlib.import_module(
+    "stomatal_optimiaztion.domains.load_cell.synthetic_test"
+)
+
+
+def test_load_cell_import_surface_exposes_synthetic_harness() -> None:
+    assert load_cell.generate_synthetic_dataset is generate_synthetic_dataset
+    assert load_cell.run_synthetic_pipeline is run_synthetic_pipeline
+    assert load_cell.synthetic_test_main is load_cell_synthetic_test.main
+
+
+def test_generate_synthetic_dataset_is_deterministic() -> None:
+    first_df, first_truth = load_cell_synthetic_test.generate_synthetic_dataset()
+    second_df, second_truth = load_cell_synthetic_test.generate_synthetic_dataset()
+
+    assert first_truth == {
+        "irrigation_kg": 2.1,
+        "drainage_kg": 4.32,
+        "transpiration_kg": 2.1599,
+    }
+    assert first_df.equals(second_df)
+    assert first_truth == second_truth
+    assert list(first_df.columns) == ["timestamp", "weight_kg"]
+    assert len(first_df) == 21600
+
+
+def test_run_synthetic_pipeline_returns_small_errors(tmp_path: Path, capsys) -> None:
+    result = load_cell_synthetic_test.run_synthetic_pipeline(tmp_path / "synthetic")
+
+    captured = capsys.readouterr()
+    assert "Synthetic test passed." in captured.out
+    assert set(result) == {"truth", "estimates", "errors"}
+    assert abs(result["errors"]["irrigation_kg"]) <= 0.05
+    assert abs(result["errors"]["drainage_kg"]) <= 0.05
+    assert abs(result["errors"]["transpiration_kg"]) <= 0.02
+    assert (tmp_path / "synthetic" / "synthetic_loadcell.csv").exists()
+
+
+def test_main_runs_with_legacy_default_style_output_dir(tmp_path: Path) -> None:
+    result = load_cell_synthetic_test.main(tmp_path / "synthetic-output")
+
+    assert result == 0
+    assert (tmp_path / "synthetic-output" / "synthetic_loadcell.csv").exists()


### PR DESCRIPTION
## Summary
- migrate the `load-cell-data` synthetic validation harness seam into `domains/load_cell/synthetic_test.py`
- preserve deterministic synthetic dataset generation, truth totals, and end-to-end tolerance checks over the migrated pipeline
- mark the next remaining `load-cell-data` seam at the repo-level real-data benchmark harness

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #111
