### PR TITLE
[Model Change] Migrate load-cell-data real-data benchmark harness seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -25,4 +25,5 @@ Current status:
 - Slice 056 migrated: `load-cell-data` end-to-end runner seam
 - Slice 057 migrated: `load-cell-data` raw ALMEMO preprocessing seam
 - Slice 058 migrated: `load-cell-data` synthetic validation harness seam
-- Next blocked seam: `load-cell-data` real-data benchmark harness seam at `real_data_benchmark.py`
+- Slice 059 migrated: `load-cell-data` real-data benchmark harness seam
+- Next blocked seam: `load-cell-data` preprocess-compare incremental tooling seam at `src/preprocess_incremental.py`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ poetry run ruff check .
 - `load-cell-data` end-to-end runner seam is migrated as slice 056.
 - `load-cell-data` raw ALMEMO preprocessing seam is migrated as slice 057.
 - `load-cell-data` synthetic validation harness seam is migrated as slice 058.
+- `load-cell-data` real-data benchmark harness seam is migrated as slice 059.
 
 ## Next validation
-- Audit the `load-cell-data` real-data benchmark harness seam at `real_data_benchmark.py`.
+- Audit the `load-cell-data` preprocess-compare incremental tooling seam at `src/preprocess_incremental.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 058
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 058 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 059
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 059 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -395,3 +395,9 @@ Slice 058:
 - target: `src/stomatal_optimiaztion/domains/load_cell/synthetic_test.py`, package exports, and `tests/test_load_cell_synthetic_test.py`
 - scope: bounded `load-cell-data` synthetic validation harness covering deterministic dataset generation, truth totals, end-to-end pipeline validation, and tolerance checks
 - excluded: `real_data_benchmark.py`, dashboard entrypoints, and viewer/reporting artifacts
+
+Slice 059:
+- source: `load-cell-data/real_data_benchmark.py`
+- target: `scripts/real_data_benchmark.py` and `tests/test_load_cell_real_data_benchmark_script.py`
+- scope: bounded `load-cell-data` repo-level benchmark harness covering matched-file batch runs, summary/comparison/failure CSV outputs, and overlap-window diffs
+- excluded: `src/preprocess_incremental.py`, viewer/server tooling, and dashboard entrypoints

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -508,8 +508,16 @@ The fifty-eighth slice opens the next bounded `load-cell-data` seam:
 - keep the seam validation-harness-bounded without widening into repo-level real-data benchmarks in the same slice
 - leave `load-cell-data/real_data_benchmark.py` blocked as the next seam
 
+## Slice 059: load-cell-data Real-Data Benchmark Harness
+
+The fifty-ninth slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/real_data_benchmark.py` into the repo-local `scripts/` surface
+- preserve batch summary/comparison/failure outputs over matched interpolated and raw daily CSV files
+- keep the seam benchmark-harness-bounded without widening into preprocess-compare viewer/server tooling in the same slice
+- leave `load-cell-data/src/preprocess_incremental.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first thirteen `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first fourteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `real_data_benchmark.py`
+3. prepare the next `load-cell-data` source audit for `src/preprocess_incremental.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 058 completed and slice 059 planning
+- Current phase: slice 059 completed and slice 060 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` real-data benchmark harness seam at `real_data_benchmark.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess-plus-synthetic-harness boundary while deciding how real-data batch benchmarking should land on the migrated pipeline
+1. audit the `load-cell-data` preprocess-compare incremental tooling seam at `src/preprocess_incremental.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess-plus-synthetic-harness-plus-real-benchmark boundary while deciding how compare-viewer preprocessing tooling should land on the migrated pipeline
 3. keep `load-cell-data` blocked until its source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-059-load-cell-real-data-benchmark-harness.md
