### PR TITLE
[Model Change] Add THORP package-level smoke validation note

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -35,4 +35,5 @@ Current status:
 - Slice 066 migrated: THORP IO namespace seam
 - Slice 067 migrated: THORP model namespace seam
 - Slice 068 migrated: THORP params compatibility seam
-- Next blocked artifact: THORP package-level smoke validation note
+- Slice 069 recorded: THORP package-level smoke validation note
+- Next blocked artifact: second-domain comparison note for shared utility justification

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ poetry run ruff check .
 - THORP IO namespace seam is migrated as slice 066.
 - THORP model namespace seam is migrated as slice 067.
 - THORP params compatibility seam is migrated as slice 068.
+- THORP package-level smoke validation note is recorded as slice 069.
 
 ## Next validation
-- Add the THORP package-level smoke validation note to close the remaining validation gap.
+- Add the second-domain comparison note before opening any shared utility layer.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 068
-- Gate D. Bounded slices 001 through 024 plus slices 063 through 068 approved for THORP, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 069
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 068 approved for THORP, slice 069 recorded as THORP package-level smoke evidence, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -455,3 +455,9 @@ Slice 068:
 - target: `src/stomatal_optimiaztion/domains/thorp/params.py` and `tests/test_thorp_params_compatibility.py`
 - scope: bounded THORP compatibility surface covering legacy grouped exports plus flat `default_params()` over the migrated params module
 - excluded: package-level smoke validation, root package export redesign, and shared utility abstraction decisions
+
+Slice 069:
+- source: migrated `src/stomatal_optimiaztion/domains/thorp/__init__.py` plus restored THORP compatibility wrappers
+- target: `tests/test_smoke.py` and `docs/architecture/review/thorp-package-smoke-validation-note.md`
+- scope: bounded package-level validation evidence covering root THORP imports, compatibility wrapper presence, and smoke-suite limits
+- excluded: deeper numerical regression redesign and cross-domain shared utility decisions

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -588,8 +588,16 @@ The sixty-eighth slice closes the remaining bounded THORP namespace-wrapper gap:
 - keep the seam compatibility-bounded without reintroducing the legacy `config.py` module layout
 - leave package-level smoke validation as the next artifact
 
+## Slice 069: THORP Package-Level Smoke Validation
+
+The sixty-ninth slice closes the remaining THORP validation gap:
+- extend the repo smoke suite so it exercises the migrated THORP root package and restored compatibility wrappers together
+- record a review note that states the smoke-covered surface and the still out-of-scope numerical depth
+- keep the slice validation-bounded without widening into new runtime abstractions
+- leave the second-domain comparison note as the next artifact
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the THORP package-level smoke validation note as the next artifact
+3. prepare the second-domain comparison note as the next artifact

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 068 completed and THORP validation-gap planning
+- Current phase: slice 069 completed and shared-utility-justification planning
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP `params` compatibility surface is closed after broadening `params.py`
-2. add the THORP package-level smoke validation note as the next bounded artifact
-3. compare at least two domains before justifying any shared utility layer
+1. confirm the THORP package-level smoke note is recorded against the updated smoke suite
+2. add the second-domain comparison note as the next bounded artifact
+3. keep shared utilities blocked until the comparison shows a real cross-domain seam

--- a/docs/architecture/executor/issue-133-model-change.md
+++ b/docs/architecture/executor/issue-133-model-change.md
@@ -1,0 +1,19 @@
+## Why
+- With `slice 068`, the THORP namespace-wrapper gap is closed, but `GAP-008` remains: current coverage still leans on seam-level unit tests more than package-level smoke checks.
+- The repo already has a minimal smoke test, but it does not explicitly lock the migrated THORP package import surface that compatibility callers now rely on.
+- This slice should stay validation-bounded: add one package-level smoke check, record the resulting coverage note, and update architecture status only.
+
+## Affected model
+- `thorp`
+- `tests/test_smoke.py`
+- `docs/architecture/review/`
+- architecture status docs
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- extend smoke coverage for package-level THORP imports and document what remains out of scope
+
+## Comparison target
+- current migrated `src/stomatal_optimiaztion/domains/thorp/__init__.py`
+- existing repo smoke validation baseline

--- a/docs/architecture/executor/pr-133-thorp-package-level-smoke-validation-note.md
+++ b/docs/architecture/executor/pr-133-thorp-package-level-smoke-validation-note.md
@@ -1,0 +1,10 @@
+## Summary
+- extend the repo smoke suite to cover the migrated THORP package import surface and restored compatibility wrappers
+- add a review note that records the package-level smoke scope and its current limits
+- move the next bounded artifact to the second-domain comparison note for shared utility justification
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #133

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,5 +2,4 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-008 | THORP migrated seams are still validated primarily by unit and seam-level tests | Package-level execution regressions may still hide outside the current harness | package-level smoke validation note |
 | GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |

--- a/docs/architecture/review/thorp-package-smoke-validation-note.md
+++ b/docs/architecture/review/thorp-package-smoke-validation-note.md
@@ -1,0 +1,29 @@
+# THORP Package-Level Smoke Validation Note
+
+## Purpose
+
+Record the minimum package-level smoke coverage now that the THORP runtime and compatibility wrappers are migrated.
+
+## Covered Surface
+
+- root `stomatal_optimiaztion.domains.thorp` import surface
+- compatibility wrapper packages `thorp.io`, `thorp.model`, and `thorp.utils`
+- broadened `thorp.params.default_params()` flat legacy bundle
+- curated `model_card` inventory presence
+
+## Validation Hook
+
+- `tests/test_smoke.py::test_smoke`
+- `tests/test_smoke.py::test_thorp_package_import_surface_smoke`
+- `.\.venv\Scripts\python.exe -m pytest`
+- `.\.venv\Scripts\ruff.exe check .`
+
+## Out Of Scope
+
+- full THORP numerical regression coverage beyond the already migrated seam tests
+- long-running forcing-driven simulations
+- TOMATO or `load-cell-data` package-level smoke expansion
+
+## Result
+
+The repo now has one package-level smoke check that exercises the migrated THORP root import surface and the restored compatibility wrappers together, reducing the risk that wrapper-level breakage escapes the seam-level test suite.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,20 @@
-from stomatal_optimiaztion.domains.thorp import model_card_document_names
+from importlib import import_module
+
+import stomatal_optimiaztion.domains.thorp as thorp
+
+io_pkg = import_module("stomatal_optimiaztion.domains.thorp.io")
+model_pkg = import_module("stomatal_optimiaztion.domains.thorp.model")
+params_module = import_module("stomatal_optimiaztion.domains.thorp.params")
+utils_pkg = import_module("stomatal_optimiaztion.domains.thorp.utils")
 
 
 def test_smoke() -> None:
-    assert len(model_card_document_names()) == 11
+    assert len(thorp.model_card_document_names()) == 11
+
+
+def test_thorp_package_import_surface_smoke() -> None:
+    assert thorp.Forcing is io_pkg.Forcing
+    assert thorp.load_mat is io_pkg.load_mat
+    assert thorp.radiation is model_pkg.radiation
+    assert thorp.require_equation_ids is utils_pkg.require_equation_ids
+    assert params_module.default_params().run_name == "0.6RH"


### PR DESCRIPTION
## Summary
- extend the repo smoke suite to cover the migrated THORP package import surface and restored compatibility wrappers
- add a review note that records the package-level smoke scope and its current limits
- move the next bounded artifact to the second-domain comparison note for shared utility justification

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #133
