### PR TITLE
[Model Change] Migrate load-cell-data preprocess-compare local server seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -27,4 +27,5 @@ Current status:
 - Slice 058 migrated: `load-cell-data` synthetic validation harness seam
 - Slice 059 migrated: `load-cell-data` real-data benchmark harness seam
 - Slice 060 migrated: `load-cell-data` incremental preprocess harness seam
-- Next blocked seam: `load-cell-data` preprocess-compare local server seam at `src/preprocess_compare_server.py`
+- Slice 061 migrated: `load-cell-data` preprocess-compare local server seam
+- Next blocked seam: `load-cell-data` static preprocess-compare viewer seam at `src/build_preprocess_compare_viewer.py`

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ poetry run ruff check .
 - `load-cell-data` synthetic validation harness seam is migrated as slice 058.
 - `load-cell-data` real-data benchmark harness seam is migrated as slice 059.
 - `load-cell-data` incremental preprocess harness seam is migrated as slice 060.
+- `load-cell-data` preprocess-compare local server seam is migrated as slice 061.
 
 ## Next validation
-- Audit the `load-cell-data` preprocess-compare local server seam at `src/preprocess_compare_server.py`.
+- Audit the `load-cell-data` static preprocess-compare viewer seam at `src/build_preprocess_compare_viewer.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 060
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 060 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 061
+- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 061 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -407,3 +407,9 @@ Slice 060:
 - target: `scripts/preprocess_incremental.py`, `tests/test_load_cell_preprocess_incremental_script.py`, `pyproject.toml`, and `poetry.lock`
 - scope: bounded `load-cell-data` incremental preprocess harness covering marker-backed raw-file skips, canonical parquet upserts, transpiration parquet outputs, viewer cache refresh, and repo-level CLI defaults
 - excluded: `src/preprocess_compare_server.py`, `src/build_preprocess_compare_viewer.py`, and broader compare-viewer UX changes
+
+Slice 061:
+- source: `load-cell-data/src/preprocess_compare_server.py`
+- target: `scripts/preprocess_compare_server.py` and `tests/test_load_cell_preprocess_compare_server_script.py`
+- scope: bounded `load-cell-data` local server surface covering health/export/preprocess/cancel APIs, transpiration export computation, static viewer serving, and repo-level CLI defaults
+- excluded: `src/build_preprocess_compare_viewer.py`, viewer asset generation, and broader web-framework adoption

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -524,8 +524,16 @@ The sixtieth slice opens the next bounded `load-cell-data` seam:
 - keep the seam incremental-tooling-bounded without widening into the preprocess-compare server or static viewer builder in the same slice
 - leave `load-cell-data/src/preprocess_compare_server.py` blocked as the next seam
 
+## Slice 061: load-cell-data Preprocess-Compare Local Server
+
+The sixty-first slice opens the next bounded `load-cell-data` seam:
+- move `load-cell-data/src/preprocess_compare_server.py` into the repo-local `scripts/` surface
+- preserve local health/export/preprocess/cancel APIs, transpiration export computation, static viewer serving, and repo-level CLI defaults
+- keep the seam server-bounded without widening into the static viewer builder or broader web-framework choices in the same slice
+- leave `load-cell-data/src/build_preprocess_compare_viewer.py` blocked as the next seam
+
 ## Immediate Deliverables
 
-1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first fifteen `load-cell-data` bounded seams
+1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next `load-cell-data` source audit for `src/preprocess_compare_server.py`
+3. prepare the next `load-cell-data` source audit for `src/build_preprocess_compare_viewer.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 060 completed and slice 061 planning
+- Current phase: slice 061 completed and slice 062 planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. audit the `load-cell-data` preprocess-compare local server seam at `src/preprocess_compare_server.py`
-2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess-plus-synthetic-harness-plus-real-benchmark-plus-incremental-preprocess boundary while deciding how the compare viewer and export API should land on the migrated repo
-3. keep `load-cell-data` blocked until its server-plus-viewer source audit is deeper
+1. audit the `load-cell-data` static preprocess-compare viewer seam at `src/build_preprocess_compare_viewer.py`
+2. preserve the config-plus-IO-plus-aggregation-plus-thresholds-plus-preprocessing-plus-events-plus-fluxes-plus-cli-plus-workflow-plus-sweep-plus-runner-plus-raw-preprocess-plus-synthetic-harness-plus-real-benchmark-plus-incremental-preprocess-plus-local-server boundary while deciding how the remaining static viewer bundle should land on the migrated repo
+3. keep `load-cell-data` blocked until its remaining viewer-builder source audit is deeper

