### PR TITLE
[Bug] Narrow TDGM drift to root dk_canopy_max branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ poetry run ruff check .
 - Issue `#209` / module `109` fixed the first proven root `TDGM` long-horizon control-drift seam and locked it with a bounded regression.
 - Issue `#218` / module `110` diagnosed the remaining post-day-`791.5` reopening point and ruled out the mean-allocation filter as the next fix direction.
 - Issue `#220` / module `111` rejected the stale stem-curve candidate and narrowed the remaining drift to the root-specific zero-point derivative branch, with the vertical-root sensitivity path most inflated.
-- One bounded follow-up gap remains open: the remaining post-day-`791.5` root `TDGM` full-series control drift (`D-108`), prepared next as module `112` and GitHub issue `#222`.
+- Issue `#222` / module `112` exonerated the direct `d_psi_rc0_d_c_r_*` branch and narrowed the remaining drift to the root-specific `dk_canopy_max_d_c_r_*` derivative branch, with the vertical-root path still more inflated than the horizontal-root path.
+- One bounded follow-up gap remains open: the remaining post-day-`791.5` root `TDGM` full-series control drift (`D-108`), prepared next as module `113` and GitHub issue `#224`.
 - Gates A through C are satisfied for the first bounded migration slice.
 - THORP `model_card` and traceability helpers are migrated into the new package layout.
 - THORP `radiation` runtime seam is migrated as slice 002.
@@ -146,7 +147,7 @@ poetry run ruff check .
 
 ## Next validation
 - Keep `pytest`, `ruff`, and the root rerun parity renderers green while the architecture remains in monitor mode.
-- Start the next implementation wave only from `docs/architecture/architecture/module_specs/module-112-tdgm-root-sensitivity-zero-point-derivative-branch.md` and GitHub issue `#222`.
+- Start the next implementation wave only from `docs/architecture/architecture/module_specs/module-113-tdgm-root-dk-canopy-max-derivative-branch.md` and GitHub issue `#224`.
 - Keep the fast root `GOSM` rerun tests warning-free and run the opt-in slow `imag` branch whenever root `gosm` hydraulics or stomatal logic changes.
 - Run the opt-in slow `GOSM` `imag` conductance-loss parity branch when root `gosm` hydraulics or stomatal logic changes.
 - Re-render `scripts/render_root_rerun_parity_figures.py` whenever root `THORP`, `GOSM`, or `TDGM` rerun kernels change.

--- a/docs/architecture/Phytoritas.md
+++ b/docs/architecture/Phytoritas.md
@@ -5,7 +5,7 @@
 - Bound repo root: `C:\Users\yhmoo\OneDrive\Phytoritas\projects\stomatal-optimiaztion`
 - Legacy source root: `C:\Users\yhmoo\OneDrive\Phytoritas\00. Stomatal Optimization`
 - Working mode: auto-bootstrap plus manual evidence capture
-- Current phase: the recursive architecture refactoring wave is closed through slices `101-108`, slice `109` has fixed the first proven root `TDGM` long-horizon control-drift seam, slice `110` has diagnosed the remaining post-day-`791.5` reopening point, slice `111` has narrowed the remaining gap to the root-specific zero-point derivative branch, the architecture spine and validation contract are green, and the repository is now in delivery-closeout mode with one bounded follow-up gap still open: the remaining post-day-`791.5` root `TDGM` control drift (`D-108`, prepared next as module `112` and GitHub issue `#222`)
+- Current phase: the recursive architecture refactoring wave is closed through slices `101-108`, slice `109` has fixed the first proven root `TDGM` long-horizon control-drift seam, slice `110` has diagnosed the remaining post-day-`791.5` reopening point, slice `111` has narrowed the remaining gap to the root-specific zero-point derivative branch, slice `112` has further narrowed that gap to the root-specific `dk_canopy_max` derivative branch, the architecture spine and validation contract are green, and the repository is now in delivery-closeout mode with one bounded follow-up gap still open: the remaining post-day-`791.5` root `TDGM` control drift (`D-108`, prepared next as module `113` and GitHub issue `#224`)
 
 ## Scope
 
@@ -102,5 +102,5 @@ Broad implementation remains blocked until Gates A through C are satisfied.
 1. treat the current architecture scaffold, ADR spine, module-spec chain, and rerun parity bundle contract as the stable baseline for further work
 2. keep the validation gates green by rerunning the fast root parity tests and `scripts/render_root_rerun_parity_figures.py --fast-smoke` whenever `THORP`, `GOSM`, or `TDGM` runtime kernels change
 3. rerender the default full-series control bundles for root `THORP` and `TDGM` whenever their runtime kernels change so the canonical `python/legacy/diff` CSV evidence stays current