+++ b/docs/architecture/architecture/module_specs/module-059-load-cell-real-data-benchmark-harness.md
@@ -1,0 +1,35 @@
+# Module Spec 059: load-cell-data Real-Data Benchmark Harness
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the repo-level real-data benchmark harness that compares interpolated and raw daily CSV runs across dates and loadcells.
+
+## Source Inputs
+
+- `load-cell-data/real_data_benchmark.py`
+
+## Target Outputs
+
+- `scripts/real_data_benchmark.py`
+- `tests/test_load_cell_real_data_benchmark_script.py`
+
+## Responsibilities
+
+1. preserve batch orchestration across matched interpolated and raw daily CSV files
+2. preserve summary, comparison, overlap-window comparison, and failure CSV outputs
+3. keep the seam repo-level and benchmark-bounded without widening into preprocess-compare viewer tooling
+
+## Non-Goals
+
+- migrate `load-cell-data/src/preprocess_incremental.py`
+- migrate `load-cell-data/src/preprocess_compare_server.py`
+- migrate `load-cell-data/src/build_preprocess_compare_viewer.py`
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/src/preprocess_incremental.py`

--- a/docs/architecture/executor/issue-059-model-change.md
+++ b/docs/architecture/executor/issue-059-model-change.md
@@ -1,0 +1,18 @@
+## Why
+- `slice 058` migrated the synthetic validation harness seam, so the next remaining bounded `load-cell-data` surface is the repo-level real-data benchmark harness at `real_data_benchmark.py`.
+- The migrated repo now has package-level pipeline coverage, but it still lacks the legacy batch comparison script that benchmarks interpolated versus raw daily CSV outputs across dates and loadcells.
+- This slice should stay benchmark-harness-bounded: batch run orchestration, summary/comparison CSV emission, overlap-window diffs, failure capture, and repo-level CLI wiring only.
+
+## Affected model
+- `load-cell-data`
+- `scripts/`
+- related load-cell real-data benchmark tests and architecture docs
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for no-common-file failure, batch summary output, overlap comparison output, failure capture, and CLI argument dispatch
+
+## Comparison target
+- legacy `load-cell-data/real_data_benchmark.py`
+- current migrated `src/stomatal_optimiaztion/domains/load_cell/{cli.py,config.py,workflow.py}`

--- a/docs/architecture/executor/pr-113-load-cell-real-data-benchmark-harness.md
+++ b/docs/architecture/executor/pr-113-load-cell-real-data-benchmark-harness.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the `load-cell-data` real-data benchmark harness into `scripts/real_data_benchmark.py`
+- preserve batch summary/comparison/failure outputs over the migrated `load_cell` pipeline
+- move the next remaining `load-cell-data` seam to the preprocess-compare incremental tooling
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #113

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed synthetic validation harness seam | the repo-level real-data benchmark surface still remains unmigrated, so the domain has bounded package coverage but not yet its legacy batch benchmark harness | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed real-data benchmark harness seam | preprocess-compare incremental tooling and viewer/server surfaces still remain unmigrated, so the domain has bounded pipeline coverage but not yet its legacy inspection tooling | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/scripts/real_data_benchmark.py
+++ b/scripts/real_data_benchmark.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from stomatal_optimiaztion.domains.load_cell import (  # noqa: E402
+    PipelineConfig,
+    load_config,
+    run_pipeline,
+)
+
+LOADCELL_MAP_RAW: dict[int, str] = {
+    1: "M000.0 N",
+    2: "M001.0 N",
+    3: "M002.0 N",
+    4: "M003.0 Kg",
+    5: "M004.0 Kg",
+    6: "M005.0 Kg",
+}
+
+
+def _safe_tail(df: pd.DataFrame, column: str) -> float:
+    if column not in df.columns or df.empty:
+        return 0.0
+    return float(df[column].iloc[-1])
+
+
+def _summarize_run(
+    df: pd.DataFrame,
+    events_df: pd.DataFrame,
+    metadata: dict[str, Any],
+    *,
+    input_path: Path,
+    weight_column: str,
+    tag: str,
+    loadcell: int,
+    runtime_sec: float,
+) -> dict[str, Any]:
+    stats = metadata.get("stats", {})
+    irrigation_threshold = float(metadata.get("irrigation_threshold", float("nan")))
+    drainage_threshold = float(metadata.get("drainage_threshold", float("nan")))
+
+    merged_events = metadata.get("events_merged", metadata.get("events", events_df))
+    if merged_events is None:
+        merged_events = events_df
+
+    irrigation_events = (
+        merged_events[merged_events["event_type"] == "irrigation"]
+        if isinstance(merged_events, pd.DataFrame) and not merged_events.empty
+        else pd.DataFrame()
+    )
+    drainage_events = (
+        merged_events[merged_events["event_type"] == "drainage"]
+        if isinstance(merged_events, pd.DataFrame) and not merged_events.empty
+        else pd.DataFrame()
+    )
+
+    return {
+        "tag": tag,
+        "file": input_path.name,
+        "path": str(input_path),
+        "loadcell": int(loadcell),
+        "weight_column": weight_column,
+        "n_samples": int(len(df)),
+        "start_time": df.index.min(),
+        "end_time": df.index.max(),
+        "irrigation_threshold": irrigation_threshold,
+        "drainage_threshold": drainage_threshold,
+        "irrigation_event_count": (
+            int(len(irrigation_events)) if not irrigation_events.empty else 0
+        ),
+        "drainage_event_count": int(len(drainage_events)) if not drainage_events.empty else 0,
+        "total_irrigation_kg": _safe_tail(df, "cum_irrigation_kg"),
+        "total_drainage_kg": _safe_tail(df, "cum_drainage_kg"),
+        "total_transpiration_kg": _safe_tail(df, "cum_transpiration_kg"),
+        "final_balance_error_kg": float(stats.get("final_balance_error_kg", 0.0)),
+        "mean_abs_balance_error_kg": (
+            float(df["water_balance_error_kg"].abs().mean())
+            if "water_balance_error_kg" in df.columns
+            else 0.0
+        ),
+        "interpolated_frac": (
+            float(df["is_interpolated"].mean()) if "is_interpolated" in df.columns else 0.0
+        ),
+        "outlier_frac": float(df["is_outlier"].mean()) if "is_outlier" in df.columns else 0.0,
+        "transpiration_scale": (
+            float(df["transpiration_scale"].iloc[-1]) if "transpiration_scale" in df.columns else 1.0
+        ),
+        "runtime_sec": float(runtime_sec),
+    }
+
+
+def _run_one_with_df(
+    input_path: Path,
+    base_cfg: PipelineConfig,
+    *,
+    weight_column: str,
+    tag: str,
+    loadcell: int,
+    logger: logging.Logger,
+) -> tuple[dict[str, Any], pd.DataFrame]:
+    started = time.perf_counter()
+
+    cfg = PipelineConfig(**asdict(base_cfg))
+    cfg.input_path = Path(input_path)
+    cfg.output_path = None
+    cfg.timestamp_column = "timestamp"
+    cfg.weight_column = weight_column
+
+    df, events_df, metadata = run_pipeline(
+        cfg,
+        include_excel=False,
+        write_output=False,
+        logger=logger,
+    )
+    runtime_sec = time.perf_counter() - started
+
+    row = _summarize_run(
+        df,
+        events_df,
+        metadata,
+        input_path=input_path,
+        weight_column=weight_column,
+        tag=tag,
+        loadcell=loadcell,
+        runtime_sec=runtime_sec,
+    )
+    return row, df
+
+
+def _sum(df: pd.DataFrame, column: str) -> float:
+    if column not in df.columns or df.empty:
+        return 0.0
+    return float(df[column].sum())
+
+
+def run_real_data_benchmark(
+    *,
+    dir_interpolated: Path = Path("data/preprocessed_csv_interpolated"),
+    dir_raw: Path = Path("data/preprocessed_csv"),
+    config_path: Path | None = Path("config.yaml"),
+    out_dir: Path = Path("real_data_test"),
+    loadcells: list[int] | tuple[int, ...] = (1, 2, 3, 4, 5, 6),
+    log_level: str = "WARNING",
+) -> dict[str, Any]:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.WARNING),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    logger = logging.getLogger("real_data_benchmark")
+    logger.setLevel(getattr(logging, log_level.upper(), logging.WARNING))
+
+    base_cfg = load_config(config_path) if config_path else PipelineConfig()
+    files_interpolated = {path.name: path for path in Path(dir_interpolated).glob("*.csv")}
+    files_raw = {path.name: path for path in Path(dir_raw).glob("*.csv")}
+    common = sorted(set(files_interpolated) & set(files_raw))
+    if not common:
+        raise SystemExit("No common CSV filenames between the two directories.")
+
+    rows: list[dict[str, Any]] = []
+    overlap_rows: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+
+    total_runs = len(common) * len(loadcells) * 2
+    done = 0
+
+    for name in common:
+        interpolated_path = files_interpolated[name]
+        raw_path = files_raw[name]
+        for loadcell in loadcells:
+            df_interpolated: pd.DataFrame | None = None
+            df_raw: pd.DataFrame | None = None
+
+            try:
+                row_interpolated, df_interpolated = _run_one_with_df(
+                    interpolated_path,
+                    base_cfg,
+                    weight_column=f"loadcell_{loadcell}_kg",
+                    tag="interpolated",
+                    loadcell=loadcell,
+                    logger=logger,
+                )
+                rows.append(row_interpolated)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    {
+                        "tag": "interpolated",
+                        "file": name,
+                        "loadcell": int(loadcell),
+                        "error": repr(exc),
+                    }
+                )
+            done += 1
+
+            try:
+                row_raw, df_raw = _run_one_with_df(
+                    raw_path,
+                    base_cfg,
+                    weight_column=LOADCELL_MAP_RAW[int(loadcell)],
+                    tag="raw",
+                    loadcell=loadcell,
+                    logger=logger,
+                )
+                rows.append(row_raw)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    {
+                        "tag": "raw",
+                        "file": name,
+                        "loadcell": int(loadcell),
+                        "error": repr(exc),
+                    }
+                )
+            done += 1
+
+            if isinstance(df_interpolated, pd.DataFrame) and isinstance(df_raw, pd.DataFrame):
+                overlap_start = max(df_interpolated.index.min(), df_raw.index.min())
+                overlap_end = min(df_interpolated.index.max(), df_raw.index.max())
+                if (
+                    pd.notna(overlap_start)
+                    and pd.notna(overlap_end)
+                    and overlap_start <= overlap_end
+                ):
+                    di = df_interpolated.loc[overlap_start:overlap_end]
+                    dr = df_raw.loc[overlap_start:overlap_end]
+                    overlap_rows.append(
+                        {
+                            "file": name,
+                            "loadcell": int(loadcell),
+                            "overlap_start": overlap_start,
+                            "overlap_end": overlap_end,
+                            "overlap_n_samples": int(min(len(di), len(dr))),
+                            "irrigation_kg_interp": _sum(di, "irrigation_kg_s"),
+                            "drainage_kg_interp": _sum(di, "drainage_kg_s"),
+                            "transpiration_kg_interp": _sum(di, "transpiration_kg_s"),
+                            "irrigation_kg_raw": _sum(dr, "irrigation_kg_s"),
+                            "drainage_kg_raw": _sum(dr, "drainage_kg_s"),
+                            "transpiration_kg_raw": _sum(dr, "transpiration_kg_s"),
+                            "diff_irrigation_kg": _sum(di, "irrigation_kg_s")
+                            - _sum(dr, "irrigation_kg_s"),
+                            "diff_drainage_kg": _sum(di, "drainage_kg_s")
+                            - _sum(dr, "drainage_kg_s"),
+                            "diff_transpiration_kg": _sum(di, "transpiration_kg_s")
+                            - _sum(dr, "transpiration_kg_s"),
+                            "mean_abs_balance_error_kg_interp": (
+                                float(di["water_balance_error_kg"].abs().mean())
+                                if "water_balance_error_kg" in di.columns and not di.empty
+                                else 0.0
+                            ),
+                            "mean_abs_balance_error_kg_raw": (
+                                float(dr["water_balance_error_kg"].abs().mean())
+                                if "water_balance_error_kg" in dr.columns and not dr.empty
+                                else 0.0
+                            ),
+                        }
+                    )
+
+        if done % max(2 * len(loadcells), 1) == 0:
+            print(f"Progress: {done}/{total_runs} runs")
+
+    summary_path = out_dir / "summary_runs.csv"
+    summary = pd.DataFrame(rows)
+    summary.to_csv(summary_path, index=False)
+
+    comparison_path: Path | None = None
+    if not summary.empty:
+        interpolated_df = summary[summary["tag"] == "interpolated"].copy()
+        raw_df = summary[summary["tag"] == "raw"].copy()
+        merged = interpolated_df.merge(raw_df, on=["file", "loadcell"], suffixes=("_interp", "_raw"), how="inner")
+        for column in [
+            "total_irrigation_kg",
+            "total_drainage_kg",
+            "total_transpiration_kg",
+            "final_balance_error_kg",
+            "irrigation_event_count",
+            "drainage_event_count",
+            "runtime_sec",
+            "interpolated_frac",
+        ]:
+            merged[f"diff_{column}"] = merged[f"{column}_interp"] - merged[f"{column}_raw"]
+        comparison_path = out_dir / "comparison.csv"
+        merged.to_csv(comparison_path, index=False)
+
+        abs_drain = merged["diff_total_drainage_kg"].abs()
+        abs_irrig = merged["diff_total_irrigation_kg"].abs()
+        abs_trans = merged["diff_total_transpiration_kg"].abs()
+        print("\n=== Summary (abs diff) ===")
+        print("files:", len(common), "loadcells:", len(loadcells))
+        print(
+            "Irrigation kg | median:",
+            float(abs_irrig.median()),
+            "p90:",
+            float(abs_irrig.quantile(0.9)),
+        )
+        print(
+            "Drainage   kg | median:",
+            float(abs_drain.median()),
+            "p90:",
+            float(abs_drain.quantile(0.9)),
+        )
+        print(
+            "Transp.    kg | median:",
+            float(abs_trans.median()),
+            "p90:",
+            float(abs_trans.quantile(0.9)),
+        )
+
+    overlap_path: Path | None = None
+    overlap_df = pd.DataFrame(overlap_rows)
+    if not overlap_df.empty:
+        overlap_path = out_dir / "comparison_overlap.csv"
+        overlap_df.to_csv(overlap_path, index=False)
+
+        abs_irrig = overlap_df["diff_irrigation_kg"].abs()
+        abs_drain = overlap_df["diff_drainage_kg"].abs()
+        abs_trans = overlap_df["diff_transpiration_kg"].abs()
+        print("\n=== Summary (abs diff, overlap window only) ===")
+        print("rows:", int(len(overlap_df)))
+        print(
+            "Irrigation kg | median:",
+            float(abs_irrig.median()),
+            "p90:",
+            float(abs_irrig.quantile(0.9)),
+        )
+        print(
+            "Drainage   kg | median:",
+            float(abs_drain.median()),
+            "p90:",
+            float(abs_drain.quantile(0.9)),
+        )
+        print(
+            "Transp.    kg | median:",
+            float(abs_trans.median()),
+            "p90:",
+            float(abs_trans.quantile(0.9)),
+        )
+
+    failures_path: Path | None = None
+    if failures:
+        failures_path = out_dir / "failures.csv"
+        pd.DataFrame(failures).to_csv(failures_path, index=False)
+        print(f"\nFailures: {len(failures)} (see {failures_path})")
+    else:
+        print("\nNo failures.")
+
+    return {
+        "common_files": common,
+        "summary_path": summary_path,
+        "comparison_path": comparison_path,
+        "overlap_path": overlap_path,
+        "failures_path": failures_path,
+        "row_count": int(len(rows)),
+        "failure_count": int(len(failures)),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Batch benchmark for real greenhouse data (interpolated vs raw)."
+    )
+    parser.add_argument(
+        "--interpolated-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv_interpolated"),
+        help="Directory containing interpolated daily CSVs.",
+    )
+    parser.add_argument(
+        "--raw-dir",
+        type=Path,
+        default=Path("data/preprocessed_csv"),
+        help="Directory containing raw daily CSVs.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Pipeline config YAML path.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("real_data_test"),
+        help="Output directory for benchmark CSVs.",
+    )
+    parser.add_argument(
+        "--loadcells",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3, 4, 5, 6],
+        help="Loadcell ids to benchmark.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="WARNING",
+        help="Logging level (DEBUG, INFO, WARNING, ...).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    run_real_data_benchmark(
+        dir_interpolated=args.interpolated_dir,
+        dir_raw=args.raw_dir,
+        config_path=args.config,
+        out_dir=args.out_dir,
+        loadcells=args.loadcells,
+        log_level=args.log_level,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_load_cell_real_data_benchmark_script.py
+++ b/tests/test_load_cell_real_data_benchmark_script.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.load_cell import PipelineConfig
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "real_data_benchmark.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "load_cell_real_data_benchmark_script",
+        _script_path(),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_real_data_benchmark_requires_common_files(tmp_path: Path) -> None:
+    module = _load_script_module()
+    interpolated_dir = tmp_path / "interp"
+    raw_dir = tmp_path / "raw"
+    interpolated_dir.mkdir()
+    raw_dir.mkdir()
+    (interpolated_dir / "2025-01-01.csv").write_text("timestamp\n", encoding="utf-8")
+    (raw_dir / "2025-01-02.csv").write_text("timestamp\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="No common CSV filenames"):
+        module.run_real_data_benchmark(
+            dir_interpolated=interpolated_dir,
+            dir_raw=raw_dir,
+            config_path=None,
+            out_dir=tmp_path / "out",
+            loadcells=[1],
+        )
+
+
+def test_real_data_benchmark_writes_summary_and_overlap_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+    interpolated_dir = tmp_path / "interp"
+    raw_dir = tmp_path / "raw"
+    out_dir = tmp_path / "out"
+    interpolated_dir.mkdir()
+    raw_dir.mkdir()
+    (interpolated_dir / "2025-01-01.csv").write_text("timestamp\n", encoding="utf-8")
+    (raw_dir / "2025-01-01.csv").write_text("timestamp\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "load_config", lambda path: PipelineConfig(smooth_window_sec=15))
+
+    index = pd.date_range("2025-01-01 00:00:00", periods=3, freq="s", name="timestamp")
+    events_df = pd.DataFrame(
+        [
+            {
+                "event_id": 1,
+                "event_type": "irrigation",
+                "start_time": index[0],
+                "end_time": index[0],
+                "duration_sec": 1,
+                "mass_change_kg": 0.2,
+            }
+        ]
+    )
+
+    def fake_run_pipeline(cfg, include_excel, write_output, logger):
+        assert include_excel is False
+        assert write_output is False
+        if cfg.weight_column == "loadcell_1_kg":
+            df = pd.DataFrame(
+                {
+                    "irrigation_kg_s": [0.2, 0.0, 0.0],
+                    "drainage_kg_s": [0.0, 0.0, 0.1],
+                    "transpiration_kg_s": [0.0, 0.1, 0.1],
+                    "cum_irrigation_kg": [0.2, 0.2, 0.2],
+                    "cum_drainage_kg": [0.0, 0.0, 0.1],
+                    "cum_transpiration_kg": [0.0, 0.1, 0.2],
+                    "water_balance_error_kg": [0.0, 0.01, 0.01],
+                    "is_interpolated": [1.0, 1.0, 1.0],
+                    "is_outlier": [0.0, 0.0, 0.0],
+                    "transpiration_scale": [1.0, 1.0, 1.0],
+                },
+                index=index,
+            )
+        else:
+            df = pd.DataFrame(
+                {
+                    "irrigation_kg_s": [0.1, 0.0, 0.0],
+                    "drainage_kg_s": [0.0, 0.0, 0.05],
+                    "transpiration_kg_s": [0.0, 0.05, 0.05],
+                    "cum_irrigation_kg": [0.1, 0.1, 0.1],
+                    "cum_drainage_kg": [0.0, 0.0, 0.05],
+                    "cum_transpiration_kg": [0.0, 0.05, 0.1],
+                    "water_balance_error_kg": [0.0, 0.02, 0.02],
+                    "is_interpolated": [0.0, 0.0, 0.0],
+                    "is_outlier": [0.0, 0.0, 0.0],
+                    "transpiration_scale": [1.0, 1.0, 1.0],
+                },
+                index=index,
+            )
+        return (
+            df,
+            events_df.copy(),
+            {
+                "irrigation_threshold": 0.4,
+                "drainage_threshold": -0.3,
+                "events_merged": events_df.copy(),
+                "stats": {"final_balance_error_kg": float(df["water_balance_error_kg"].iloc[-1])},
+            },
+        )
+
+    monkeypatch.setattr(module, "run_pipeline", fake_run_pipeline)
+
+    result = module.run_real_data_benchmark(
+        dir_interpolated=interpolated_dir,
+        dir_raw=raw_dir,
+        config_path=tmp_path / "config.yaml",
+        out_dir=out_dir,
+        loadcells=[1],
+    )
+
+    summary_df = pd.read_csv(out_dir / "summary_runs.csv")
+    comparison_df = pd.read_csv(out_dir / "comparison.csv")
+    overlap_df = pd.read_csv(out_dir / "comparison_overlap.csv")
+    captured = capsys.readouterr()
+
+    assert result["row_count"] == 2
+    assert result["failure_count"] == 0
+    assert result["failures_path"] is None
+    assert len(summary_df) == 2
+    assert set(summary_df["tag"]) == {"interpolated", "raw"}
+    assert comparison_df.loc[0, "diff_total_irrigation_kg"] == pytest.approx(0.1)
+    assert comparison_df.loc[0, "diff_total_drainage_kg"] == pytest.approx(0.05)
+    assert comparison_df.loc[0, "diff_total_transpiration_kg"] == pytest.approx(0.1)
+    assert overlap_df.loc[0, "diff_irrigation_kg"] == pytest.approx(0.1)
+    assert "No failures." in captured.out
+    assert "Progress: 2/2 runs" in captured.out
+
+
+def test_real_data_benchmark_writes_failures_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_script_module()
+    interpolated_dir = tmp_path / "interp"
+    raw_dir = tmp_path / "raw"
+    out_dir = tmp_path / "out"
+    interpolated_dir.mkdir()
+    raw_dir.mkdir()
+    (interpolated_dir / "2025-01-01.csv").write_text("timestamp\n", encoding="utf-8")
+    (raw_dir / "2025-01-01.csv").write_text("timestamp\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "load_config", lambda path: PipelineConfig())
+
+    index = pd.date_range("2025-01-01 00:00:00", periods=2, freq="s", name="timestamp")
+
+    def fake_run_pipeline(cfg, include_excel, write_output, logger):
+        if cfg.weight_column == "M000.0 N":
+            raise ValueError("raw failure")
+        df = pd.DataFrame(
+            {
+                "cum_irrigation_kg": [0.1, 0.1],
+                "cum_drainage_kg": [0.0, 0.0],
+                "cum_transpiration_kg": [0.0, 0.05],
+                "water_balance_error_kg": [0.0, 0.0],
+            },
+            index=index,
+        )
+        return df, pd.DataFrame(), {"stats": {"final_balance_error_kg": 0.0}}
+
+    monkeypatch.setattr(module, "run_pipeline", fake_run_pipeline)
+
+    result = module.run_real_data_benchmark(
+        dir_interpolated=interpolated_dir,
+        dir_raw=raw_dir,
+        config_path=tmp_path / "config.yaml",
+        out_dir=out_dir,
+        loadcells=[1],
+    )
+
+    failures_df = pd.read_csv(out_dir / "failures.csv")
+    assert result["failure_count"] == 1
+    assert result["failures_path"] == out_dir / "failures.csv"
+    assert failures_df.loc[0, "tag"] == "raw"
+    assert "ValueError('raw failure')" in failures_df.loc[0, "error"]
+
+
+def test_real_data_benchmark_main_dispatches_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_script_module()
+    captures: dict[str, object] = {}
+
+    def fake_run_real_data_benchmark(**kwargs):
+        captures.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(module, "run_real_data_benchmark", fake_run_real_data_benchmark)
+
+    result = module.main(
+        [
+            "--interpolated-dir",
+            "interp",
+            "--raw-dir",
+            "raw",
+            "--config",
+            "config.yaml",
+            "--out-dir",
+            "out",
+            "--loadcells",
+            "2",
+            "4",
+            "--log-level",
+            "INFO",
+        ]
+    )
+
+    assert result == 0
+    assert captures == {
+        "dir_interpolated": Path("interp"),
+        "dir_raw": Path("raw"),
+        "config_path": Path("config.yaml"),
+        "out_dir": Path("out"),
+        "loadcells": [2, 4],
+        "log_level": "INFO",
+    }


### PR DESCRIPTION
## Summary
- migrate the `load-cell-data` real-data benchmark harness into `scripts/real_data_benchmark.py`
- preserve batch summary/comparison/failure outputs over the migrated `load_cell` pipeline
- move the next remaining `load-cell-data` seam to the preprocess-compare incremental tooling

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #113