--- a/docs/architecture/architecture/module_specs/module-061-load-cell-preprocess-compare-local-server.md
+++ b/docs/architecture/architecture/module_specs/module-061-load-cell-preprocess-compare-local-server.md
@@ -1,0 +1,35 @@
+# Module Spec 061: load-cell-data Preprocess-Compare Local Server
+
+## Purpose
+
+Open the next bounded `load-cell-data` seam by porting the repo-level preprocess-compare local server that serves static viewer assets and exposes export plus preprocess APIs.
+
+## Source Inputs
+
+- `load-cell-data/src/preprocess_compare_server.py`
+
+## Target Outputs
+
+- `scripts/preprocess_compare_server.py`
+- `tests/test_load_cell_preprocess_compare_server_script.py`
+
+## Responsibilities
+
+1. preserve local health, export, preprocess, and cancel API behavior
+2. preserve transpiration export computation across `diff_1s`, `ma_diff_1s`, `reg_1s`, and `diff60_1m`
+3. keep the seam repo-level and server-bounded without widening into static viewer generation
+
+## Non-Goals
+
+- migrate `load-cell-data/src/build_preprocess_compare_viewer.py`
+- redesign the viewer HTML, CSS, or JS bundle
+- widen the server into a package-level web framework
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `load-cell-data/src/build_preprocess_compare_viewer.py`

--- a/docs/architecture/executor/issue-061-model-change.md
+++ b/docs/architecture/executor/issue-061-model-change.md
@@ -1,0 +1,20 @@
+## Why
+- `slice 060` migrated the incremental preprocess harness, so the next remaining bounded `load-cell-data` surface is the preprocess-compare local server at `src/preprocess_compare_server.py`.
+- The migrated repo now has canonical parquet updates and viewer JSON cache refresh, but it still lacks the HTTP server layer that exposes health, preprocess, cancel, and export APIs to the local compare viewer.
+- This slice should stay server-bounded: export computation, preprocess job orchestration, local static serving, and repo-level CLI wiring only.
+
+## Affected model
+- `load-cell-data`
+- `scripts/`
+- preprocess-compare local server tests
+- architecture docs for the next viewer/server seam
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for safe path checks, transpiration export computation, health/export/preprocess API responses, cancel flow, and CLI/default wiring
+
+## Comparison target
+- legacy `load-cell-data/src/preprocess_compare_server.py`
+- current migrated `scripts/preprocess_incremental.py`
+- deferred viewer-builder seam at `load-cell-data/src/build_preprocess_compare_viewer.py`