-4. resume implementation only through the bounded follow-up slice in `docs/architecture/architecture/module_specs/module-112-tdgm-root-sensitivity-zero-point-derivative-branch.md` and GitHub issue `#222`
-5. do not declare the root `TDGM` parity wave closed until new full-series evidence shows the remaining post-day-`791.5` drift is either explained or removed by the narrowed root-specific zero-point derivative slice
+4. resume implementation only through the bounded follow-up slice in `docs/architecture/architecture/module_specs/module-113-tdgm-root-dk-canopy-max-derivative-branch.md` and GitHub issue `#224`
+5. do not declare the root `TDGM` parity wave closed until new full-series evidence shows the remaining post-day-`791.5` drift is either explained or removed by the narrowed root-specific `dk_canopy_max` derivative slice

--- a/docs/architecture/architecture/module_specs/module-113-tdgm-root-dk-canopy-max-derivative-branch.md
+++ b/docs/architecture/architecture/module_specs/module-113-tdgm-root-dk-canopy-max-derivative-branch.md
@@ -1,0 +1,59 @@
+# Module 113: TDGM Root dk_canopy_max Derivative Branch
+
+## Goal
+
+Reduce the remaining open `D-108` gap to the next bounded implementation slice by checking whether the post-day-`791.5` root `TDGM` drift is caused specifically by `dk_canopy_max_d_c_r_h` and `dk_canopy_max_d_c_r_v` inside `tdgm.thorp_g.hydraulics.stomata()`.
+
+## Inputs
+
+- module `112` diagnosis note:
+  - `docs/architecture/review/tdgm-root-dk-canopy-max-derivative-diagnosis-note.md`
+- open gap `D-108` in `docs/architecture/gap_register.md`
+- current runtime seam under:
+  - `src/stomatal_optimiaztion/domains/tdgm/thorp_g/hydraulics.py`
+- current rerun evidence under:
+  - `out/rerun_parity/tdgm/thorp_data_control_turgor/`
+
+## Target Artifacts
+
+- update `docs/architecture/review/python-rerun-parity-audit-note.md`
+- add or update a focused diagnosis note for the `dk_canopy_max` branch
+- if the seam is fixed, extend the bounded TDGM rerun regression window beyond day `791.5`
+- if the seam is only partially narrowed, open one more focused follow-up slice instead of reopening the full THORP-G sensitivity path
+
+## Responsibilities
+
+1. audit the root-specific `dk_canopy_max` derivative terms:
+   - `dk_canopy_max_d_c_r_h`
+   - `dk_canopy_max_d_c_r_v`
+2. compare their upstream state terms against the legacy MATLAB path:
+   - `c0_var`
+   - `f_r0`
+   - `df_r0_d_psi_rc0`
+   - `d2f_r0_d_psi_rc0`
+   - `r_r_h0`
+   - `r_r_v0`
+   - `r_r0`
+3. prove whether one bounded change in that branch moves or closes the first reopened day-`791.5` drift point
+4. keep the slice scoped to the `dk_canopy_max` root branch rather than reopening mean allocation, sapwood sensitivity, or the direct `d_psi_rc0_d_c_r_*` path
+
+## Non-Goals
+
+- do not revisit the already-exonerated zero-flux `f_ri` branch in `e_from_soil_to_root_collar()`
+- do not reopen the rejected stale stem-curve candidate
+- do not replace the MATLAB-consistent mean-allocation update with an exact filter
+- do not treat the direct `d_psi_rc0_d_c_r_*` terms as the primary target unless new evidence contradicts module `112`
+
+## Validation
+
+1. `.\.venv\Scripts\python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py -q`
+2. bounded rerun audit through at least `max_steps=3300`
+3. `.\.venv\Scripts\python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py tests/test_root_rerun_parity_figures.py -q`
+4. `.\.venv\Scripts\python.exe scripts\render_root_rerun_parity_figures.py --output-dir out/rerun_parity --domains tdgm`
+5. `.\.venv\Scripts\python.exe -m pytest -q`
+6. `.\.venv\Scripts\ruff.exe check .`
+
+## Exit Criteria
+
+- the first post-day-`791.5` drift point either moves later or is removed with one bounded `dk_canopy_max` root-sensitivity change, or
+- the next remaining culprit is named explicitly inside the root-specific `dk_canopy_max` derivative branch with tighter evidence than module `112`

