### PR TITLE
[Doc] Close architecture wave and hand off TDGM drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ poetry run ruff check .
 `THORP` and `TDGM` full-series control rerenders are long-running. On the current workstation, the canonical full rerender completed in about 52 minutes for `THORP` and 56 minutes for `TDGM`.
 
 ## Current status
+- Recursive architecture refactoring is closed through slices `101-108`; the closeout summary lives in [`docs/architecture/delivery/architecture-closeout-note.md`](docs/architecture/delivery/architecture-closeout-note.md).
+- The architecture spine, validation contract, and rerun-parity bundle contract are stable enough for monitor mode.
+- One bounded follow-up gap remains open: root `TDGM` full-series control drift (`D-108`), prepared as module `109` and GitHub issue `#209`.
 - Gates A through C are satisfied for the first bounded migration slice.
 - THORP `model_card` and traceability helpers are migrated into the new package layout.
 - THORP `radiation` runtime seam is migrated as slice 002.
@@ -140,6 +143,7 @@ poetry run ruff check .
 
 ## Next validation
 - Keep `pytest`, `ruff`, and the root rerun parity renderers green while the architecture remains in monitor mode.
+- Start the next implementation wave only from `docs/architecture/architecture/module_specs/module-109-tdgm-full-series-control-drift-investigation.md` and GitHub issue `#209`.
 - Keep the fast root `GOSM` rerun tests warning-free and run the opt-in slow `imag` branch whenever root `gosm` hydraulics or stomatal logic changes.
 - Run the opt-in slow `GOSM` `imag` conductance-loss parity branch when root `gosm` hydraulics or stomatal logic changes.
 - Re-render `scripts/render_root_rerun_parity_figures.py` whenever root `THORP`, `GOSM`, or `TDGM` rerun kernels change.

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: slice 108 keeps only Plotkit-style `Python rerun vs MATLAB reference` bundles under `out/rerun_parity/`, finishes the canonical full-series control rerenders for root `THORP` and `TDGM`, and reopens a bounded follow-up gap because root `TDGM` still drifts from the legacy MATLAB control payload over the full stored horizon
+- Current phase: the recursive architecture refactoring wave is closed through slices `101-108`, the architecture spine and validation contract are green, and the repository is now in delivery-closeout mode with one bounded follow-up gap still open: root `TDGM` full-series control drift (`D-108`, prepared as module `109` and GitHub issue `#209`)
 
 ## Scope
 
@@ -99,8 +99,8 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 
 ## Immediate Next Actions
 
-1. keep the current validation gates green now that the root rerun parity wave also has canonical `png + python/legacy/diff csv` bundles on disk
-2. rerun the fast root parity tests and `scripts/render_root_rerun_parity_figures.py --fast-smoke` when touching `THORP`, `GOSM`, or `TDGM` runtime kernels
-3. rerender the default full-series control bundles for root `THORP` and `TDGM` whenever their runtime kernels change
-4. investigate the newly exposed root `TDGM` long-horizon control drift from the legacy MATLAB payload
-5. run the opt-in slow `GOSM` `imag` conductance-loss branch and bundle when root `gosm` hydraulics or stomatal logic changes
+1. treat the current architecture scaffold, ADR spine, module-spec chain, and rerun parity bundle contract as the stable baseline for further work
+2. keep the validation gates green by rerunning the fast root parity tests and `scripts/render_root_rerun_parity_figures.py --fast-smoke` whenever `THORP`, `GOSM`, or `TDGM` runtime kernels change
+3. rerender the default full-series control bundles for root `THORP` and `TDGM` whenever their runtime kernels change so the canonical `python/legacy/diff` CSV evidence stays current
+4. resume implementation only through the bounded follow-up slice in `docs/architecture/architecture/module_specs/module-109-tdgm-full-series-control-drift-investigation.md` and GitHub issue `#209`
+5. do not declare the root `TDGM` parity wave closed until new full-series evidence shows the long-horizon drift is either explained or removed

