### PR TITLE
[Model Change] Broaden THORP params compatibility seam

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -34,4 +34,5 @@ Current status:
 - Slice 065 migrated: THORP utilities namespace seam
 - Slice 066 migrated: THORP IO namespace seam
 - Slice 067 migrated: THORP model namespace seam
-- Next blocked seam: THORP params compatibility seam at `THORP/src/thorp/params/__init__.py`
+- Slice 068 migrated: THORP params compatibility seam
+- Next blocked artifact: THORP package-level smoke validation note

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ poetry run ruff check .
 - THORP utilities namespace seam is migrated as slice 065.
 - THORP IO namespace seam is migrated as slice 066.
 - THORP model namespace seam is migrated as slice 067.
+- THORP params compatibility seam is migrated as slice 068.
 
 ## Next validation
-- Audit the THORP params compatibility seam at `THORP/src/thorp/params/__init__.py`.
+- Add the THORP package-level smoke validation note to close the remaining validation gap.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 067
-- Gate D. Bounded slices 001 through 024 plus slices 063 through 067 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 068
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 068 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -449,3 +449,9 @@ Slice 067:
 - target: `src/stomatal_optimiaztion/domains/thorp/model/__init__.py` and `tests/test_thorp_model_namespace.py`
 - scope: bounded THORP namespace-wrapper surface covering grouped model-core helper re-exports across allocation, growth, hydraulics, radiation, and soil modules
 - excluded: THORP params compatibility broadening, root package export redesign, and numerical runtime changes
+
+Slice 068:
+- source: `THORP/src/thorp/params/__init__.py` and `THORP/src/thorp/config.py`
+- target: `src/stomatal_optimiaztion/domains/thorp/params.py` and `tests/test_thorp_params_compatibility.py`
+- scope: bounded THORP compatibility surface covering legacy grouped exports plus flat `default_params()` over the migrated params module
+- excluded: package-level smoke validation, root package export redesign, and shared utility abstraction decisions

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -580,8 +580,16 @@ The sixty-seventh slice opens the next bounded THORP namespace-wrapper seam:
 - keep the seam wrapper-bounded without widening into new runtime abstractions
 - leave `THORP/src/thorp/params/__init__.py` blocked as the next seam
 
+## Slice 068: THORP Params Compatibility
+
+The sixty-eighth slice closes the remaining bounded THORP namespace-wrapper gap:
+- broaden `src/stomatal_optimiaztion/domains/thorp/params.py` so legacy callers recover the grouped `thorp.params` surface
+- preserve grouped exports for `BottomBoundaryCondition`, `SoilHydraulics`, `THORPParams`, `WeibullVC`, and flat `default_params()`
+- keep the seam compatibility-bounded without reintroducing the legacy `config.py` module layout
+- leave package-level smoke validation as the next artifact
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the next THORP namespace-wrapper audit for `THORP/src/thorp/params/__init__.py`
+3. prepare the THORP package-level smoke validation note as the next artifact

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 067 completed and THORP namespace-wrapper planning
+- Current phase: slice 068 completed and THORP validation-gap planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP `model` namespace surface is closed after migrating `model/__init__.py`
-2. audit `THORP/src/thorp/params/__init__.py` as the next bounded compatibility seam
-3. prepare the next module spec only after the params surface is scoped against the existing defaults and flat params module
+1. confirm the THORP `params` compatibility surface is closed after broadening `params.py`
+2. add the THORP package-level smoke validation note as the next bounded artifact
+3. compare at least two domains before justifying any shared utility layer

--- a/docs/architecture/architecture/module_specs/module-068-thorp-params-compatibility.md
+++ b/docs/architecture/architecture/module_specs/module-068-thorp-params-compatibility.md
@@ -1,0 +1,36 @@
+# Module Spec 068: THORP Params Compatibility
+
+## Purpose
+
+Broaden the migrated `thorp.params` module so legacy callers can recover the grouped compatibility surface that previously came from `THORP/src/thorp/params/__init__.py`.
+
+## Source Inputs
+
+- `THORP/src/thorp/params/__init__.py`
+- `THORP/src/thorp/config.py`
+
+## Target Outputs
+
+- `src/stomatal_optimiaztion/domains/thorp/params.py`
+- `tests/test_thorp_params_compatibility.py`
+
+## Responsibilities
+
+1. preserve the legacy `thorp.params` exports for `BottomBoundaryCondition`, `SoilHydraulics`, `THORPParams`, `WeibullVC`, and flat `default_params()`
+2. preserve symbol identity for migrated primitive types instead of redefining them
+3. keep the seam compatibility-bounded instead of redesigning the internal THORP defaults bundle
+
+## Non-Goals
+
+- redesign `defaults.py` or the root `domains.thorp` export surface
+- reintroduce the legacy `config.py` module layout
+- widen the slice into package-level smoke validation or shared utility design notes
+
+## Validation
+
+- `poetry run pytest`
+- `poetry run ruff check .`
+
+## Next Artifact
+
+- THORP package-level smoke validation note