--- a/docs/architecture/delivery/architecture-closeout-note.md
+++ b/docs/architecture/delivery/architecture-closeout-note.md
@@ -16,9 +16,10 @@
   - diagnosis note: `docs/architecture/review/tdgm-full-series-control-drift-diagnosis-note.md`
   - module `110` diagnosis note: `docs/architecture/review/tdgm-post-791d-stomata-sensitivity-diagnosis-note.md`
   - module `111` diagnosis note: `docs/architecture/review/tdgm-root-sensitivity-zero-point-diagnosis-note.md`
-  - next module spec: `docs/architecture/architecture/module_specs/module-112-tdgm-root-sensitivity-zero-point-derivative-branch.md`
-  - next executor packet: `docs/architecture/executor/issue-222-bug-tdgm-root-sensitivity-zero-point-derivative-branch.md`
-  - GitHub tracking: issue `#222` should be the next `Ready` bounded bug slice
+  - module `112` diagnosis note: `docs/architecture/review/tdgm-root-dk-canopy-max-derivative-diagnosis-note.md`
+  - next module spec: `docs/architecture/architecture/module_specs/module-113-tdgm-root-dk-canopy-max-derivative-branch.md`
+  - next executor packet: `docs/architecture/executor/issue-224-bug-tdgm-root-dk-canopy-max-derivative-branch.md`
+  - GitHub tracking: issue `#224` should be the next `Ready` bounded bug slice
 
 ## Verification
 
@@ -32,11 +33,11 @@
 
 ## Open Gap
 
-- `D-108`: root `TDGM` canonical full-series control rerun still reopens against the legacy MATLAB payload after day `791.5`; module `111` narrows the next likely culprit to the root-specific zero-point derivative branch inside the `THORP-G` sensitivity path
+- `D-108`: root `TDGM` canonical full-series control rerun still reopens against the legacy MATLAB payload after day `791.5`; module `112` narrows the next likely culprit to the root-specific `dk_canopy_max` derivative branch inside the `THORP-G` sensitivity path
 - this gap is not treated as a scaffold failure; it is a bounded numerical diagnosis slice queued for the next implementation wave
 
 ## Next Action
 
-- start from module `112` / issue `#222`
-- audit the root-specific zero-point derivative terms inside the `THORP-G` sensitivity path
+- start from module `113` / issue `#224`
+- audit the root-specific `dk_canopy_max` derivative terms inside the `THORP-G` sensitivity path
 - keep the next slice bounded to one fix or one tighter culprit

--- a/docs/architecture/executor/issue-224-bug-tdgm-root-dk-canopy-max-derivative-branch.md
+++ b/docs/architecture/executor/issue-224-bug-tdgm-root-dk-canopy-max-derivative-branch.md
@@ -1,0 +1,25 @@
+## repro
+- rerun the canonical root `TDGM` control case against `THORP_data_Control_Turgor.mat`
+- confirm that the first remaining mismatch still reopens at day `791.5`
+- inspect the root-specific `dk_canopy_max` derivative terms inside `src/stomatal_optimiaztion/domains/tdgm/thorp_g/hydraulics.py`
+
+## expected / actual
+- expected: the post-day-`791.5` control drift should be reducible by one bounded `dk_canopy_max` change or be narrowed to one explicit derivative culprit inside that branch
+- actual: module `112` shows that scaling the direct `d_psi_rc0_d_c_r_*` terms does almost nothing, while scaling only `dk_canopy_max_d_c_r_h` and `dk_canopy_max_d_c_r_v` sharply improves the day-`791.5` legacy allocation fit
+
+## scope
+- `src/stomatal_optimiaztion/domains/tdgm/thorp_g/hydraulics.py`
+- specifically `dk_canopy_max_d_c_r_h` and `dk_canopy_max_d_c_r_v`
+- bounded rerun evidence around day `791.5`
+
+## fix idea
+- audit the `dk_canopy_max` derivative formulas and their upstream state terms against the legacy MATLAB path
+- test one bounded change at a time inside that branch
+- keep the fast parity tests and the bounded long-horizon diagnostics green while pushing the first mismatch later than day `791.5`
+
+## test
+- `.\.venv\Scripts\python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py -q`
+- bounded rerun audit through `max_steps=3300`
+- `.\.venv\Scripts\python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py tests/test_root_rerun_parity_figures.py -q`
+- `.\.venv\Scripts\python.exe -m pytest -q`
+- `.\.venv\Scripts\ruff.exe check .`

