### PR TITLE
[Model Change] Migrate THORP IO namespace seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -32,4 +32,5 @@ Current status:
 - Slice 063 migrated: THORP stable `sim` runner seam
 - Slice 064 migrated: THORP equation-registry seam
 - Slice 065 migrated: THORP utilities namespace seam
-- Next blocked seam: THORP IO namespace seam at `THORP/src/thorp/io/__init__.py`
+- Slice 066 migrated: THORP IO namespace seam
+- Next blocked seam: THORP model namespace seam at `THORP/src/thorp/model/__init__.py`

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ poetry run ruff check .
 - THORP stable `sim` runner seam is migrated as slice 063.
 - THORP equation-registry seam is migrated as slice 064.
 - THORP utilities namespace seam is migrated as slice 065.
+- THORP IO namespace seam is migrated as slice 066.
 
 ## Next validation
-- Audit the THORP IO namespace seam at `THORP/src/thorp/io/__init__.py`.
+- Audit the THORP model namespace seam at `THORP/src/thorp/model/__init__.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 065
-- Gate D. Bounded slices 001 through 024 plus slices 063 through 065 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 066
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 066 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -437,3 +437,9 @@ Slice 065:
 - target: `src/stomatal_optimiaztion/domains/thorp/utils/__init__.py` and `tests/test_thorp_utils_namespace.py`
 - scope: bounded THORP namespace-wrapper surface covering grouped traceability and model-card helper re-exports
 - excluded: THORP IO/model namespace wrappers, root package export redesign, and numerical runtime changes
+
+Slice 066:
+- source: `THORP/src/thorp/io/__init__.py`
+- target: `src/stomatal_optimiaztion/domains/thorp/io/__init__.py` and `tests/test_thorp_io_namespace.py`
+- scope: bounded THORP namespace-wrapper surface covering grouped forcing and MATLAB I/O helper re-exports
+- excluded: THORP model namespace wrapper, params compatibility broadening, root package export redesign, and numerical runtime changes

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -564,8 +564,16 @@ The sixty-fifth slice opens the next bounded THORP namespace-wrapper seam:
 - keep the seam wrapper-bounded without widening into new shared utility abstractions
 - leave `THORP/src/thorp/io/__init__.py` blocked as the next seam
 
+## Slice 066: THORP IO Namespace
+
+The sixty-sixth slice opens the next bounded THORP namespace-wrapper seam:
+- move `THORP/src/thorp/io/__init__.py` into the staged `domains/thorp/io/` package
+- preserve the grouped convenience imports for forcing and MATLAB compatibility helpers
+- keep the seam wrapper-bounded without widening into new I/O abstractions
+- leave `THORP/src/thorp/model/__init__.py` blocked as the next seam
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/io/__init__.py`
+3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/model/__init__.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 065 completed and THORP namespace-wrapper planning
+- Current phase: slice 066 completed and THORP namespace-wrapper planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP `utils` namespace surface is closed after migrating `utils/__init__.py`
-2. audit `THORP/src/thorp/io/__init__.py` as the next bounded namespace-wrapper seam
-3. prepare the next module spec only after the IO wrapper is scoped against the existing forcing and MATLAB helpers
+1. confirm the THORP `io` namespace surface is closed after migrating `io/__init__.py`
+2. audit `THORP/src/thorp/model/__init__.py` as the next bounded namespace-wrapper seam
+3. prepare the next module spec only after the model wrapper is scoped against the existing runtime modules