--- a/docs/architecture/executor/issue-131-model-change.md
+++ b/docs/architecture/executor/issue-131-model-change.md
@@ -1,0 +1,20 @@
+## Why
+- `slice 067` restored the legacy `thorp.model` namespace wrapper, so the remaining bounded THORP compatibility gap is the broadened `THORP/src/thorp/params/__init__.py` import surface.
+- The migrated repo already has `THORPParams` and default-bundle builders, but legacy callers still expect `BottomBoundaryCondition`, `SoilHydraulics`, `WeibullVC`, and a flat `default_params()` under `thorp.params`.
+- This slice should stay compatibility-bounded: broaden the existing `params.py` exports, lock the legacy import surface with regression coverage, and update architecture records only.
+
+## Affected model
+- `thorp`
+- `src/stomatal_optimiaztion/domains/thorp/params.py`
+- THORP compatibility tests
+- architecture docs closing the THORP namespace-wrapper gap
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- add coverage for `thorp.params` legacy export identity and flat `default_params()` compatibility
+
+## Comparison target
+- legacy `THORP/src/thorp/params/__init__.py`
+- legacy `THORP/src/thorp/config.py`
+- current migrated `src/stomatal_optimiaztion/domains/thorp/{params.py,defaults.py,soil_hydraulics.py,soil_initialization.py,vulnerability.py}`

--- a/docs/architecture/executor/pr-131-thorp-params-compatibility.md
+++ b/docs/architecture/executor/pr-131-thorp-params-compatibility.md
@@ -1,0 +1,10 @@
+## Summary
+- broaden `src/stomatal_optimiaztion/domains/thorp/params.py` to preserve the legacy THORP params compatibility surface
+- re-export migrated primitive types and add flat `default_params()` coverage for legacy callers
+- move the next bounded artifact to a THORP package-level smoke validation note
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #131

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,6 +2,5 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-002 | THORP namespace wrappers are still incomplete after the restored `model` path | Compatibility callers may still miss the broadened `params` package-level import surface | next THORP namespace-wrapper module spec |
 | GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/src/stomatal_optimiaztion/domains/thorp/params.py
+++ b/src/stomatal_optimiaztion/domains/thorp/params.py
@@ -34,6 +34,17 @@ DEFAULT_FORCING_REPEAT_Q = 15
 DEFAULT_FORCING_RH_SCALE = 0.6
 DEFAULT_FORCING_PRECIP_SCALE = 1.0
 
+__all__ = [
+    "BottomBoundaryCondition",
+    "ResponseCurve",
+    "SoilHydraulics",
+    "THORPParams",
+    "TemperatureResponse",
+    "WeibullVC",
+    "default_params",
+    "thorp_params_from_defaults",
+]
+
 
 @dataclass(frozen=True, slots=True)
 class THORPParams:
@@ -207,3 +218,9 @@ def thorp_params_from_defaults(
         forcing_rh_scale=float(forcing_rh_scale),
         forcing_precip_scale=float(forcing_precip_scale),
     )
+
+
+def default_params() -> THORPParams:
+    """Return the legacy flat THORP params surface expected by compatibility callers."""
+
+    return thorp_params_from_defaults()

--- a/tests/test_thorp_params_compatibility.py
+++ b/tests/test_thorp_params_compatibility.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+from stomatal_optimiaztion.domains.thorp.params import THORPParams, default_params
+
+params_module = import_module("stomatal_optimiaztion.domains.thorp.params")
+soil_hydraulics_module = import_module("stomatal_optimiaztion.domains.thorp.soil_hydraulics")
+soil_initialization_module = import_module(
+    "stomatal_optimiaztion.domains.thorp.soil_initialization"
+)
+vulnerability_module = import_module("stomatal_optimiaztion.domains.thorp.vulnerability")
+
+
+def test_params_module_reexports_legacy_types() -> None:
+    assert params_module.SoilHydraulics is soil_hydraulics_module.SoilHydraulics
+    assert params_module.BottomBoundaryCondition is soil_initialization_module.BottomBoundaryCondition
+    assert params_module.WeibullVC is vulnerability_module.WeibullVC
+
+
+def test_params_default_params_returns_flat_legacy_bundle() -> None:
+    params = default_params()
+
+    assert isinstance(params, THORPParams)
+    assert params.run_name == "0.6RH"
+    assert params.forcing_repeat_q == 15


### PR DESCRIPTION
## Summary
- broaden `src/stomatal_optimiaztion/domains/thorp/params.py` to preserve the legacy THORP params compatibility surface
- re-export migrated primitive types and add flat `default_params()` coverage for legacy callers
- move the next bounded artifact to a THORP package-level smoke validation note

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #131
