### PR TITLE
[Model Change] Migrate THORP model namespace seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -33,4 +33,5 @@ Current status:
 - Slice 064 migrated: THORP equation-registry seam
 - Slice 065 migrated: THORP utilities namespace seam
 - Slice 066 migrated: THORP IO namespace seam
-- Next blocked seam: THORP model namespace seam at `THORP/src/thorp/model/__init__.py`
+- Slice 067 migrated: THORP model namespace seam
+- Next blocked seam: THORP params compatibility seam at `THORP/src/thorp/params/__init__.py`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ poetry run ruff check .
 - THORP equation-registry seam is migrated as slice 064.
 - THORP utilities namespace seam is migrated as slice 065.
 - THORP IO namespace seam is migrated as slice 066.
+- THORP model namespace seam is migrated as slice 067.
 
 ## Next validation
-- Audit the THORP model namespace seam at `THORP/src/thorp/model/__init__.py`.
+- Audit the THORP params compatibility seam at `THORP/src/thorp/params/__init__.py`.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 066
-- Gate D. Bounded slices 001 through 024 plus slices 063 through 066 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 067
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 067 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -443,3 +443,9 @@ Slice 066:
 - target: `src/stomatal_optimiaztion/domains/thorp/io/__init__.py` and `tests/test_thorp_io_namespace.py`
 - scope: bounded THORP namespace-wrapper surface covering grouped forcing and MATLAB I/O helper re-exports
 - excluded: THORP model namespace wrapper, params compatibility broadening, root package export redesign, and numerical runtime changes
+
+Slice 067:
+- source: `THORP/src/thorp/model/__init__.py`
+- target: `src/stomatal_optimiaztion/domains/thorp/model/__init__.py` and `tests/test_thorp_model_namespace.py`
+- scope: bounded THORP namespace-wrapper surface covering grouped model-core helper re-exports across allocation, growth, hydraulics, radiation, and soil modules
+- excluded: THORP params compatibility broadening, root package export redesign, and numerical runtime changes

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -572,8 +572,16 @@ The sixty-sixth slice opens the next bounded THORP namespace-wrapper seam:
 - keep the seam wrapper-bounded without widening into new I/O abstractions
 - leave `THORP/src/thorp/model/__init__.py` blocked as the next seam
 
+## Slice 067: THORP Model Namespace
+
+The sixty-seventh slice opens the next bounded THORP namespace-wrapper seam:
+- move `THORP/src/thorp/model/__init__.py` into the staged `domains/thorp/model/` package
+- preserve the grouped convenience imports for allocation, growth, hydraulics, radiation, and soil helpers
+- keep the seam wrapper-bounded without widening into new runtime abstractions
+- leave `THORP/src/thorp/params/__init__.py` blocked as the next seam
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/model/__init__.py`
+3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/params/__init__.py`

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 066 completed and THORP namespace-wrapper planning
+- Current phase: slice 067 completed and THORP namespace-wrapper planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP `io` namespace surface is closed after migrating `io/__init__.py`
-2. audit `THORP/src/thorp/model/__init__.py` as the next bounded namespace-wrapper seam
-3. prepare the next module spec only after the model wrapper is scoped against the existing runtime modules
+1. confirm the THORP `model` namespace surface is closed after migrating `model/__init__.py`
+2. audit `THORP/src/thorp/params/__init__.py` as the next bounded compatibility seam
+3. prepare the next module spec only after the params surface is scoped against the existing defaults and flat params module

--- a/docs/architecture/architecture/module_specs/module-067-thorp-model-namespace.md
+++ b/docs/architecture/architecture/module_specs/module-067-thorp-model-namespace.md
@@ -1,0 +1,35 @@
+# Module Spec 067: THORP Model Namespace
+
+## Purpose
+
+Restore the legacy `thorp.model` convenience import surface over the already migrated allocation, growth, hydraulics, radiation, and soil helpers.
+
+## Source Inputs
+
+- `THORP/src/thorp/model/__init__.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/model/__init__.py`
+- `tests/test_thorp_model_namespace.py`
+
+## Responsibilities
+
+1. preserve the `thorp.model` grouped import surface for model-core helpers
+2. preserve symbol identity instead of wrapping or redefining existing helpers
+3. keep the seam namespace-wrapper-bounded instead of widening into new runtime abstractions
+
+## Non-Goals
+
+- redesign allocation, growth, hydraulics, radiation, or soil runtime modules
+- widen the THORP root package exports in the same slice
+- migrate the broadened `thorp.params` compatibility surface in the same slice
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Seam
+
+- `THORP/src/thorp/params/__init__.py`

