### PR TITLE
[Model Change] Migrate THORP stable sim runner seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -29,4 +29,5 @@ Current status:
 - Slice 060 migrated: `load-cell-data` incremental preprocess harness seam
 - Slice 061 migrated: `load-cell-data` preprocess-compare local server seam
 - Slice 062 migrated: `load-cell-data` static preprocess-compare viewer seam
-- Next blocked seam: post-`load-cell-data` workspace re-audit to select the next bounded legacy seam
+- Slice 063 migrated: THORP stable `sim` runner seam
+- Next blocked seam: THORP equation-registry seam at `THORP/src/thorp/equation_registry.py`

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ poetry run ruff check .
 - `load-cell-data` incremental preprocess harness seam is migrated as slice 060.
 - `load-cell-data` preprocess-compare local server seam is migrated as slice 061.
 - `load-cell-data` static preprocess-compare viewer seam is migrated as slice 062.
+- THORP stable `sim` runner seam is migrated as slice 063.
 
 ## Next validation
-- Re-audit the remaining legacy workspace outside `load-cell-data/src/` to select the next bounded seam.
+- Audit the THORP equation-registry seam at `THORP/src/thorp/equation_registry.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 061
-- Gate D. Bounded slices 001 through 024 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 063
+- Gate D. Bounded slices 001 through 024 plus slice 063 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -419,3 +419,9 @@ Slice 062:
 - target: `scripts/build_preprocess_compare_viewer.py` and `tests/test_load_cell_build_preprocess_compare_viewer_script.py`
 - scope: bounded `load-cell-data` static viewer-builder surface covering canonical day discovery, transpiration fallback loading, static asset writing, and per-day JSON generation
 - excluded: broader UI redesign, new frontend packaging, and next-domain seam selection
+
+Slice 063:
+- source: `THORP/src/thorp/sim/{runner.py,__init__.py}`
+- target: `src/stomatal_optimiaztion/domains/thorp/sim/` and `tests/test_thorp_sim_runner.py`
+- scope: bounded THORP compatibility surface covering the stable `thorp.sim.run` wrapper import path and passthrough delegation to the migrated simulation runtime
+- excluded: THORP equation-registry imports, package-wide export redesign, and numerical runtime changes

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -540,8 +540,16 @@ The sixty-second slice closes the remaining bounded `load-cell-data/src` seam:
 - keep the seam viewer-builder-bounded without widening into a new frontend architecture or a second server framework
 - leave post-`load-cell-data` workspace re-audit blocked as the next step
 
+## Slice 063: THORP Stable Sim Runner
+
+The sixty-third slice opens the next bounded THORP compatibility seam:
+- move `THORP/src/thorp/sim/runner.py` and `THORP/src/thorp/sim/__init__.py` into the staged `domains/thorp/sim/` package
+- preserve the stable `thorp.sim.run` wrapper import surface over the already migrated simulation runtime
+- keep the seam wrapper-bounded without widening into THORP numerical kernels or package-wide export redesign
+- leave `THORP/src/thorp/equation_registry.py` blocked as the next seam
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare a post-`load-cell-data` workspace-audit delta to select the next bounded seam
+3. prepare the next THORP compatibility audit for `THORP/src/thorp/equation_registry.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 062 completed and post-load-cell re-audit planning
+- Current phase: slice 063 completed and THORP compatibility planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the legacy `load-cell-data/src/` source wave is closed after migrating `build_preprocess_compare_viewer.py`
-2. run a post-`load-cell-data` workspace audit to identify the next bounded seam across the remaining legacy sources
-3. prepare the next module spec only after the next non-`load-cell-data` seam is explicitly selected
+1. confirm the THORP stable `sim` wrapper surface is closed after migrating `thorp.sim.run`
+2. audit `THORP/src/thorp/equation_registry.py` as the next bounded compatibility seam
+3. prepare the next module spec only after the equation-registry import surface is scoped against the existing traceability helpers

--- a/docs/architecture/architecture/module_specs/module-063-thorp-stable-sim-runner.md
+++ b/docs/architecture/architecture/module_specs/module-063-thorp-stable-sim-runner.md
@@ -1,0 +1,37 @@
+# Module Spec 063: THORP Stable Sim Runner
+
+## Purpose
+
+Open the next bounded THORP compatibility seam by porting the stable `thorp.sim.run` wrapper surface over the already migrated simulation runtime.
+
+## Source Inputs
+
+- `THORP/src/thorp/sim/runner.py`
+- `THORP/src/thorp/sim/__init__.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/sim/runner.py`
+- `src/stomatal_optimiaztion/domains/thorp/sim/__init__.py`
+- `tests/test_thorp_sim_runner.py`
+
+## Responsibilities
+
+1. preserve the package-local `thorp.sim.run` import surface
+2. preserve passthrough delegation to the migrated simulation runtime without changing behavior
+3. keep the seam wrapper-bounded instead of reopening THORP numerical kernels or package-wide export redesign
+
+## Non-Goals
+
+- redesign `domains.thorp.simulation.run()`
+- widen the THORP package export surface in the same slice
+- migrate `THORP/src/thorp/equation_registry.py` in the same slice
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `THORP/src/thorp/equation_registry.py`