--- a/docs/architecture/executor/pr-117-load-cell-preprocess-compare-local-server.md
+++ b/docs/architecture/executor/pr-117-load-cell-preprocess-compare-local-server.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the `load-cell-data` preprocess-compare local server into `scripts/preprocess_compare_server.py`
+- preserve export computation, preprocess job state handling, static serving, and repo-level CLI wiring
+- move the next remaining `load-cell-data` seam to the static viewer builder
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #117

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed incremental preprocess harness seam | preprocess-compare local server and static viewer surfaces still remain unmigrated, so the domain has bounded pipeline coverage but not yet its legacy inspection tooling | next load-cell module spec |
+| GAP-002 | `load-cell-data` migration depth is still shallow beyond the completed preprocess-compare local server seam | the static preprocess-compare viewer builder still remains unmigrated, so the domain has bounded pipeline and server coverage but not yet the full legacy inspection tooling | next load-cell module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/scripts/preprocess_compare_server.py
+++ b/scripts/preprocess_compare_server.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import threading
+import time
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from socketserver import ThreadingMixIn
+from typing import Any
+from urllib.parse import urlparse
+
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = Path(__file__).resolve().parent
+SRC_DIR = PROJECT_ROOT / "src"
+for path in (SRC_DIR, SCRIPTS_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import preprocess_incremental as pp  # noqa: E402
+
+DATE_RE = r"^\d{4}-\d{2}-\d{2}$"
+LC_COLS = [f"loadcell_{idx}_kg" for idx in range(1, 7)]
+
+
+def _safe_path_under(root: Path, user_path: str) -> Path:
+    path = Path(user_path).expanduser()
+    path = (root / path).resolve() if not path.is_absolute() else path.resolve()
+    root_resolved = root.resolve()
+    if path == root_resolved:
+        return path
+    if root_resolved not in path.parents:
+        raise ValueError(f"final_dir must be under repo root: {root_resolved}")
+    return path
+
+
+def _rolling_slope_trailing(values: np.ndarray, window: int) -> np.ndarray:
+    size = int(len(values))
+    out = np.full(size, np.nan, dtype=np.float64)
+    window_size = int(window)
+    if window_size < 2 or size < window_size:
+        return out
+
+    idx = np.arange(size, dtype=np.float64)
+    cumsum_y = np.cumsum(values, dtype=np.float64)
+    cumsum_xy = np.cumsum(idx * values, dtype=np.float64)
+
+    sum_x = (window_size * (window_size - 1)) / 2.0
+    var_x = (window_size * (window_size * window_size - 1)) / 12.0
+    if var_x <= 0:
+        return out
+
+    for end_idx in range(window_size - 1, size):
+        start_idx = end_idx - window_size + 1
+        sum_y = float(cumsum_y[end_idx] - (cumsum_y[start_idx - 1] if start_idx > 0 else 0.0))
+        sum_xy = float(
+            cumsum_xy[end_idx] - (cumsum_xy[start_idx - 1] if start_idx > 0 else 0.0)
+        )
+        shifted_sum_xy = sum_xy - float(start_idx) * sum_y
+        numerator = shifted_sum_xy - (sum_x * sum_y) / float(window_size)
+        out[end_idx] = numerator / var_x
+
+    return out
+
+
+def _compute_transpiration(
+    *,
+    canonical_path: Path,
+    transpiration_1m_dir: Path,
+    date: str,
+    method: str,
+    resolution: str,
+    plants_per_loadcell: int,
+    ma_window_sec: int,
+    reg_window_sec: int,
+    cap_g_min_per_plant: float | None,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    if plants_per_loadcell < 1:
+        raise ValueError("plants_per_loadcell must be >= 1")
+    if cap_g_min_per_plant is not None and (
+        not math.isfinite(cap_g_min_per_plant) or cap_g_min_per_plant <= 0
+    ):
+        raise ValueError("cap_g_min_per_plant must be a finite value > 0")
+
+    df = pd.read_parquet(canonical_path, columns=["timestamp", *LC_COLS])
+    if df.empty:
+        raise ValueError(f"Empty canonical file: {canonical_path}")
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df = df.sort_values("timestamp").set_index("timestamp", drop=True)
+    weights_g = df[LC_COLS].astype("float64") * 1000.0
+
+    meta = {
+        "date": date,
+        "method": method,
+        "resolution": resolution,
+        "plants_per_loadcell": int(plants_per_loadcell),
+        "ma_window_sec": int(ma_window_sec),
+        "reg_window_sec": int(reg_window_sec),
+        "cap_g_min_per_plant": cap_g_min_per_plant,
+        "source_canonical": str(canonical_path),
+        "source_transpiration_1m": None,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+
+    def apply_cap(frame: pd.DataFrame) -> pd.DataFrame:
+        if cap_g_min_per_plant is None:
+            return frame
+        return frame.clip(upper=float(cap_g_min_per_plant))
+
+    if method == "diff60_1m":
+        if resolution != "1m":
+            raise ValueError("diff60_1m method only supports resolution=1m")
+        pattern = f"{date}__transpiration_1m__diff60__g_min_per_plant__p{plants_per_loadcell}*.parquet"
+        matches = sorted(transpiration_1m_dir.glob(pattern)) if transpiration_1m_dir.exists() else []
+        if matches:
+            meta["source_transpiration_1m"] = str(matches[0])
+            tdf = pd.read_parquet(matches[0])
+            columns = [f"loadcell_{idx}_transpiration_g_min_per_plant" for idx in range(1, 7)]
+            missing = [column for column in columns if column not in tdf.columns]
+            if missing:
+                raise KeyError(f"Missing columns in {matches[0]}: {missing}")
+            tdf["timestamp"] = pd.to_datetime(tdf["timestamp"])
+            transpiration = tdf.sort_values("timestamp").set_index("timestamp", drop=True)[columns]
+            transpiration = transpiration.astype("float64")
+            transpiration.columns = LC_COLS
+        else:
+            delta_g = weights_g.resample("1min", label="right", closed="right").last().diff()
+            transpiration = (-delta_g).clip(lower=0.0).fillna(0.0) / float(plants_per_loadcell)
+        transpiration = apply_cap(transpiration)
+    elif method in {"diff_1s", "ma_diff_1s", "reg_1s"}:
+        if method == "diff_1s":
+            base = weights_g
+            delta_g = base.diff()
+            transpiration = (-delta_g).clip(lower=0.0).fillna(0.0) / float(plants_per_loadcell)
+            transpiration = apply_cap(transpiration * 60.0)
+        elif method == "ma_diff_1s":
+            base = weights_g.rolling(window=max(1, int(ma_window_sec)), min_periods=1).mean()
+            delta_g = base.diff()
+            transpiration = (-delta_g).clip(lower=0.0).fillna(0.0) / float(plants_per_loadcell)
+            transpiration = apply_cap(transpiration * 60.0)
+        else:
+            slopes = {
+                column: _rolling_slope_trailing(
+                    weights_g[column].to_numpy(dtype=np.float64),
+                    max(2, int(reg_window_sec)),
+                )
+                for column in LC_COLS
+            }
+            transpiration = pd.DataFrame(slopes, index=weights_g.index)
+            transpiration = (
+                (-transpiration).clip(lower=0.0).fillna(0.0) / float(plants_per_loadcell)
+            ) * 60.0
+            transpiration = apply_cap(transpiration)
+
+        if resolution == "1m":
+            transpiration = transpiration.resample("1min", label="right", closed="right").mean()
+        elif resolution != "1s":
+            raise ValueError("resolution must be '1s' or '1m'")
+    else:
+        raise ValueError(f"Unknown method: {method}")
+
+    out = pd.DataFrame(index=transpiration.index)
+    for idx in range(1, 7):
+        out[f"loadcell_{idx}_transpiration_g_min_per_plant"] = transpiration[f"loadcell_{idx}_kg"]
+    transpiration_total = transpiration * float(plants_per_loadcell)
+    out["total_transpiration_g_min"] = transpiration_total.sum(axis=1)
+    out["avg_transpiration_g_min_per_plant"] = (
+        out["total_transpiration_g_min"] / float(plants_per_loadcell * 6)
+    )
+    return out.reset_index(), meta
+
+
+class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+def _utc_iso_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _init_preprocess_state() -> dict[str, Any]:
+    return {
+        "running": False,
+        "cancel_requested": False,
+        "phase": "idle",
+        "message": "",
+        "started_at_utc": None,
+        "ended_at_utc": None,
+        "updated_at_utc": None,
+        "log_tail": [],
+        "result": None,
+        "error": None,
+    }
+
+
+def _append_log(preprocess_state: dict[str, Any], message: str, *, max_lines: int = 240) -> None:
+    line = f"{_utc_iso_now()} {message}"
+    preprocess_state["message"] = message
+    preprocess_state["updated_at_utc"] = _utc_iso_now()
+    tail = preprocess_state.get("log_tail", [])
+    if not isinstance(tail, list):
+        tail = []
+    tail.append(line)
+    preprocess_state["log_tail"] = tail[-max_lines:]
+
+
+def _start_preprocess_job(server_state: dict[str, Any], request_payload: dict[str, Any]) -> dict[str, Any]:
+    lock: threading.Lock = server_state["preprocess_lock"]
+    with lock:
+        state = server_state["preprocess_state"]
+        if state.get("running"):
+            return {"ok": True, "started": False, "running": True, "message": "already running"}
+        server_state["preprocess_state"] = _init_preprocess_state()
+        state = server_state["preprocess_state"]
+        state["running"] = True
+        state["phase"] = "starting"
+        state["started_at_utc"] = _utc_iso_now()
+        state["updated_at_utc"] = state["started_at_utc"]
+        _append_log(state, "[info] preprocess job started")
+
+    cfg = pp.PreprocessConfig(
+        repo_root=server_state["repo_root"],
+        raw_dir=_safe_path_under(
+            server_state["repo_root"],
+            str(request_payload.get("raw_dir", "data/raw")).strip() or "data/raw",
+        ),
+        raw_pattern=str(request_payload.get("pattern", "ALMEMO500~*.csv")).strip() or "ALMEMO500~*.csv",
+        canonical_dir=Path(server_state["canonical_dir"]),
+        transpiration_1m_dir=Path(server_state["transpiration_1m_dir"]),
+        marker_dir=Path(server_state["marker_dir"]),
+        viewer_dir=Path(server_state["viewer_dir"]),
+        plants_per_loadcell=int(request_payload.get("plants_per_loadcell", request_payload.get("plants", 3)) or 3),
+        overwrite=False,
+        max_files=(
+            None
+            if request_payload.get("max_files", None) is None
+            else int(request_payload["max_files"])
+        ),
+    )
+
+    def should_cancel() -> bool:
+        with lock:
+            return bool(server_state["preprocess_state"].get("cancel_requested", False))
+
+    def log(message: str) -> None:
+        with lock:
+            _append_log(server_state["preprocess_state"], message)
+
+    def worker() -> None:
+        try:
+            with lock:
+                server_state["preprocess_state"]["phase"] = "running"
+            result = pp.run_incremental_preprocess(cfg, log=log, should_cancel=should_cancel)
+            with lock:
+                state = server_state["preprocess_state"]
+                state["phase"] = "done"
+                state["running"] = False
+                state["ended_at_utc"] = _utc_iso_now()
+                state["result"] = {
+                    "raw_total": result.raw_total,
+                    "raw_skipped": result.raw_skipped,
+                    "raw_processed": result.raw_processed,
+                    "raw_failed": result.raw_failed,
+                    "updated_dates": result.updated_dates,
+                }
+        except Exception as exc:
+            with lock:
+                state = server_state["preprocess_state"]
+                state["phase"] = "error"
+                state["running"] = False
+                state["ended_at_utc"] = _utc_iso_now()
+                state["error"] = str(exc)
+                _append_log(state, f"[error] {exc}")
+
+    thread = threading.Thread(target=worker, name="preprocess-job", daemon=True)
+    with lock:
+        server_state["preprocess_thread"] = thread
+    thread.start()
+    return {"ok": True, "started": True, "running": True}
+
+
+def _make_handler(*, directory: Path, server_state: dict[str, Any]):
+    class Handler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(directory), **kwargs)
+
+        def _send_json(self, payload_obj: Any, status: int = 200) -> None:
+            payload = json.dumps(payload_obj, ensure_ascii=True).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def _read_json(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                return json.loads(raw.decode("utf-8"))
+            except Exception as exc:
+                raise ValueError(f"Invalid JSON: {exc}") from exc
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path == "/api/health":
+                self._send_json(
+                    {
+                        "ok": True,
+                        "viewer_dir": str(directory),
+                        "canonical_dir": str(server_state["canonical_dir"]),
+                        "transpiration_1m_dir": str(server_state["transpiration_1m_dir"]),
+                        "final_dir": str(server_state["final_dir"]),
+                        "marker_dir": str(server_state["marker_dir"]),
+                    }
+                )
+                return
+            if parsed.path == "/api/preprocess/status":
+                with server_state["preprocess_lock"]:
+                    state = dict(server_state["preprocess_state"])
+                self._send_json({"ok": True, "state": state})
+                return
+            super().do_GET()
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            try:
+                request_payload = self._read_json()
+                if parsed.path == "/api/preprocess":
+                    self._send_json(_start_preprocess_job(server_state, request_payload))
+                    return
+                if parsed.path == "/api/preprocess/cancel":
+                    with server_state["preprocess_lock"]:
+                        server_state["preprocess_state"]["cancel_requested"] = True
+                        _append_log(server_state["preprocess_state"], "[warn] cancel requested")
+                    self._send_json({"ok": True})
+                    return
+                if parsed.path != "/api/export":
+                    self.send_error(404)
+                    return
+
+                date = str(request_payload.get("date", "")).strip()
+                if not pd.Series([date]).str.match(DATE_RE).item():
+                    raise ValueError("date must be YYYY-MM-DD")
+
+                final_dir = _safe_path_under(
+                    server_state["repo_root"],
+                    str(request_payload.get("final_dir", str(server_state["final_dir"]))).strip()
+                    or str(server_state["final_dir"]),
+                )
+                canonical_path = Path(server_state["canonical_dir"]) / f"{date}_canonical_1s.parquet"
+                if not canonical_path.exists():
+                    raise FileNotFoundError(f"canonical file not found: {canonical_path}")
+
+                method = str(request_payload.get("method", "")).strip()
+                resolution = str(request_payload.get("resolution", "")).strip()
+                out_df, meta = _compute_transpiration(
+                    canonical_path=canonical_path,
+                    transpiration_1m_dir=Path(server_state["transpiration_1m_dir"]),
+                    date=date,
+                    method=method,
+                    resolution=resolution,
+                    plants_per_loadcell=int(request_payload.get("plants_per_loadcell", 3)),
+                    ma_window_sec=int(request_payload.get("ma_window_sec", 60)),
+                    reg_window_sec=int(request_payload.get("reg_window_sec", 300)),
+                    cap_g_min_per_plant=(
+                        None
+                        if request_payload.get("cap_g_min_per_plant", None) is None
+                        else float(request_payload["cap_g_min_per_plant"])
+                    ),
+                )
+
+                out_dir = final_dir / date
+                out_dir.mkdir(parents=True, exist_ok=True)
+                out_path = out_dir / f"transpiration_{resolution}__{method}.parquet"
+                meta_path = out_dir / f"transpiration_{resolution}__{method}__meta.json"
+                out_df.to_parquet(out_path, index=False, engine="pyarrow", compression="snappy")
+                meta_path.write_text(
+                    json.dumps(meta, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+                self._send_json({"ok": True, "path": str(out_path), "rows": int(len(out_df))})
+            except Exception as exc:
+                self._send_json({"ok": False, "error": str(exc)}, status=400)
+
+    return Handler
+
+
+def create_server(
+    *,
+    bind: str,
+    port: int,
+    viewer_dir: Path,
+    canonical_dir: Path,
+    transpiration_1m_dir: Path,
+    final_dir: Path,
+    marker_dir: Path,
+    repo_root: Path = PROJECT_ROOT,
+) -> _ThreadingHTTPServer:
+    server_state = {
+        "repo_root": Path(repo_root).resolve(),
+        "viewer_dir": Path(viewer_dir).resolve(),
+        "canonical_dir": Path(canonical_dir).resolve(),
+        "transpiration_1m_dir": Path(transpiration_1m_dir).resolve(),
+        "final_dir": Path(final_dir).resolve(),
+        "marker_dir": Path(marker_dir).resolve(),
+        "preprocess_lock": threading.Lock(),
+        "preprocess_state": _init_preprocess_state(),
+        "preprocess_thread": None,
+    }
+    handler_cls = _make_handler(directory=Path(viewer_dir).resolve(), server_state=server_state)
+    server = _ThreadingHTTPServer((str(bind), int(port)), handler_cls)
+    setattr(server, "preprocess_compare_state", server_state)
+    return server
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Serve preprocess-compare viewer with export API.")
+    parser.add_argument(
+        "--viewer-dir",
+        type=Path,
+        default=Path("artifacts/preprocess_compare"),
+        help="Directory with index.html/app.js/style.css/data/*.json.",
+    )
+    parser.add_argument(
+        "--canonical-dir",
+        type=Path,
+        default=Path("data/processed/canonical_1s"),
+        help="Directory with YYYY-MM-DD_canonical_1s.parquet files.",
+    )
+    parser.add_argument(
+        "--transpiration-1m-dir",
+        type=Path,
+        default=Path("data/processed/transpiration_1m"),
+        help="Directory with transpiration 1m parquet outputs.",
+    )
+    parser.add_argument(
+        "--final-dir",
+        type=Path,
+        default=Path("data/final"),
+        help="Base directory for saved final outputs.",
+    )
+    parser.add_argument(
+        "--marker-dir",
+        type=Path,
+        default=Path("data/processed/_batch_markers"),
+        help="Directory for per-raw-file processing markers.",
+    )
+    parser.add_argument("--bind", type=str, default="127.0.0.1", help="Bind address.")
+    parser.add_argument("--port", type=int, default=8000, help="Port.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    viewer_dir = Path(args.viewer_dir)
+    canonical_dir = Path(args.canonical_dir)
+    if not (viewer_dir / "index.html").exists():
+        raise FileNotFoundError(f"viewer-dir missing index.html: {viewer_dir}")
+    if not canonical_dir.exists():
+        raise FileNotFoundError(f"canonical-dir not found: {canonical_dir}")
+
+    server = create_server(
+        bind=args.bind,
+        port=args.port,
+        viewer_dir=viewer_dir,
+        canonical_dir=canonical_dir,
+        transpiration_1m_dir=Path(args.transpiration_1m_dir),
+        final_dir=Path(args.final_dir),
+        marker_dir=Path(args.marker_dir),
+        repo_root=PROJECT_ROOT,
+    )
+    host, port = server.server_address
+    state = getattr(server, "preprocess_compare_state")
+    print(f"[ok] serving viewer: {viewer_dir}  (bind={host} port={port})")
+    print(f"[ok] export base dir: {state['final_dir']}")
+    print("open: http://<host>:<port>/")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"[error] {exc}", file=sys.stderr)
+        raise

--- a/tests/test_load_cell_preprocess_compare_server_script.py
+++ b/tests/test_load_cell_preprocess_compare_server_script.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "preprocess_compare_server.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "load_cell_preprocess_compare_server_script",
+        _script_path(),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _canonical_frame(*, start: str = "2025-01-01 00:00:00", periods: int = 61) -> pd.DataFrame:
+    index = pd.date_range(start, periods=periods, freq="1s", name="timestamp")
+    data = {
+        f"loadcell_{idx}_kg": [10.0 - (row / 60.0 if idx == 1 else 0.0) for row in range(periods)]
+        for idx in range(1, 7)
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def _write_canonical_day(path: Path) -> None:
+    _canonical_frame().reset_index().to_parquet(
+        path,
+        index=False,
+        engine="pyarrow",
+        compression="snappy",
+    )
+
+
+def _write_transpiration_day(path: Path, value: float = 7.5) -> None:
+    pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-01-01 00:01:00", periods=1, freq="1min"),
+            **{
+                f"loadcell_{idx}_transpiration_g_min_per_plant": [value + idx - 1]
+                for idx in range(1, 7)
+            },
+        }
+    ).to_parquet(path, index=False, engine="pyarrow", compression="snappy")
+
+
+def _write_viewer_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "index.html").write_text("<!doctype html><title>viewer</title>", encoding="utf-8")
+
+
+def _http_json(url: str, *, method: str = "GET", payload: dict[str, object] | None = None) -> dict[str, object]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # pragma: no cover
+        body = exc.read().decode("utf-8")
+        raise AssertionError(f"HTTP {exc.code}: {body}") from exc
+
+
+def _start_server(module, tmp_path: Path):
+    viewer_dir = tmp_path / "viewer"
+    canonical_dir = tmp_path / "data" / "processed" / "canonical_1s"
+    transpiration_dir = tmp_path / "data" / "processed" / "transpiration_1m"
+    marker_dir = tmp_path / "data" / "processed" / "_batch_markers"
+    final_dir = tmp_path / "data" / "final"
+    for directory in (canonical_dir, transpiration_dir, marker_dir, final_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+    _write_viewer_dir(viewer_dir)
+    _write_canonical_day(canonical_dir / "2025-01-01_canonical_1s.parquet")
+    _write_transpiration_day(
+        transpiration_dir / "2025-01-01__transpiration_1m__diff60__g_min_per_plant__p3.parquet"
+    )
+    server = module.create_server(
+        bind="127.0.0.1",
+        port=0,
+        viewer_dir=viewer_dir,
+        canonical_dir=canonical_dir,
+        transpiration_1m_dir=transpiration_dir,
+        final_dir=final_dir,
+        marker_dir=marker_dir,
+        repo_root=tmp_path,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+    return server, thread, base_url, {
+        "viewer_dir": viewer_dir,
+        "canonical_dir": canonical_dir,
+        "transpiration_dir": transpiration_dir,
+        "final_dir": final_dir,
+        "marker_dir": marker_dir,
+    }
+
+
+def test_safe_path_under_rejects_escape(tmp_path: Path) -> None:
+    module = _load_script_module()
+
+    assert module._safe_path_under(tmp_path, "data/final") == (tmp_path / "data" / "final").resolve()
+    with pytest.raises(ValueError, match="final_dir must be under repo root"):
+        module._safe_path_under(tmp_path, "..")
+
+
+def test_build_parser_defaults_match_legacy_server_paths() -> None:
+    module = _load_script_module()
+    args = module.build_parser().parse_args([])
+
+    assert args.viewer_dir == Path("artifacts/preprocess_compare")
+    assert args.canonical_dir == Path("data/processed/canonical_1s")
+    assert args.transpiration_1m_dir == Path("data/processed/transpiration_1m")
+    assert args.final_dir == Path("data/final")
+    assert args.marker_dir == Path("data/processed/_batch_markers")
+    assert args.bind == "127.0.0.1"
+    assert args.port == 8000
+
+
+def test_compute_transpiration_prefers_existing_one_minute_artifact(tmp_path: Path) -> None:
+    module = _load_script_module()
+    canonical_path = tmp_path / "2025-01-01_canonical_1s.parquet"
+    transpiration_dir = tmp_path / "transpiration_1m"
+    transpiration_dir.mkdir()
+    _write_canonical_day(canonical_path)
+    transpiration_path = (
+        transpiration_dir / "2025-01-01__transpiration_1m__diff60__g_min_per_plant__p3.parquet"
+    )
+    _write_transpiration_day(transpiration_path, value=8.5)
+
+    out_df, meta = module._compute_transpiration(
+        canonical_path=canonical_path,
+        transpiration_1m_dir=transpiration_dir,
+        date="2025-01-01",
+        method="diff60_1m",
+        resolution="1m",
+        plants_per_loadcell=3,
+        ma_window_sec=60,
+        reg_window_sec=300,
+        cap_g_min_per_plant=None,
+    )
+
+    assert meta["source_transpiration_1m"] == str(transpiration_path)
+    assert float(out_df["loadcell_1_transpiration_g_min_per_plant"].iloc[0]) == pytest.approx(8.5)
+
+
+def test_compute_transpiration_regression_supports_one_second_cap(tmp_path: Path) -> None:
+    module = _load_script_module()
+    canonical_path = tmp_path / "2025-01-01_canonical_1s.parquet"
+    _write_canonical_day(canonical_path)
+
+    out_df, meta = module._compute_transpiration(
+        canonical_path=canonical_path,
+        transpiration_1m_dir=tmp_path / "missing",
+        date="2025-01-01",
+        method="reg_1s",
+        resolution="1s",
+        plants_per_loadcell=3,
+        ma_window_sec=60,
+        reg_window_sec=5,
+        cap_g_min_per_plant=5.0,
+    )
+
+    assert meta["method"] == "reg_1s"
+    assert meta["resolution"] == "1s"
+    assert len(out_df) == 61
+    assert float(out_df["loadcell_1_transpiration_g_min_per_plant"].max()) <= 5.0
+
+
+def test_server_health_and_export_api_write_final_outputs(tmp_path: Path) -> None:
+    module = _load_script_module()
+    server, thread, base_url, paths = _start_server(module, tmp_path)
+    try:
+        health = _http_json(f"{base_url}/api/health")
+        export = _http_json(
+            f"{base_url}/api/export",
+            method="POST",
+            payload={
+                "date": "2025-01-01",
+                "method": "diff60_1m",
+                "resolution": "1m",
+                "plants_per_loadcell": 3,
+                "final_dir": "data/final",
+            },
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    out_path = Path(str(export["path"]))
+    meta_path = out_path.with_name(f"{out_path.stem}__meta.json")
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert health["ok"] is True
+    assert health["final_dir"] == str(paths["final_dir"].resolve())
+    assert export["ok"] is True
+    assert out_path.exists()
+    assert meta["method"] == "diff60_1m"
+    assert meta["resolution"] == "1m"
+    assert meta["source_transpiration_1m"] == str(
+        (
+            paths["transpiration_dir"]
+            / "2025-01-01__transpiration_1m__diff60__g_min_per_plant__p3.parquet"
+        ).resolve()
+    )
+
+
+def test_server_preprocess_endpoints_track_status_and_cancel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module()
+    server, thread, base_url, _ = _start_server(module, tmp_path)
+    (tmp_path / "data" / "raw").mkdir(parents=True, exist_ok=True)
+
+    def fake_run_incremental_preprocess(cfg, *, log, should_cancel=None):
+        log(f"[info] fake preprocess {cfg.raw_pattern}")
+        while should_cancel is not None and not should_cancel():
+            time.sleep(0.02)
+        log("[warn] fake cancel observed")
+        return module.pp.PreprocessResult(
+            raw_total=1,
+            raw_skipped=0,
+            raw_processed=1,
+            raw_failed=0,
+            updated_dates=["2025-01-01"],
+        )
+
+    monkeypatch.setattr(module.pp, "run_incremental_preprocess", fake_run_incremental_preprocess)
+
+    try:
+        started = _http_json(
+            f"{base_url}/api/preprocess",
+            method="POST",
+            payload={"raw_dir": "data/raw", "pattern": "ALMEMO500~*.csv"},
+        )
+        already_running = _http_json(
+            f"{base_url}/api/preprocess",
+            method="POST",
+            payload={"raw_dir": "data/raw"},
+        )
+        status = _http_json(f"{base_url}/api/preprocess/status")
+        canceled = _http_json(f"{base_url}/api/preprocess/cancel", method="POST", payload={})
+
+        deadline = time.time() + 3.0
+        final_status = status
+        while time.time() < deadline:
+            final_status = _http_json(f"{base_url}/api/preprocess/status")
+            if not final_status["state"]["running"]:
+                break
+            time.sleep(0.05)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert started["started"] is True
+    assert already_running["started"] is False
+    assert status["state"]["running"] is True
+    assert canceled["ok"] is True
+    assert final_status["state"]["phase"] == "done"
+    assert final_status["state"]["result"]["updated_dates"] == ["2025-01-01"]
+    log_tail = "\n".join(final_status["state"]["log_tail"])
+    assert "cancel requested" in log_tail
+    assert "fake cancel observed" in log_tail
+
+
+def test_main_dispatches_cli_arguments(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    viewer_dir = tmp_path / "viewer"
+    canonical_dir = tmp_path / "canonical"
+    transpiration_dir = tmp_path / "transpiration_1m"
+    final_dir = tmp_path / "final"
+    marker_dir = tmp_path / "markers"
+    _write_viewer_dir(viewer_dir)
+    canonical_dir.mkdir()
+    captures: dict[str, object] = {}
+
+    class FakeServer:
+        server_address = ("127.0.0.1", 8123)
+
+        def __init__(self) -> None:
+            self.preprocess_compare_state = {"final_dir": final_dir.resolve()}
+
+        def serve_forever(self) -> None:
+            return None
+
+        def server_close(self) -> None:
+            return None
+
+    def fake_create_server(**kwargs):
+        captures.update(kwargs)
+        return FakeServer()
+
+    monkeypatch.setattr(module, "create_server", fake_create_server)
+
+    result = module.main(
+        [
+            "--viewer-dir",
+            str(viewer_dir),
+            "--canonical-dir",
+            str(canonical_dir),
+            "--transpiration-1m-dir",
+            str(transpiration_dir),
+            "--final-dir",
+            str(final_dir),
+            "--marker-dir",
+            str(marker_dir),
+            "--bind",
+            "0.0.0.0",
+            "--port",
+            "9001",
+        ]
+    )
+
+    assert result == 0
+    assert captures == {
+        "bind": "0.0.0.0",
+        "port": 9001,
+        "viewer_dir": viewer_dir,
+        "canonical_dir": canonical_dir,
+        "transpiration_1m_dir": transpiration_dir,
+        "final_dir": final_dir,
+        "marker_dir": marker_dir,
+        "repo_root": module.PROJECT_ROOT,
+    }


### PR DESCRIPTION
## Summary
- migrate the `load-cell-data` preprocess-compare local server into `scripts/preprocess_compare_server.py`
- preserve export computation, preprocess job state handling, static serving, and repo-level CLI wiring
- move the next remaining `load-cell-data` seam to the static viewer builder

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #117