--- a/docs/architecture/executor/issue-129-model-change.md
+++ b/docs/architecture/executor/issue-129-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 066` restored the legacy `thorp.io` namespace wrapper, so the next bounded THORP compatibility seam is `THORP/src/thorp/model/__init__.py`.
+- The migrated repo already exposes the underlying allocation, growth, hydraulics, radiation, and soil helpers, but callers that import them through `thorp.model` still do not have a stable namespace path.
+- This slice should stay namespace-wrapper-bounded: grouped re-exports, import compatibility regression coverage, and architecture records only.
+
+## Affected model
+- `thorp`
+- `src/stomatal_optimiaztion/domains/thorp/model/`
+- THORP namespace-wrapper tests
+- architecture docs for the next THORP wrapper seam
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for `thorp.model` symbol identity over allocation, growth, hydraulics, radiation, and soil helpers
+
+## Comparison target
+- legacy `THORP/src/thorp/model/__init__.py`
+- current migrated `src/stomatal_optimiaztion/domains/thorp/{allocation.py,growth.py,hydraulics.py,radiation.py,soil_initialization.py,soil_dynamics.py}`

--- a/docs/architecture/executor/pr-129-thorp-model-namespace.md
+++ b/docs/architecture/executor/pr-129-thorp-model-namespace.md
@@ -1,0 +1,10 @@
+## Summary
+- migrate the legacy THORP `model` namespace wrapper into `src/stomatal_optimiaztion/domains/thorp/model/__init__.py`
+- preserve grouped imports for allocation, growth, hydraulics, radiation, and soil helpers without redefining them
+- move the next bounded THORP compatibility seam to `THORP/src/thorp/params/__init__.py`
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #129

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,6 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | THORP namespace wrappers are still incomplete after the restored `io` path | Compatibility callers may still miss legacy `model` or broadened `params` package-level import surfaces | next THORP namespace-wrapper module spec |
+| GAP-002 | THORP namespace wrappers are still incomplete after the restored `model` path | Compatibility callers may still miss the broadened `params` package-level import surface | next THORP namespace-wrapper module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/model/__init__.py
+++ b/src/stomatal_optimiaztion/domains/thorp/model/__init__.py
@@ -1,0 +1,38 @@
+"""Legacy THORP grouped model namespace."""
+
+from __future__ import annotations
+
+from stomatal_optimiaztion.domains.thorp.allocation import (
+    AllocationFractions,
+    allocation_fractions,
+)
+from stomatal_optimiaztion.domains.thorp.growth import GrowthState, grow
+from stomatal_optimiaztion.domains.thorp.hydraulics import (
+    StomataResult,
+    e_from_soil_to_root_collar,
+    stomata,
+)
+from stomatal_optimiaztion.domains.thorp.radiation import RadiationResult, radiation
+from stomatal_optimiaztion.domains.thorp.soil_dynamics import richards_equation, soil_moisture
+from stomatal_optimiaztion.domains.thorp.soil_initialization import (
+    InitialSoilAndRoots,
+    SoilGrid,
+    initial_soil_and_roots,
+)
+
+__all__ = [
+    "AllocationFractions",
+    "GrowthState",
+    "InitialSoilAndRoots",
+    "RadiationResult",
+    "SoilGrid",
+    "StomataResult",
+    "allocation_fractions",
+    "e_from_soil_to_root_collar",
+    "grow",
+    "initial_soil_and_roots",
+    "radiation",
+    "richards_equation",
+    "soil_moisture",
+    "stomata",
+]

--- a/tests/test_thorp_model_namespace.py
+++ b/tests/test_thorp_model_namespace.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+import stomatal_optimiaztion.domains.thorp.model as model_pkg
+
+allocation_module = import_module("stomatal_optimiaztion.domains.thorp.allocation")
+growth_module = import_module("stomatal_optimiaztion.domains.thorp.growth")
+hydraulics_module = import_module("stomatal_optimiaztion.domains.thorp.hydraulics")
+radiation_module = import_module("stomatal_optimiaztion.domains.thorp.radiation")
+soil_dynamics_module = import_module("stomatal_optimiaztion.domains.thorp.soil_dynamics")
+soil_initialization_module = import_module(
+    "stomatal_optimiaztion.domains.thorp.soil_initialization"
+)
+
+
+def test_model_package_reexports_grouped_helpers() -> None:
+    assert model_pkg.AllocationFractions is allocation_module.AllocationFractions
+    assert model_pkg.allocation_fractions is allocation_module.allocation_fractions
+    assert model_pkg.GrowthState is growth_module.GrowthState
+    assert model_pkg.grow is growth_module.grow
+    assert model_pkg.StomataResult is hydraulics_module.StomataResult
+    assert model_pkg.e_from_soil_to_root_collar is hydraulics_module.e_from_soil_to_root_collar
+    assert model_pkg.stomata is hydraulics_module.stomata
+    assert model_pkg.RadiationResult is radiation_module.RadiationResult
+    assert model_pkg.radiation is radiation_module.radiation
+    assert model_pkg.InitialSoilAndRoots is soil_initialization_module.InitialSoilAndRoots
+    assert model_pkg.SoilGrid is soil_initialization_module.SoilGrid
+    assert model_pkg.initial_soil_and_roots is soil_initialization_module.initial_soil_and_roots
+    assert model_pkg.richards_equation is soil_dynamics_module.richards_equation
+    assert model_pkg.soil_moisture is soil_dynamics_module.soil_moisture


### PR DESCRIPTION
## Summary
- migrate the legacy THORP `model` namespace wrapper into `src/stomatal_optimiaztion/domains/thorp/model/__init__.py`
- preserve grouped imports for allocation, growth, hydraulics, radiation, and soil helpers without redefining them
- move the next bounded THORP compatibility seam to `THORP/src/thorp/params/__init__.py`

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #129