--- a/docs/architecture/architecture/module_specs/module-066-thorp-io-namespace.md
+++ b/docs/architecture/architecture/module_specs/module-066-thorp-io-namespace.md
@@ -1,0 +1,35 @@
+# Module Spec 066: THORP IO Namespace
+
+## Purpose
+
+Restore the legacy `thorp.io` convenience import surface over the already migrated forcing and MATLAB compatibility helpers.
+
+## Source Inputs
+
+- `THORP/src/thorp/io/__init__.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/io/__init__.py`
+- `tests/test_thorp_io_namespace.py`
+
+## Responsibilities
+
+1. preserve the `thorp.io` grouped import surface for forcing and MATLAB I/O helpers
+2. preserve symbol identity instead of wrapping or redefining existing helpers
+3. keep the seam namespace-wrapper-bounded instead of widening into new file-format or forcing abstractions
+
+## Non-Goals
+
+- redesign `forcing.py` or `matlab_io.py`
+- widen the THORP root package exports in the same slice
+- migrate the `THORP/src/thorp/model/__init__.py` namespace wrapper in the same slice
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `THORP/src/thorp/model/__init__.py`

--- a/docs/architecture/executor/issue-127-model-change.md
+++ b/docs/architecture/executor/issue-127-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 065` restored the legacy `thorp.utils` namespace wrapper, so the next bounded THORP compatibility seam is `THORP/src/thorp/io/__init__.py`.
+- The migrated repo already exposes `Forcing`, `load_forcing()`, `load_mat()`, and `save_mat()`, but callers that import them through `thorp.io` still do not have a stable namespace path.
+- This slice should stay namespace-wrapper-bounded: grouped re-exports, import compatibility regression coverage, and architecture records only.
+
+## Affected model
+- `thorp`
+- `src/stomatal_optimiaztion/domains/thorp/io/`
+- THORP namespace-wrapper tests
+- architecture docs for the next THORP wrapper seam
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for `thorp.io` symbol identity over forcing and MATLAB I/O helpers
+
+## Comparison target
+- legacy `THORP/src/thorp/io/__init__.py`
+- current migrated `src/stomatal_optimiaztion/domains/thorp/{forcing.py,matlab_io.py}`

--- a/docs/architecture/executor/pr-127-thorp-io-namespace.md
+++ b/docs/architecture/executor/pr-127-thorp-io-namespace.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the legacy THORP `io` namespace wrapper into `src/stomatal_optimiaztion/domains/thorp/io/__init__.py`
+- preserve grouped imports for forcing and MATLAB I/O helpers without redefining them
+- move the next bounded THORP namespace-wrapper seam to `THORP/src/thorp/model/__init__.py`
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #127

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | THORP namespace wrappers are still incomplete after the restored `utils` path | Compatibility callers may still miss legacy `io`, `model`, or broadened `params` package-level import surfaces | next THORP namespace-wrapper module spec |
+| GAP-002 | THORP namespace wrappers are still incomplete after the restored `io` path | Compatibility callers may still miss legacy `model` or broadened `params` package-level import surfaces | next THORP namespace-wrapper module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/io/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/io/__init__.py
@@ -1,0 +1,8 @@
+"""Legacy THORP grouped I/O namespace."""
+
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.thorp.forcing import Forcing, load_forcing
+from stomatal_optimiaztion.domains.thorp.matlab_io import load_mat, save_mat
+
+__all__ = ["Forcing", "load_forcing", "load_mat", "save_mat"]

--- a/tests/test_thorp_io_namespace.py
+++ b/tests/test_thorp_io_namespace.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import stomatal_optimiaztion.domains.thorp.forcing as forcing_module
+import stomatal_optimiaztion.domains.thorp.io as io_pkg
+import stomatal_optimiaztion.domains.thorp.matlab_io as matlab_io_module
+
+
+def test_io_package_reexports_grouped_helpers() -> None:
+    assert io_pkg.Forcing is forcing_module.Forcing
+    assert io_pkg.load_forcing is forcing_module.load_forcing
+    assert io_pkg.load_mat is matlab_io_module.load_mat
+    assert io_pkg.save_mat is matlab_io_module.save_mat


### PR DESCRIPTION
## Summary
- migrate the legacy THORP `io` namespace wrapper into `src/stomatal_optimiaztion/domains/thorp/io/__init__.py`
- preserve grouped imports for forcing and MATLAB I/O helpers without redefining them
- move the next bounded THORP namespace-wrapper seam to `THORP/src/thorp/model/__init__.py`

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #127
