### PR TITLE
[Doc] Add second-domain utility comparison note

### DIFF
--- a/Phytoritas.md
+++ b/Phytoritas.md
@@ -36,4 +36,5 @@ Current status:
 - Slice 067 migrated: THORP model namespace seam
 - Slice 068 migrated: THORP params compatibility seam
 - Slice 069 recorded: THORP package-level smoke validation note
-- Next blocked artifact: second-domain comparison note for shared utility justification
+- Slice 070 recorded: second-domain utility comparison note
+- Current open architecture gaps: none

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ poetry run ruff check .
 - THORP model namespace seam is migrated as slice 067.
 - THORP params compatibility seam is migrated as slice 068.
 - THORP package-level smoke validation note is recorded as slice 069.
+- Second-domain utility comparison note is recorded as slice 070.
 
 ## Next validation
-- Add the second-domain comparison note before opening any shared utility layer.
+- Monitor for new structural requirements before opening another slice.

--- a/docs/architecture/00_workspace_audit.md
+++ b/docs/architecture/00_workspace_audit.md
@@ -43,8 +43,8 @@ Legacy source profile:
 
 - Gate A. Source audit complete for top-level legacy domains
 - Gate B. Target architecture chosen
-- Gate C. Validation plan ready through slice 069
-- Gate D. Bounded slices 001 through 024 plus slices 063 through 068 approved for THORP, slice 069 recorded as THORP package-level smoke evidence, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
+- Gate C. Validation plan ready through slice 070
+- Gate D. Bounded slices 001 through 024 plus slices 063 through 068 approved for THORP, slice 069 recorded as THORP package-level smoke evidence, slice 070 recorded as the cross-domain utility comparison decision, slices 025 through 045 approved for TOMATO, and slices 046 through 062 approved for `load-cell-data`
 
 ## Migrated THORP Slices
 
@@ -461,3 +461,9 @@ Slice 069:
 - target: `tests/test_smoke.py` and `docs/architecture/review/thorp-package-smoke-validation-note.md`
 - scope: bounded package-level validation evidence covering root THORP imports, compatibility wrapper presence, and smoke-suite limits
 - excluded: deeper numerical regression redesign and cross-domain shared utility decisions
+
+Slice 070:
+- source: migrated THORP, TOMATO `tTHORP`, and `load_cell` utility-like seams
+- target: `docs/architecture/system/second-domain-utility-comparison-note.md`
+- scope: bounded architecture decision note comparing utility pressure across domains and deciding whether `shared/` should stay blocked
+- excluded: new shared code extraction and fresh domain refactors

--- a/docs/architecture/01_system_brief.md
+++ b/docs/architecture/01_system_brief.md
@@ -596,8 +596,16 @@ The sixty-ninth slice closes the remaining THORP validation gap:
 - keep the slice validation-bounded without widening into new runtime abstractions
 - leave the second-domain comparison note as the next artifact
 
+## Slice 070: Second-Domain Utility Comparison
+
+The seventieth slice closes the final open architecture gap:
+- compare utility-like seams across THORP, TOMATO `tTHORP`, and `load_cell`
+- record whether a shared utility layer is justified today
+- keep `shared/` blocked because the current contracts, dependencies, and reuse pressure still diverge by domain
+- leave the architecture in monitor mode until a new structural uncertainty appears
+
 ## Immediate Deliverables
 
 1. keep `poetry run pytest` green for the migrated THORP seams, the first twenty-one TOMATO bounded seams, and the first sixteen `load-cell-data` bounded seams
 2. keep `poetry run ruff check .` green as the minimum lint gate
-3. prepare the second-domain comparison note as the next artifact
+3. monitor for new structural uncertainty before opening another slice

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 069 completed and shared-utility-justification planning
+- Current phase: slice 070 completed and architecture gaps cleared
 
 ## Scope
 
@@ -99,6 +99,6 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. confirm the THORP package-level smoke note is recorded against the updated smoke suite
-2. add the second-domain comparison note as the next bounded artifact
-3. keep shared utilities blocked until the comparison shows a real cross-domain seam
+1. keep the current validation gates green as new work lands
+2. reopen the gap register only when a new structural uncertainty appears
+3. keep shared utilities blocked until a concrete cross-domain helper emerges

