### PR TITLE
[Model Change] Migrate THORP equation registry seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -30,4 +30,5 @@ Current status:
 - Slice 061 migrated: `load-cell-data` preprocess-compare local server seam
 - Slice 062 migrated: `load-cell-data` static preprocess-compare viewer seam
 - Slice 063 migrated: THORP stable `sim` runner seam
-- Next blocked seam: THORP equation-registry seam at `THORP/src/thorp/equation_registry.py`
+- Slice 064 migrated: THORP equation-registry seam
+- Next blocked seam: THORP utilities namespace seam at `THORP/src/thorp/utils/__init__.py`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ poetry run ruff check .
 - `load-cell-data` preprocess-compare local server seam is migrated as slice 061.
 - `load-cell-data` static preprocess-compare viewer seam is migrated as slice 062.
 - THORP stable `sim` runner seam is migrated as slice 063.
+- THORP equation-registry seam is migrated as slice 064.
 
 ## Next validation
-- Audit the THORP equation-registry seam at `THORP/src/thorp/equation_registry.py`.
+- Audit the THORP utilities namespace seam at `THORP/src/thorp/utils/__init__.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 063
-- Gate D. Bounded slices 001 through 024 plus slice 063 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 064
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 064 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -425,3 +425,9 @@ Slice 063:
 - target: `src/stomatal_optimiaztion/domains/thorp/sim/` and `tests/test_thorp_sim_runner.py`
 - scope: bounded THORP compatibility surface covering the stable `thorp.sim.run` wrapper import path and passthrough delegation to the migrated simulation runtime
 - excluded: THORP equation-registry imports, package-wide export redesign, and numerical runtime changes
+
+Slice 064:
+- source: `THORP/src/thorp/equation_registry.py`
+- target: `src/stomatal_optimiaztion/domains/thorp/equation_registry.py` and `tests/test_thorp_equation_registry.py`
+- scope: bounded THORP compatibility surface covering module-bound annotated-callable discovery and equation-mapping construction over migrated runtime modules
+- excluded: THORP utilities namespace wrappers, package-wide export redesign, and numerical runtime changes

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -548,8 +548,16 @@ The sixty-third slice opens the next bounded THORP compatibility seam:
 - keep the seam wrapper-bounded without widening into THORP numerical kernels or package-wide export redesign
 - leave `THORP/src/thorp/equation_registry.py` blocked as the next seam
 
+## Slice 064: THORP Equation Registry
+
+The sixty-fourth slice opens the next bounded THORP compatibility seam:
+- move `THORP/src/thorp/equation_registry.py` into the staged `domains/thorp/` package
+- preserve module-bound annotated-callable discovery and one-call equation mapping over the migrated THORP runtime modules
+- keep the seam compatibility-bounded without redesigning the existing traceability helper layer
+- leave `THORP/src/thorp/utils/__init__.py` blocked as the next seam
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP compatibility audit for `THORP/src/thorp/equation_registry.py`
+3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/utils/__init__.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 063 completed and THORP compatibility planning
+- Current phase: slice 064 completed and THORP namespace-wrapper planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP stable `sim` wrapper surface is closed after migrating `thorp.sim.run`
-2. audit `THORP/src/thorp/equation_registry.py` as the next bounded compatibility seam
-3. prepare the next module spec only after the equation-registry import surface is scoped against the existing traceability helpers
+1. confirm the THORP equation-registry surface is closed after migrating `equation_registry.py`
+2. audit `THORP/src/thorp/utils/__init__.py` as the next bounded namespace-wrapper seam
+3. prepare the next module spec only after the utilities wrapper is scoped against the existing traceability and model-card helpers

--- a/docs/architecture/architecture/module_specs/module-064-thorp-equation-registry.md
+++ b/docs/architecture/architecture/module_specs/module-064-thorp-equation-registry.md
@@ -1,0 +1,35 @@
+# Module Spec 064: THORP Equation Registry
+
+## Purpose
+
+Open the next bounded THORP compatibility seam by restoring the explicit `equation_registry` module path over the already migrated traceability helpers and annotated runtime modules.
+
+## Source Inputs
+
+- `THORP/src/thorp/equation_registry.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/equation_registry.py`
+- `tests/test_thorp_equation_registry.py`
+
+## Responsibilities
+
+1. preserve module-bound annotated-callable discovery across migrated THORP runtime modules
+2. preserve one-call mapping construction without caller-provided namespaces
+3. keep the seam compatibility-bounded instead of redesigning the traceability helper layer
+
+## Non-Goals
+
+- redesign `traceability.py` or `implements.py`
+- widen the THORP root package exports in the same slice
+- migrate the `THORP/src/thorp/utils/__init__.py` namespace wrapper in the same slice
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `THORP/src/thorp/utils/__init__.py`

--- a/docs/architecture/executor/issue-123-model-change.md
+++ b/docs/architecture/executor/issue-123-model-change.md
@@ -1,0 +1,20 @@
+## Why
+- `slice 063` restored the stable `thorp.sim.run` wrapper path, so the next smallest remaining THORP compatibility seam is `THORP/src/thorp/equation_registry.py`.
+- The migrated repo already has generic traceability helpers, but it still lacks the explicit legacy module path that binds THORP modules and builds the equation-to-callable mapping without caller-provided namespaces.
+- This slice should stay compatibility-bounded: module-bound annotated-callable discovery, mapping construction, and regression coverage only.
+
+## Affected model
+- `thorp`
+- `src/stomatal_optimiaztion/domains/thorp/equation_registry.py`
+- THORP traceability compatibility tests
+- architecture docs for the next THORP package-surface seam
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for module-bound annotated-callable discovery and equation-mapping output over migrated THORP modules
+
+## Comparison target
+- legacy `THORP/src/thorp/equation_registry.py`
+- current migrated `src/stomatal_optimiaztion/domains/thorp/traceability.py`
+- current migrated THORP runtime modules with `@implements(...)` annotations

--- a/docs/architecture/executor/pr-123-thorp-equation-registry.md
+++ b/docs/architecture/executor/pr-123-thorp-equation-registry.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the legacy THORP `equation_registry` module into `src/stomatal_optimiaztion/domains/thorp/equation_registry.py`
+- preserve module-bound annotated-callable discovery and equation mapping over migrated THORP runtime modules
+- move the next bounded THORP compatibility seam to `THORP/src/thorp/utils/__init__.py`
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #123

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | THORP compatibility imports still miss the legacy equation-registry module surface | Traceability helpers exist, but callers that expect the explicit `equation_registry` module path still have no migrated seam | next THORP module spec |
+| GAP-002 | THORP namespace wrappers are still incomplete after the restored equation-registry path | Compatibility callers may still miss legacy `utils`, `io`, `model`, or `params` package-level import surfaces | next THORP namespace-wrapper module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/equation_registry.py
+++ b/src/stomatal_optimiaztion/domains/thorp/equation_registry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Iterable
+
+from stomatal_optimiaztion.domains.thorp.traceability import (
+    EquationMapping,
+    build_mapping as _build_mapping,
+    iter_annotated_callables as _iter_annotated_callables,
+)
+
+_MODULES = [
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.soil_hydraulics"),
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.soil_initialization"),
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.soil_dynamics"),
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.hydraulics"),
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.allocation"),
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.growth"),
+    importlib.import_module("stomatal_optimiaztion.domains.thorp.radiation"),
+]
+
+
+def iter_annotated_callables() -> Iterable[Callable[..., object]]:
+    for module in _MODULES:
+        yield from _iter_annotated_callables(vars(module))
+
+
+def build_mapping() -> EquationMapping:
+    return _build_mapping(iter_annotated_callables())
+
+
+__all__ = ["EquationMapping", "build_mapping", "iter_annotated_callables"]

--- a/tests/test_thorp_equation_registry.py
+++ b/tests/test_thorp_equation_registry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.thorp.equation_registry import (
+    build_mapping,
+    iter_annotated_callables,
+)
+
+
+def test_iter_annotated_callables_discovers_migrated_thorp_runtime_functions() -> None:
+    discovered = {callable_obj.__qualname__ for callable_obj in iter_annotated_callables()}
+
+    assert any(name.endswith("radiation") for name in discovered)
+    assert any(name.endswith("stomata") for name in discovered)
+    assert any(name.endswith("SoilHydraulics.k_s") for name in discovered)
+
+
+def test_build_mapping_groups_equations_for_migrated_thorp_modules() -> None:
+    mapping = build_mapping()
+
+    assert "E_S5_1" in mapping.equation_to_callables
+    assert any(
+        name.endswith("radiation") for name in mapping.equation_to_callables["E_S5_1"]
+    )
+    assert "E_S2_4" in mapping.equation_to_callables
+    assert any(
+        name.endswith("SoilHydraulics.k_s")
+        for name in mapping.equation_to_callables["E_S2_4"]
+    )


### PR DESCRIPTION
## Summary
- migrate the legacy THORP `equation_registry` module into `src/stomatal_optimiaztion/domains/thorp/equation_registry.py`
- preserve module-bound annotated-callable discovery and equation mapping over migrated THORP runtime modules
- move the next bounded THORP compatibility seam to `THORP/src/thorp/utils/__init__.py`

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #123