--- a/docs/architecture/architecture/module_specs/module-109-tdgm-full-series-control-drift-investigation.md
+++ b/docs/architecture/architecture/module_specs/module-109-tdgm-full-series-control-drift-investigation.md
@@ -1,0 +1,55 @@
+# Module 109: TDGM Full-Series Control Drift Investigation
+
+## Goal
+
+Turn the open `D-108` gap into a bounded diagnosis slice by identifying where the canonical root `TDGM` full-series control rerun first diverges from the legacy MATLAB payload and which runtime seam most likely introduces that drift.
+
+## Inputs
+
+- module 108 full-series rerender audit
+- open gap `D-108` in `docs/architecture/gap_register.md`
+- current rerun evidence under:
+  - `out/rerun_parity/tdgm/thorp_data_control_turgor/`
+- current root `TDGM` runtime seams under:
+  - `src/stomatal_optimiaztion/domains/tdgm/`
+  - `src/stomatal_optimiaztion/domains/tdgm/thorp_g/`
+
+## Target Artifacts
+
+- `docs/architecture/review/python-rerun-parity-audit-note.md`
+- `docs/architecture/review/appendix-equation-coverage-audit-note.md` only if appendix interpretation changes
+- one new bounded drift-diagnosis note under `docs/architecture/review/`
+- if needed, one follow-up module spec for the first proven kernel mismatch
+
+## Responsibilities
+
+1. identify the first stored timestep or horizon segment where the canonical root `TDGM` control rerun begins to drift from the legacy MATLAB payload
+2. classify the likely source of the drift into one of:
+   - growth-state carryover
+   - mean allocation updates
+   - THORP-G coupling state
+   - another bounded long-horizon kernel mismatch
+3. keep the slice diagnosis-bounded rather than opening a broad numerical refactor before the first failing seam is explicit
+
+## Non-Goals
+
+- do not declare the root `TDGM` parity wave closed without new full-series evidence
+- do not broaden the slice into unrelated `THORP` or `GOSM` runtime changes
+- do not rewrite the rerun bundle contract under `out/rerun_parity/`
+
+## Validation
+
+1. `.\.venv\Scripts\python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py tests/test_root_rerun_parity_figures.py -q`
+2. `.\.venv\Scripts\python.exe scripts\render_root_rerun_parity_figures.py --output-dir out/rerun_parity --domains tdgm`
+3. compare:
+   - `*_python.csv`
+   - `*_legacy.csv`
+   - `*_diff.csv`
+4. `.\.venv\Scripts\python.exe -m pytest`
+5. `.\.venv\Scripts\ruff.exe check .`
+
+## Exit Criteria
+
+- the first clear divergence point in the full-series root `TDGM` control rerun is documented
+- the most likely bounded source seam is named explicitly
+- the next architecture step is one focused implementation slice, not a broad exploratory rewrite

--- a/docs/architecture/delivery/README.md
+++ b/docs/architecture/delivery/README.md
@@ -1,3 +1,7 @@
 # Delivery Notes
 
 Use this directory for milestone summaries, handoff notes, and validation evidence summaries.
+
+Current notes:
+
+- `architecture-closeout-note.md`: delivery-closeout summary for recursive architecture refactoring through slices `101-108`, with the remaining bounded `TDGM` drift gap called out explicitly

--- a/docs/architecture/delivery/architecture-closeout-note.md
+++ b/docs/architecture/delivery/architecture-closeout-note.md
@@ -1,0 +1,38 @@
+# Architecture Closeout Note
+
+## Status
+
+- recursive architecture refactoring is closed through slices `101-108`
+- the architecture artifact spine under `docs/architecture/` is present and internally consistent
+- the repository is ready for the next bounded implementation slice, not for a blanket "all drift is solved" claim
+
+## What Changed
+
+- completed the rerun-parity architecture wave for root `THORP`, `GOSM`, and `TDGM`
+- reduced live rerun artifacts to the canonical Plotkit-style `python/legacy/diff` bundle contract under `out/rerun_parity/`
+- added `docs/architecture/review/appendix-equation-coverage-audit-note.md` to record paper-appendix coverage across `THORP`, `GOSM`, and `TDGM`
+- converted the remaining `TDGM` long-horizon drift into a bounded follow-up slice:
+  - module spec: `docs/architecture/architecture/module_specs/module-109-tdgm-full-series-control-drift-investigation.md`
+  - executor packet: `docs/architecture/executor/issue-209-bug-tdgm-full-series-control-rerun-drift.md`
+  - GitHub tracking: issue `#209` set to `Ready`
+
+## Verification
+
+- `.\.venv\Scripts\python.exe -m pytest -q`
+  - last recorded result: `418 passed, 1 skipped`
+- `.\.venv\Scripts\ruff.exe check .`
+  - last recorded result: pass
+- targeted appendix-coverage guard:
+  - `.\.venv\Scripts\python.exe -m pytest tests/test_gosm_steady_state_inversion.py tests/test_tdgm_coupling.py tests/test_thorp_equation_registry.py -q`
+  - result: `9 passed`
+
+## Open Gap
+
+- `D-108`: root `TDGM` canonical full-series control rerun still drifts from the legacy MATLAB payload over the full stored horizon even though the fast bounded parity tests pass
+- this gap is not treated as a scaffold failure; it is a bounded numerical diagnosis slice queued for the next implementation wave
+
+## Next Action
+
+- start from module `109` / issue `#209`
+- identify the first divergence point in the full-series root `TDGM` control rerun
+- narrow the cause to one runtime seam before changing numerical kernels broadly