--- a/docs/architecture/executor/issue-135-doc.md
+++ b/docs/architecture/executor/issue-135-doc.md
@@ -1,0 +1,19 @@
+## Why
+- `slice 069` closed the THORP package-level smoke validation gap, leaving `GAP-007` as the final open architecture gap.
+- The repo still needs an explicit second-domain comparison note before anyone introduces `src/stomatal_optimiaztion/shared/` or another cross-domain utility layer.
+- This slice should stay documentation-bounded: compare migrated utilities across domains, decide whether sharing is justified, and update architecture status only.
+
+## Affected scope
+- `docs/architecture/system/`
+- architecture status docs
+- gap register closure
+
+## Validation method
+- `poetry run pytest`
+- `poetry run ruff check .`
+- confirm the comparison note names at least two migrated domains and produces a concrete keep-blocked or proceed decision
+
+## Comparison target
+- `domains/thorp` utility-like surfaces such as `forcing.py`, `matlab_io.py`, and `params.py`
+- `domains/tomato/tthorp/core/` utility-like surfaces such as `io.py` and `util_units.py`
+- `domains/load_cell` utility-like surfaces such as `config.py` and `io.py`

--- a/docs/architecture/executor/pr-135-second-domain-utility-comparison-note.md
+++ b/docs/architecture/executor/pr-135-second-domain-utility-comparison-note.md
@@ -1,0 +1,10 @@
+## Summary
+- add a second-domain comparison note that contrasts THORP, TOMATO `tTHORP`, and `load_cell` utility-like seams
+- document the decision to keep `shared/` blocked until a concrete cross-domain helper appears
+- clear the final open architecture gap and move the repo into monitor mode
+
+## Validation
+- `.\\.venv\\Scripts\\python.exe -m pytest`
+- `.\\.venv\\Scripts\\ruff.exe check .`
+
+Closes #135

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -2,4 +2,5 @@
 
 | ID | Gap | Impact | Required Artifact |
 | --- | --- | --- | --- |
-| GAP-007 | Shared utilities layer is not justified yet | Premature abstraction could create churn | second-domain comparison note |
+
+Current open gaps: none.

--- a/docs/architecture/system/second-domain-utility-comparison-note.md
+++ b/docs/architecture/system/second-domain-utility-comparison-note.md
@@ -1,0 +1,43 @@
+# Second-Domain Utility Comparison Note
+
+## Purpose
+
+Decide whether the migrated repository now justifies a shared cross-domain utility layer.
+
+## Domains Compared
+
+### THORP
+
+- `domains/thorp/forcing.py` is a domain runtime seam that reconstructs solar-angle and repeated forcing fields from THORP-specific netCDF structure.
+- `domains/thorp/matlab_io.py` is a legacy MATLAB compatibility seam tied to THORP output contracts.
+- `domains/thorp/params.py` is a flat physiology/config compatibility surface for THORP callers.
+
+### TOMATO tTHORP
+
+- `domains/tomato/tthorp/core/io.py` handles config inheritance, YAML loading, JSON metadata emission, and output-directory setup for TOMATO pipelines.
+- `domains/tomato/tthorp/core/util_units.py` is a very small PAR conversion utility scoped to TOMATO feature building.
+
+### load_cell
+
+- `domains/load_cell/config.py` is a pipeline-config loader for CSV preprocessing and event-detection parameters.
+- `domains/load_cell/io.py` is a pandas-heavy ingestion/output seam for 1-second reindexing, interpolation flags, and multi-resolution artifact writing.
+
+## Comparison
+
+1. The names overlap at a superficial level, but the contracts do not. THORP `forcing.py` and TOMATO `core/io.py` both touch files, yet one is model-runtime forcing reconstruction and the other is pipeline-config orchestration.
+2. The dependencies do not align. THORP utility-like seams are built around `netCDF4`, `scipy.io`, and physiological parameter objects, while `load_cell` utilities are pandas-centered ETL seams and TOMATO utilities are YAML/JSON pipeline helpers.
+3. The reuse pressure is still weak. Only TOMATO currently needs `ensure_dir` and config merge helpers; only load-cell needs tabular multi-resolution writers; only THORP needs MATLAB and forcing compatibility layers.
+
+## Decision
+
+Do not introduce `src/stomatal_optimiaztion/shared/` yet.
+
+Keep utility-like seams inside their current domains until at least one concrete helper is used by two migrated domains without adapter glue or contract distortion.
+
+## Reopen Trigger
+
+Revisit a shared utility layer only if one of the following becomes true:
+
+- the same helper implementation is copied or reimplemented across two migrated domains
+- a new cross-domain adapter repeatedly normalizes the same file/config contract
+- tests start requiring duplicate fixtures or assertions for one identical helper concept


### PR DESCRIPTION
## Summary
- add a second-domain comparison note that contrasts THORP, TOMATO `tTHORP`, and `load_cell` utility-like seams
- document the decision to keep `shared/` blocked until a concrete cross-domain helper appears
- clear the final open architecture gap and move the repo into monitor mode

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest`
- `.\\.venv\\Scripts\\ruff.exe check .`

Closes #135