--- a/docs/architecture/gap_register.md
+++ b/docs/architecture/gap_register.md
@@ -4,7 +4,7 @@
 | --- | --- | --- | --- |
 
 Current open gaps:
-- `D-108`: root `TDGM` canonical full-series control rerun still reopens against the legacy MATLAB payload after day `791.5`; module `111` narrows the next likely culprit to the root-specific zero-point derivative branch inside the `THORP-G` sensitivity path, especially `d_psi_rc0_d_c_r_*` and `dk_canopy_max_d_c_r_*`
+- `D-108`: root `TDGM` canonical full-series control rerun still reopens against the legacy MATLAB payload after day `791.5`; module `112` narrows the next likely culprit to the root-specific `dk_canopy_max` derivative branch inside the `THORP-G` sensitivity path, especially `dk_canopy_max_d_c_r_h` and `dk_canopy_max_d_c_r_v`
 
 Last closed wave:
 - slices `101-108` restored direct root Python rerun parity against legacy MATLAB outputs for `THORP`, `GOSM`, and `TDGM`, upgraded the live graph surface to rerun-only Plotkit bundles with explicit `python/legacy/diff` CSV exports, pruned the remaining legacy-only example plotting assets from the repository, and vectorized the THORP/TDGM root-uptake bottleneck so canonical full-series control rerenders complete in practical time

--- a/docs/architecture/review/README.md
+++ b/docs/architecture/review/README.md
@@ -8,6 +8,7 @@ Current notes:
 - `tdgm-full-series-control-drift-diagnosis-note.md`: bounded diagnosis summary for the first proven root `TDGM` long-horizon control-drift seam and its post-`791.5` handoff
 - `tdgm-post-791d-stomata-sensitivity-diagnosis-note.md`: bounded diagnosis summary for the remaining post-`791.5` TDGM drift, including why the next seam is in the THORP-G sensitivity path rather than the mean-allocation filter
 - `tdgm-root-sensitivity-zero-point-diagnosis-note.md`: bounded diagnosis summary showing that the remaining post-`791.5` TDGM drift is now narrowed to the root-specific zero-point sensitivity derivatives, with the vertical-root branch most inflated
+- `tdgm-root-dk-canopy-max-derivative-diagnosis-note.md`: bounded diagnosis summary showing that the remaining post-`791.5` TDGM drift is dominated by the root-specific `dk_canopy_max` derivative branch rather than the direct `d_psi_rc0` branch
 - `matlab-source-parity-audit-note.md`: original MATLAB source coverage audit for root `THORP`, `GOSM`, and `TDGM`
 - `legacy-example-parity-audit-note.md`: legacy example and figure workflow audit after the MATLAB-source parity wave
 - `thorp-package-smoke-validation-note.md`: package-level THORP smoke validation summary

--- a/docs/architecture/review/python-rerun-parity-audit-note.md
+++ b/docs/architecture/review/python-rerun-parity-audit-note.md
@@ -52,12 +52,17 @@ Out of scope for this note:
    - a bounded stem-curve candidate that swapped `VC_sw(min(0, psi_l_i))` for `VC_sw(min(0, psi_s_i))` is rejected because it breaks the fast THORP-G parity guard immediately
    - day-`791.5` allocation-fit experiments show that scaling only the root sensitivity derivatives improves the legacy match more than scaling all `dE` derivatives together
    - the vertical-root sensitivity branch is more overestimated than the horizontal-root branch, so the next likely culprit is the root-specific zero-point derivative branch rather than sapwood or the shared mean-allocation logic
-10. Root rerun parity is now directly inspectable without reading pytest internals. `scripts/render_root_rerun_parity_figures.py` renders Plotkit-style bundles under `out/rerun_parity/` with:
+10. Module `112` narrows the same gap one step further:
+   - the zero-flux `f_ri` legacy quirk in `e_from_soil_to_root_collar()` never triggers in the bounded rerun and is therefore exonerated as the reopened culprit
+   - at day `791.5`, the direct `k_canopy_max * d_psi_rc0_d_c_r_*` contribution is tiny, while the `i_var * dk_canopy_max_d_c_r_*` contribution dominates both root sensitivity branches
+   - scaling only the `dk_canopy_max` contribution improves the day-`791.5` legacy allocation fit by about twenty-fold, while scaling only the direct `d_psi_rc0` contribution does almost nothing
+   - the next likely culprit is therefore the root-specific `dk_canopy_max_d_c_r_*` branch, especially the vertical-root path
+11. Root rerun parity is now directly inspectable without reading pytest internals. `scripts/render_root_rerun_parity_figures.py` renders Plotkit-style bundles under `out/rerun_parity/` with:
    - `THORP` control `png + python/legacy/diff csv`
    - `GOSM` control plus fast sensitivity `png + python/legacy/diff csv`
    - `TDGM` canonical control `png + python/legacy/diff csv` by default