--- a/docs/architecture/executor/issue-121-model-change.md
+++ b/docs/architecture/executor/issue-121-model-change.md
@@ -1,0 +1,20 @@
+## Why
+- `load-cell-data` source wave closed at `slice 062`, so the next smallest remaining legacy runtime surface sits in `THORP/src/thorp/sim/runner.py`.
+- The migrated repo already exposes `domains.thorp.simulation.run`, but it does not yet preserve the refactor-friendly stable wrapper import path `domains.thorp.sim.run`.
+- This slice should stay wrapper-bounded: package-local `sim` namespace, stable `runner.run()` delegation, and import-compatibility regression coverage only.
+
+## Affected model
+- `thorp`
+- `src/stomatal_optimiaztion/domains/thorp/sim/`
+- THORP wrapper/import compatibility tests
+- architecture docs for the next THORP compatibility seam
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for `thorp.sim.run` delegation, passthrough arguments, and package import surface stability
+
+## Comparison target
+- legacy `THORP/src/thorp/sim/runner.py`
+- legacy `THORP/src/thorp/sim/__init__.py`
+- current migrated `src/stomatal_optimiaztion/domains/thorp/simulation.py`

--- a/docs/architecture/executor/pr-121-thorp-stable-sim-runner.md
+++ b/docs/architecture/executor/pr-121-thorp-stable-sim-runner.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the legacy THORP stable `sim` wrapper into `src/stomatal_optimiaztion/domains/thorp/sim/`
+- preserve `thorp.sim.run` passthrough behavior over the migrated simulation runtime
+- move the next bounded THORP compatibility seam to `THORP/src/thorp/equation_registry.py`
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #121

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | The next bounded seam after the completed `load-cell-data` source wave is not yet selected | Recursive slice flow can stall now that the remaining `load-cell-data/src` viewer builder is migrated but the next cross-domain target is still unset | workspace-audit delta plus next module spec |
+| GAP-002 | THORP compatibility imports still miss the legacy equation-registry module surface | Traceability helpers exist, but callers that expect the explicit `equation_registry` module path still have no migrated seam | next THORP module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/sim/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/sim/__init__.py
@@ -1,0 +1,7 @@
+"""Simulation entrypoints (refactor-friendly wrapper layer)."""
+
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.thorp.sim.runner import run
+
+__all__ = ["run"]

--- a/src/stomatal_optimiaztion/domains/thorp/sim/runner.py
+++ b/src/stomatal_optimiaztion/domains/thorp/sim/runner.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.thorp.forcing import Forcing
+from stomatal_optimiaztion.domains.thorp.params import THORPParams
+from stomatal_optimiaztion.domains.thorp.simulation import SimulationOutputs
+from stomatal_optimiaztion.domains.thorp.simulation import run as _baseline_run
+
+
+def run(
+    params: THORPParams | None = None,
+    *,
+    forcing: Forcing | None = None,
+    max_steps: int | None = None,
+    save_mat_path: str | Path | None = None,
+) -> SimulationOutputs:
+    """Run THORP simulation through the stable refactor-friendly wrapper surface."""
+
+    return _baseline_run(
+        params=params,
+        forcing=forcing,
+        max_steps=max_steps,
+        save_mat_path=save_mat_path,
+    )

--- a/tests/test_thorp_sim_runner.py
+++ b/tests/test_thorp_sim_runner.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import stomatal_optimiaztion.domains.thorp.sim as sim_pkg
+import stomatal_optimiaztion.domains.thorp.sim.runner as runner
+
+
+def test_runner_run_delegates_to_simulation_run(monkeypatch) -> None:
+    captures: dict[str, object] = {}
+    sentinel = object()
+
+    def fake_run(*, params, forcing, max_steps, save_mat_path):
+        captures["params"] = params
+        captures["forcing"] = forcing
+        captures["max_steps"] = max_steps
+        captures["save_mat_path"] = save_mat_path
+        return sentinel
+
+    monkeypatch.setattr(runner, "_baseline_run", fake_run)
+
+    params = object()
+    forcing = object()
+    result = runner.run(
+        params=params,  # type: ignore[arg-type]
+        forcing=forcing,  # type: ignore[arg-type]
+        max_steps=7,
+        save_mat_path=Path("out.mat"),
+    )
+
+    assert result is sentinel
+    assert captures == {
+        "params": params,
+        "forcing": forcing,
+        "max_steps": 7,
+        "save_mat_path": Path("out.mat"),
+    }
+
+
+def test_sim_package_reexports_runner_run() -> None:
+    assert sim_pkg.run is runner.run


### PR DESCRIPTION
## Summary
- migrate the legacy THORP stable `sim` wrapper into `src/stomatal_optimiaztion/domains/thorp/sim/`
- preserve `thorp.sim.run` passthrough behavior over the migrated simulation runtime
- move the next bounded THORP compatibility seam to `THORP/src/thorp/equation_registry.py`

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #121