--- a/docs/architecture/executor/issue-209-bug-tdgm-full-series-control-rerun-drift.md
+++ b/docs/architecture/executor/issue-209-bug-tdgm-full-series-control-rerun-drift.md
@@ -1,0 +1,25 @@
+## repro
+- regenerate the canonical root `TDGM` rerun bundle from the current Python runtime against the legacy MATLAB control payload:
+  - `.\.venv\Scripts\python.exe scripts\render_root_rerun_parity_figures.py --output-dir out/rerun_parity --domains tdgm`
+- inspect:
+  - `out/rerun_parity/tdgm/thorp_data_control_turgor/tdgm_thorp_g_rerun_parity_case_thorp_data_control_turgor_diff.csv`
+- compare the full stored horizon, not only the fast bounded regression window
+
+## expected / actual
+- expected: the canonical root `TDGM` control rerun should remain numerically tight against `THORP_data_Control_Turgor.mat` over the full stored series, the same way root `THORP` now does
+- actual: the fast bounded parity tests pass, but the full-series diff file still shows long-horizon drift in assimilation, transpiration, height, and diameter
+
+## scope
+- root `TDGM` rerun runtime under `src/stomatal_optimiaztion/domains/tdgm/`
+- shared THORP-G rerun dependencies used by the canonical control case
+- live rerun inspection artifacts under `out/rerun_parity/tdgm/`
+
+## fix idea
+- isolate the first timestep or horizon segment where the Python and legacy control traces begin to diverge
+- test whether the drift is introduced by growth-state carryover, mean allocation updates, THORP-G coupling state, or another long-horizon kernel mismatch
+- keep the investigation bounded to diagnosis and evidence capture before changing any numerical kernel broadly
+
+## test
+- rerun the bounded fast parity tests first so the short-horizon contract stays protected
+- regenerate the full root `TDGM` control rerun bundle and compare `*_python.csv`, `*_legacy.csv`, and `*_diff.csv`
+- keep `pytest` and `ruff` green while narrowing the first divergence point

--- a/docs/architecture/review/README.md
+++ b/docs/architecture/review/README.md
@@ -1,3 +1,11 @@
 # Review Notes
 
 Use this directory for architecture reviews, regression reviews, and change critiques.
+
+Current notes:
+
+- `python-rerun-parity-audit-note.md`: direct Python rerun vs legacy MATLAB payload audit for root `THORP`, `GOSM`, and `TDGM`
+- `matlab-source-parity-audit-note.md`: original MATLAB source coverage audit for root `THORP`, `GOSM`, and `TDGM`
+- `legacy-example-parity-audit-note.md`: legacy example and figure workflow audit after the MATLAB-source parity wave
+- `thorp-package-smoke-validation-note.md`: package-level THORP smoke validation summary
+- `appendix-equation-coverage-audit-note.md`: paper-appendix coverage check for root `THORP`, `GOSM`, and `TDGM`