-11. The old legacy-only example plotting scripts/specs/tests have been pruned from the live repository surface so that `out/rerun_parity/` is the only supported graph inspection entrypoint for root rerun comparison.
-12. Within the documented rerun-comparison scope, root `THORP` and root `GOSM` are currently closed, but root `TDGM` still reopens one bounded later-horizon full-series control-drift gap.
+12. The old legacy-only example plotting scripts/specs/tests have been pruned from the live repository surface so that `out/rerun_parity/` is the only supported graph inspection entrypoint for root rerun comparison.
+13. Within the documented rerun-comparison scope, root `THORP` and root `GOSM` are currently closed, but root `TDGM` still reopens one bounded later-horizon full-series control-drift gap.
 
 ## Validation Executed
 
@@ -97,4 +102,4 @@ Out of scope for this note:
 1. keep the rerun parity tests green whenever root hydraulic or growth kernels change
 2. rerun the opt-in slow `GOSM` `imag` conductance-loss branch when touching root `gosm` hydraulics or stomatal-model logic
 3. rerender `scripts/render_root_rerun_parity_figures.py` whenever root rerun kernels change
-4. investigate the remaining post-day-`791.5` root `TDGM` full-series control drift through the bounded root-specific zero-point derivative slice before declaring that domain fully parity-complete over the long horizon
+4. investigate the remaining post-day-`791.5` root `TDGM` full-series control drift through the bounded root-specific `dk_canopy_max` derivative slice before declaring that domain fully parity-complete over the long horizon

