### PR TITLE
[Model Change] Migrate THORP utilities namespace seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -31,4 +31,5 @@ Current status:
 - Slice 062 migrated: `load-cell-data` static preprocess-compare viewer seam
 - Slice 063 migrated: THORP stable `sim` runner seam
 - Slice 064 migrated: THORP equation-registry seam
-- Next blocked seam: THORP utilities namespace seam at `THORP/src/thorp/utils/__init__.py`
+- Slice 065 migrated: THORP utilities namespace seam
+- Next blocked seam: THORP IO namespace seam at `THORP/src/thorp/io/__init__.py`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ poetry run ruff check .
 - `load-cell-data` static preprocess-compare viewer seam is migrated as slice 062.
 - THORP stable `sim` runner seam is migrated as slice 063.
 - THORP equation-registry seam is migrated as slice 064.
+- THORP utilities namespace seam is migrated as slice 065.
 
 ## Next validation
-- Audit the THORP utilities namespace seam at `THORP/src/thorp/utils/__init__.py`.
+- Audit the THORP IO namespace seam at `THORP/src/thorp/io/__init__.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 064
-- Gate D. Bounded slices 001 through 024 plus slices 063 through 064 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 065
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 065 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -431,3 +431,9 @@ Slice 064:
 - target: `src/stomatal_optimiaztion/domains/thorp/equation_registry.py` and `tests/test_thorp_equation_registry.py`
 - scope: bounded THORP compatibility surface covering module-bound annotated-callable discovery and equation-mapping construction over migrated runtime modules
 - excluded: THORP utilities namespace wrappers, package-wide export redesign, and numerical runtime changes
+
+Slice 065:
+- source: `THORP/src/thorp/utils/__init__.py`
+- target: `src/stomatal_optimiaztion/domains/thorp/utils/__init__.py` and `tests/test_thorp_utils_namespace.py`
+- scope: bounded THORP namespace-wrapper surface covering grouped traceability and model-card helper re-exports
+- excluded: THORP IO/model namespace wrappers, root package export redesign, and numerical runtime changes

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -556,8 +556,16 @@ The sixty-fourth slice opens the next bounded THORP compatibility seam:
 - keep the seam compatibility-bounded without redesigning the existing traceability helper layer
 - leave `THORP/src/thorp/utils/__init__.py` blocked as the next seam
 
+## Slice 065: THORP Utilities Namespace
+
+The sixty-fifth slice opens the next bounded THORP namespace-wrapper seam:
+- move `THORP/src/thorp/utils/__init__.py` into the staged `domains/thorp/utils/` package
+- preserve the grouped convenience imports for equation-registry, implements, and model-card helpers
+- keep the seam wrapper-bounded without widening into new shared utility abstractions
+- leave `THORP/src/thorp/io/__init__.py` blocked as the next seam
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/utils/__init__.py`
+3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/io/__init__.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 064 completed and THORP namespace-wrapper planning
+- Current phase: slice 065 completed and THORP namespace-wrapper planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP equation-registry surface is closed after migrating `equation_registry.py`
-2. audit `THORP/src/thorp/utils/__init__.py` as the next bounded namespace-wrapper seam
-3. prepare the next module spec only after the utilities wrapper is scoped against the existing traceability and model-card helpers
+1. confirm the THORP `utils` namespace surface is closed after migrating `utils/__init__.py`
+2. audit `THORP/src/thorp/io/__init__.py` as the next bounded namespace-wrapper seam
+3. prepare the next module spec only after the IO wrapper is scoped against the existing forcing and MATLAB helpers

--- a/docs/architecture/architecture/module_specs/module-065-thorp-utilities-namespace.md
+++ b/docs/architecture/architecture/module_specs/module-065-thorp-utilities-namespace.md
@@ -1,0 +1,35 @@
+# Module Spec 065: THORP Utilities Namespace
+
+## Purpose
+
+Open the next bounded THORP namespace-wrapper seam by restoring the legacy `thorp.utils` convenience import surface over the already migrated traceability and model-card helpers.
+
+## Source Inputs
+
+- `THORP/src/thorp/utils/__init__.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/utils/__init__.py`
+- `tests/test_thorp_utils_namespace.py`
+
+## Responsibilities
+
+1. preserve the `thorp.utils` grouped import surface for equation-registry, implements, and model-card helpers
+2. preserve symbol identity instead of wrapping or redefining existing helpers
+3. keep the seam namespace-wrapper-bounded instead of widening into new shared utility abstractions
+
+## Non-Goals
+
+- redesign `equation_registry.py`, `implements.py`, or `model_card.py`
+- widen the THORP root package exports in the same slice
+- migrate the `THORP/src/thorp/io/__init__.py` namespace wrapper in the same slice
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `THORP/src/thorp/io/__init__.py`