--- a/docs/architecture/review/appendix-equation-coverage-audit-note.md
+++ b/docs/architecture/review/appendix-equation-coverage-audit-note.md
@@ -1,0 +1,161 @@
+# Appendix Equation Coverage Audit Note
+
+## Purpose
+
+Record a document-only audit comparing the current root `THORP`, `GOSM`, and `TDGM` implementations against three literature appendices:
+
+- `artifacts/papers/Potkay et al. - 2021 - Coupled whole-tree optimality and xylem hydraulics explain dynamic biomass partitioning-appendix.pdf`
+- `artifacts/papers/Potkay et al. - 2022 - Turgor-limited predictions of tree growth, height and metabolic scaling over tree lifespans 1.pdf`
+- `artifacts/papers/Potkay and Feng - 2023 - Do stomata optimize turgor-driven growth A new framework for integrating stomata response with whol_appendix.pdf`
+
+This note distinguishes three cases that were easy to conflate during the refactor:
+
+1. real missing runtime logic
+2. appendix derivations that are folded into a later closed-form implementation
+3. appendix future-work formulations that are documented but not part of the current executable model
+
+## Scope
+
+In scope:
+
+- root `THORP`, `GOSM`, and `TDGM` runtime seams under `src/stomatal_optimiaztion/domains/`
+- current architecture artifacts under `docs/architecture/`
+- equation traceability via `@implements(...)`, module specs, and model-card JSON
+
+Out of scope:
+
+- TOMATO placeholder packages
+- figure-only or plotting-only appendix scripts
+- new code changes
+
+## Summary
+
+No new core runtime gap was found for root `THORP`.
+
+No currently-open core runtime gap was found for root `GOSM`, but its appendix `S10.1-S10.2` branch should be interpreted as future-work support rather than as a missing part of the present executable model.
+
+No currently-open core runtime gap was found for root `TDGM`, but part of the PTM appendix remains traceable only indirectly because several derivation-stage equations are absorbed into the later closed-form concentration solver instead of being exposed as standalone helpers.
+
+The only still-open architecture/runtime issue visible after this audit remains the previously recorded long-horizon root `TDGM` parity drift, not a newly found missing appendix equation.
+
+## Reading Rule
+
+For this repository, appendix equations must be classified before calling them "missing":
+
+- `Missing`: the paper uses the equation as part of the current model and no equivalent runtime logic exists.
+- `Folded`: the paper shows the equation as an intermediate derivation, but the code implements a later equivalent closed form or decomposed final algorithm.
+- `Future-work`: the appendix itself presents the formulation as a more complex extension rather than part of the current production model.
+
+## THORP
+
+### Verdict
+
+Root `THORP` has no new missing runtime equation or algorithm relative to the 2021 appendix.
+
+### Reasoning
+
+- The current runtime covers the root-uptake, stomatal, growth, soil, and radiation seams already called out by the earlier MATLAB parity audit.
+- The 2021 appendix `S4.1-S4.6` stem-conductance equations are derivation steps that lead to the executable `S4.7-S4.8` form.
+- The current `stomata()` implementation computes `k_sw_max` directly from the final `S4.7` form and its diameter derivative from `S4.8`, so the earlier proportionality steps are folded rather than omitted.
+
+### Evidence
+
+- `docs/architecture/review/matlab-source-parity-audit-note.md` records no core `THORP` runtime gap.
+- `src/stomatal_optimiaztion/domains/thorp/hydraulics.py` implements root uptake and stomatal optimization, including the final stem-conductance scaling.
+- `src/stomatal_optimiaztion/domains/thorp/growth.py` implements the growth update used by the current runtime.
+
+### Interpretation
+
+If strict appendix traceability is desired, `S4.1-S4.6` could be documented as derivation-only ancestors of the current `k_sw_max` calculation, but this is not a runtime gap.
+
+## GOSM
+
+### Verdict
+
+Root `GOSM` has no currently-open core runtime gap against the present 2023 executable model.
+
+### Reasoning
+
+- The one bounded helper previously missing from the older parity wave, `FUNCTION_Solve_mult_phi_given_assumed_NSC.m`, is now present as `solve_mult_phi_given_assumed_nsc(...)`.
+- The present runtime pipeline still executes the steady-state `S3-S6` path, which matches the current GOSM formulation.
+- Appendix `S10.1-S10.2` is explicitly introduced as "a more complex model formulation for future development", so lack of full runtime integration there should not be treated as a missing present-day kernel.
+
+### Evidence
+
+- `docs/architecture/review/matlab-source-parity-audit-note.md` records the old helper gap and notes that it was later closed by slice `094`.
+- `src/stomatal_optimiaztion/domains/gosm/model/steady_state.py` now contains `solve_mult_phi_given_assumed_nsc(...)`.
+- `src/stomatal_optimiaztion/domains/gosm/model/pipeline.py` still exposes the current executable `S3-S6` pipeline.
+- `src/stomatal_optimiaztion/domains/gosm/model/future_work.py` contains helper-level implementations for `Eq.S10.1` and `Eq.S10.2`.
+- `src/stomatal_optimiaztion/domains/gosm/model_card/C009.json` explicitly frames `S10.2` as future development and notes unresolved definitions for the full `F_i` dynamics.
+
+### Interpretation
+
+`GOSM` currently sits in a mixed state:
+
+- present model: implemented
+- future-work branch: partially represented as helpers and documentation, not as a full runtime branch
+
+That is acceptable unless the project goal changes from parity with the published current model to prototyping the future complex formulation.
+
+## TDGM
+
+### Verdict
+
+Root `TDGM` has no currently-open core runtime gap, but it retains one documentation-grade traceability weakness.
+
+### Reasoning
+
+- The bounded compatibility helper previously missing from the MATLAB parity audit, `FUNCTION_Initial_Mean_Allocation_Fractions.m`, is now implemented as `initial_mean_allocation_fractions(...)`.
+- The turgor-driven growth core (`S2.12`, `S2.16`) and THORP-G coupling core (`S3.1-S3.8`) are present.
+- The PTM front-half derivations in `S1.9-S1.21` are not exposed as standalone runtime helpers. Instead, the current PTM seam exposes the later closed-form concentration solver (`Eq_S1.26`, `Eq_S1.30`, `Eq_S1.35`, `Eq_S1.36`, `Eq_S1.38`) and folds earlier unloading/flux derivations into the coefficients of that solver.
+
+### Evidence
+
+- `docs/architecture/review/matlab-source-parity-audit-note.md` records the old allocation-memory initialization gap and notes that it was later closed by slice `095`.
+- `src/stomatal_optimiaztion/domains/tdgm/coupling.py` now contains `initial_mean_allocation_fractions(...)`, `realized_growth_rate(...)`, and the allocation-memory filter.
+- `src/stomatal_optimiaztion/domains/tdgm/turgor_growth.py` implements `Eq_S2.12` and `Eq_S2.16`.
+- `src/stomatal_optimiaztion/domains/tdgm/ptm.py` exposes the closed-form PTM concentration solver but not separate helpers for `S1.9-S1.21`.
+- `src/stomatal_optimiaztion/domains/tdgm/model_card/C002.json` still documents `Eq_S1.9-S1.21`, so the literature traceability is richer than the current public helper surface.
+
+### Interpretation
+
+This is not a proof of wrong behavior. It means:
+
+- runtime parity target: mostly satisfied
+- appendix-to-function 1:1 traceability: incomplete for PTM derivation steps
+
+If a future documentation or pedagogy slice wants exact paper-to-code correspondence, the best candidate is a bounded TDGM PTM documentation/helper slice that re-exposes `S1.9-S1.21` as named intermediate helpers without changing numerical behavior.
+
+## Cross-Model Difference In Plain Language
+
+- `THORP`: mostly "folded, not missing"
+- `GOSM`: mostly "future-work, not required for current runtime"
+- `TDGM`: mostly "implemented, but some derivation steps are folded together"
+
+## Open Risk After This Audit
+
+The only still-open item that remains actionable at the architecture level is:
+
+- root `TDGM` long-horizon control drift against the legacy MATLAB payload, already recorded as `D-108` in `docs/architecture/gap_register.md`
+
+This audit did not find evidence that the drift is caused by a newly discovered missing appendix equation.
+
+## Verification Snapshot
+
+Targeted regression checks used during the audit:
+
+- `.venv\\Scripts\\python.exe -m pytest tests/test_gosm_steady_state_inversion.py tests/test_tdgm_coupling.py tests/test_thorp_equation_registry.py -q`
+
+Result:
+
+- `9 passed`
+
+## Recommended Next Step
+
+Do not open a new runtime refactor wave from these appendix notes alone.
+
+If a follow-up documentation slice is desired, prefer one of the following:
+
+1. add a small TDGM PTM traceability note or helper-spec for `S1.9-S1.21`
+2. add a GOSM note that explicitly separates current-model equations from `S10` future-work equations
+3. keep the repository in monitor mode and treat the appendix audit as informational evidence only


### PR DESCRIPTION
﻿## Background
- The recursive architecture refactoring wave is now closed through slices 101-108, and the repository needs an explicit closeout/handoff packet rather than leaving that state implicit in scattered notes.
- The remaining root TDGM long-horizon drift is still intentionally open as issue #209 and is prepared as the next bounded slice rather than being closed by this PR.

## Changes
- add an architecture closeout note under `docs/architecture/delivery/`
- add the appendix-equation coverage audit note for root THORP, GOSM, and TDGM
- add module 109 and the executor packet for the bounded TDGM drift follow-up
- update `Phytoritas.md`, repo `README.md`, and review/delivery indexes to reflect monitor-mode closeout and the handoff to issue #209

## Validation
- no new runtime code changed in this PR
- recorded validation carried forward in the closeout note:
  - `python -m pytest -q` -> `418 passed, 1 skipped`
  - `ruff check .` -> pass
  - targeted appendix coverage tests -> `9 passed`

## Impact
- architecture closeout is now explicit and reviewable from the repository-facing docs
- the next implementation wave is constrained to the bounded TDGM drift investigation
- issue #209 remains open and is referenced as the next action, not falsely closed

## Linked issue
Closes #216
Refs #209