--- a/docs/architecture/review/tdgm-root-dk-canopy-max-derivative-diagnosis-note.md
+++ b/docs/architecture/review/tdgm-root-dk-canopy-max-derivative-diagnosis-note.md
@@ -1,0 +1,81 @@
+# TDGM Root dk_canopy_max Derivative Diagnosis Note
+
+## Purpose
+
+Record the bounded diagnosis slice from module `112` / GitHub issue `#222` for the remaining post-day-`791.5` root `TDGM` control drift.
+
+## Scope
+
+- canonical control payload:
+  - `TDGM/example/Supplementary Code __THORP_code_v1.4/Simulations_and_code_to_plot/THORP_data_Control_Turgor.mat`
+- bounded Python rerun horizon:
+  - `max_steps=3300`
+  - stored horizon through day `819.5`
+- current runtime seam under:
+  - `src/stomatal_optimiaztion/domains/tdgm/thorp_g/hydraulics.py`
+
+## Findings
+
+1. The MATLAB `FUNCTION_E_from_Soil_to_Root_Collar.m` zero-flux branch where `E_i = 0` leaves `f_ri` implicit, but that legacy quirk is not the reopened culprit in the bounded rerun:
+   - a wrapper audit recorded `0` hits for that branch through `max_steps=3300`
+   - the active equality branch fired `3300` times instead
+   - carrying the previous `f_ri` value through the zero-flux branch changed nothing at day `784.5` or day `791.5`
+2. At the reopened day `791.5` drift point, the root-sensitivity decomposition inside `stomata()` is dominated by the `dk_canopy_max` branch rather than the direct zero-point derivative branch:
+   - horizontal root sum:
+     - direct `k_canopy_max * d_psi_rc0_d_c_r_h`: `2.76e-06`
+     - `i_var * dk_canopy_max_d_c_r_h`: `5.18e-04`
+     - local additive term: `-1.43e-04`
+   - vertical root sum:
+     - direct `k_canopy_max * d_psi_rc0_d_c_r_v`: `6.57e-06`
+     - `i_var * dk_canopy_max_d_c_r_v`: `5.69e-04`
+     - local additive term: `-1.12e-04`
+3. Scaling only the shared `dk_canopy_max` contribution sharply improves the day-`791.5` legacy allocation fit:
+   - baseline allocation-fit error: `0.03152`
+   - best shared `dk` scale: about `0.60`
+   - improved allocation-fit error: `0.00151`
+4. Scaling only the direct `d_psi_rc0_d_c_r_*` contribution does not materially improve the fit:
+   - best shared direct scale: `0.00`
+   - allocation-fit error remains `0.03046`
+   - the direct branch is therefore too small to explain the reopened drift on its own
+5. Allowing the `dk_canopy_max` terms to vary separately gives the tightest bounded fit near:
+   - `dk_canopy_max_d_c_r_h`: about `0.64` of the current Python amplitude
+   - `dk_canopy_max_d_c_r_v`: about `0.58` of the current Python amplitude
+   - resulting allocation-fit error: `0.000339`
+   This keeps the vertical-root path as the more inflated of the two `dk` branches.
+6. Allowing the direct `d_psi_rc0_d_c_r_*` terms to vary separately still does not move the fit in a meaningful way:
+   - best separate direct scales: `0.00 / 0.00`
+   - allocation-fit error remains `0.03046`
+7. The source-parity read-through did not reveal an obvious text-level transcription mismatch between the current Python `dk_canopy_max` formulas and the shipped MATLAB `FUNCTION_Stomata.m` expressions. The next bounded culprit is therefore narrower than "root zero-point derivatives" but not yet a proven one-line formula typo.
+
+## Validation Executed
+
+- targeted parity guard:
+  - `.\.venv\Scripts\python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py -q`
+  - result: `11 passed`
+- bounded decomposition and allocation-fit audit:
+  - rerun through `max_steps=3300`
+  - capture the day-`791.5` `stomata()` state
+  - decompose `d_e_d_c_r_h` and `d_e_d_c_r_v` into:
+    - direct `k_canopy_max * d_psi_rc0_d_c_r_*`
+    - `i_var * dk_canopy_max_d_c_r_*`
+    - local additive root term
+  - compare legacy allocation fit under:
+    - shared `dk` scaling
+    - shared direct scaling
+    - separate horizontal / vertical `dk` scaling
+    - separate horizontal / vertical direct scaling
+
+## Result
+
+- module `112` rules out the direct `d_psi_rc0_d_c_r_*` branch as the next meaningful fix target
+- module `112` narrows the open `D-108` gap further to the root-specific `dk_canopy_max` derivative branch inside `tdgm.thorp_g.hydraulics.stomata()`
+- the remaining likely culprits are now:
+  - `dk_canopy_max_d_c_r_h`
+  - `dk_canopy_max_d_c_r_v`
+  - especially the vertical-root `dk_canopy_max_d_c_r_v` path
+
+## Next Action
+
+1. start from `docs/architecture/architecture/module_specs/module-113-tdgm-root-dk-canopy-max-derivative-branch.md`
+2. use `docs/architecture/executor/issue-224-bug-tdgm-root-dk-canopy-max-derivative-branch.md` as the GitHub execution packet
+3. keep the next slice bounded to the `dk_canopy_max_d_c_r_*` formulas and their upstream state terms inside `src/stomatal_optimiaztion/domains/tdgm/thorp_g/hydraulics.py`


### PR DESCRIPTION
﻿## Background
- module `112` continued the bounded day-`791.5` TDGM drift diagnosis inside the root-specific zero-point derivative branch
- the remaining open gap stayed on issue `#222` while a tighter follow-up issue was prepared only after the culprit was narrowed again

## Changes
- added a new diagnosis note showing that the remaining day-`791.5` allocation mismatch is dominated by the root-specific `dk_canopy_max` derivative branch rather than the direct `d_psi_rc0` branch
- prepared module `113` and issue `#224` as the next bounded follow-up slice
- updated the README, Phytoritas blueprint, closeout note, gap register, and parity audit to point at the new handoff

## Validation
- `./.venv/Scripts/python.exe -m pytest tests/test_tdgm_thorp_g_rerun_parity.py -q`
  - `11 passed`
- bounded day-`791.5` decomposition audit through `max_steps=3300`
  - shared `dk` scaling improves allocation-fit error from `0.03152` to `0.00151`
  - direct `d_psi_rc0` scaling leaves the error essentially unchanged at `0.03046`

## Impact
- `#222` closes as a diagnosis slice rather than a code-fix slice
- the remaining open TDGM parity gap is now bounded to `dk_canopy_max_d_c_r_h` and `dk_canopy_max_d_c_r_v`, especially the vertical-root branch
- `#224` is the next `Ready` implementation target

## Linked issue
Closes #222