--- a/docs/architecture/executor/issue-125-model-change.md
+++ b/docs/architecture/executor/issue-125-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 064` restored the explicit THORP equation-registry module path, so the next smallest namespace-wrapper seam is `THORP/src/thorp/utils/__init__.py`.
+- The migrated repo has the underlying traceability and model-card helpers, but it still lacks the legacy convenience import surface that groups them under `thorp.utils`.
+- This slice should stay namespace-wrapper-bounded: symbol re-exports, import compatibility regression coverage, and architecture records only.
+
+## Affected model
+- `thorp`
+- `src/stomatal_optimiaztion/domains/thorp/utils/`
+- THORP namespace-wrapper tests
+- architecture docs for the next THORP wrapper seam
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for `thorp.utils` symbol identity over equation registry, implements, and model-card helpers
+
+## Comparison target
+- legacy `THORP/src/thorp/utils/__init__.py`
+- current migrated `src/stomatal_optimiaztion/domains/thorp/{equation_registry.py,implements.py,model_card.py}`

--- a/docs/architecture/executor/pr-125-thorp-utilities-namespace.md
+++ b/docs/architecture/executor/pr-125-thorp-utilities-namespace.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the legacy THORP `utils` namespace wrapper into `src/stomatal_optimiaztion/domains/thorp/utils/__init__.py`
+- preserve grouped imports for equation-registry, implements, and model-card helpers without redefining them
+- move the next bounded THORP namespace-wrapper seam to `THORP/src/thorp/io/__init__.py`
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #125

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | THORP namespace wrappers are still incomplete after the restored equation-registry path | Compatibility callers may still miss legacy `utils`, `io`, `model`, or `params` package-level import surfaces | next THORP namespace-wrapper module spec |
+| GAP-002 | THORP namespace wrappers are still incomplete after the restored `utils` path | Compatibility callers may still miss legacy `io`, `model`, or broadened `params` package-level import surfaces | next THORP namespace-wrapper module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/utils/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/utils/__init__.py
@@ -1,0 +1,33 @@
+"""Utilities for model-card traceability and equation registry."""
+
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.thorp.equation_registry import (
+    EquationMapping,
+    build_mapping,
+    iter_annotated_callables,
+)
+from stomatal_optimiaztion.domains.thorp.implements import (
+    implemented_equations,
+    implements,
+    qualname,
+)
+from stomatal_optimiaztion.domains.thorp.model_card import (
+    equation_id_set,
+    iter_equation_refs,
+    model_card_dir,
+    require_equation_ids,
+)
+
+__all__ = [
+    "EquationMapping",
+    "build_mapping",
+    "equation_id_set",
+    "implemented_equations",
+    "implements",
+    "iter_annotated_callables",
+    "iter_equation_refs",
+    "model_card_dir",
+    "qualname",
+    "require_equation_ids",
+]

--- a/tests/test_thorp_utils_namespace.py
+++ b/tests/test_thorp_utils_namespace.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.thorp.equation_registry import (
+    EquationMapping,
+    build_mapping,
+    iter_annotated_callables,
+)
+from stomatal_optimiaztion.domains.thorp.implements import (
+    implemented_equations,
+    implements,
+    qualname,
+)
+from stomatal_optimiaztion.domains.thorp.model_card import (
+    equation_id_set,
+    iter_equation_refs,
+    model_card_dir,
+    require_equation_ids,
+)
+from stomatal_optimiaztion.domains.thorp.utils import (
+    EquationMapping as NamespaceEquationMapping,
+)
+from stomatal_optimiaztion.domains.thorp.utils import (
+    build_mapping as namespace_build_mapping,
+)
+from stomatal_optimiaztion.domains.thorp.utils import (
+    equation_id_set as namespace_equation_id_set,
+)
+from stomatal_optimiaztion.domains.thorp.utils import (
+    implemented_equations as namespace_implemented_equations,
+)
+from stomatal_optimiaztion.domains.thorp.utils import implements as namespace_implements
+from stomatal_optimiaztion.domains.thorp.utils import (
+    iter_annotated_callables as namespace_iter_annotated_callables,
+)
+from stomatal_optimiaztion.domains.thorp.utils import (
+    iter_equation_refs as namespace_iter_equation_refs,
+)
+from stomatal_optimiaztion.domains.thorp.utils import model_card_dir as namespace_model_card_dir
+from stomatal_optimiaztion.domains.thorp.utils import qualname as namespace_qualname
+from stomatal_optimiaztion.domains.thorp.utils import (
+    require_equation_ids as namespace_require_equation_ids,
+)
+
+
+def test_utils_namespace_reexports_traceability_and_model_card_helpers() -> None:
+    assert NamespaceEquationMapping is EquationMapping
+    assert namespace_build_mapping is build_mapping
+    assert namespace_iter_annotated_callables is iter_annotated_callables
+    assert namespace_implemented_equations is implemented_equations
+    assert namespace_implements is implements
+    assert namespace_qualname is qualname
+    assert namespace_equation_id_set is equation_id_set
+    assert namespace_iter_equation_refs is iter_equation_refs
+    assert namespace_model_card_dir is model_card_dir
+    assert namespace_require_equation_ids is require_equation_ids


### PR DESCRIPTION
## Summary
- migrate the legacy THORP `utils` namespace wrapper into `src/stomatal_optimiaztion/domains/thorp/utils/__init__.py`
- preserve grouped imports for equation-registry, implements, and model-card helpers without redefining them
- move the next bounded THORP namespace-wrapper seam to `THORP/src/thorp/io/__init__.py`

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #125
