### PR TITLE
[Model Change] Sync TOMICS tomato legacy model with model-foundry tomato_v1_2

### DIFF
--- a/docs/variable_glossary.md
+++ b/docs/variable_glossary.md
@@ -53,6 +53,14 @@ Use one canonical name per concept across repositories.
 | Shoot leaf base share | `leaf_fraction_of_shoot_base` | `tomics_leaf_fraction_of_shoot_base` | fraction of shoot allocation | Default 0.70 |
 | Shoot stem base share | `stem_fraction_of_shoot_base` | `tomics_stem_fraction_of_shoot_base` | fraction of shoot allocation | Default 0.30 |
 
+## Tomato legacy model state
+
+| Concept | Canonical short name | Optional verbose alias | Typical unit | Notes |
+|---|---|---|---|---|
+| Truss development stage | `tdvs` | `truss_development_stage` | 0-1 | Cohort state advanced by FDVR in the v1.2-aligned tomato legacy model |
+| Vegetative sink strength per shoot | `veg_sink_g_d_per_shoot` | `vegetative_sink_strength_per_shoot` | g DW shoot^-1 d^-1 | Converted to per-floor sink with `shoots_per_m2` |
+| Carbohydrate reserve pool | `reserve_ch2o_g` | `carbohydrate_reserve_pool` | g CH2O m^-2 | Temporary buffer used by sink-limited tomato growth updates |
+
 ## Rules
 - Use lowercase snake_case.
 - Reuse the same name for the same concept in every repository.

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/models/tomato_legacy/tomato_model.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/models/tomato_legacy/tomato_model.py
@@ -8,13 +8,16 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from scipy.optimize import fsolve
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.partitioning import (
     PartitionPolicy,
     coerce_partition_policy,
 )
-from stomatal_optimiaztion.domains.tomato.tomics.alloc.contracts import EnvStep
-from stomatal_optimiaztion.domains.tomato.tomics.alloc.interface import run_flux_step
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.contracts import (
+    EnvStep,
+    water_supply_stress_from_theta,
+)
 
 PHOTON_UMOL_TO_MJ = 0.218e-6
 LOGGER = logging.getLogger(__name__)
@@ -48,15 +51,57 @@ def _resolve_partition_key(raw: object) -> str:
     return str(key).strip().lower()
 
 
-class TomatoModel:
-    """Bounded legacy-compatible tomato model surface for staged migration.
+def esat_Pa_from_T_C(t_c: float) -> float:
+    """Tetens saturation vapor pressure from air temperature in Celsius."""
 
-    This slice preserves the public state, CSV ingestion, output payload, and
-    default adapter construction surface from the legacy `tomato_model.py`,
-    including TOMATO-local partition-policy execution.
-    The deeper age-structured growth, full energy-balance solver, and wider
-    package-level pipeline seams remain blocked for later slices.
-    """
+    return float(610.78 * math.exp((17.2694 * t_c) / (t_c + 237.29)))
+
+
+def slope_esat_Pa_per_K(t_c: float) -> float:
+    saturation_vapor_pressure_pa = esat_Pa_from_T_C(t_c)
+    return float(saturation_vapor_pressure_pa * (17.2694 * 237.29) / ((t_c + 237.29) ** 2))
+
+
+def psychrometric_constant_Pa_per_K(
+    P_Pa: float = 101325.0,
+    cp: float = 1004.0,
+    lambda_v: float = 2.45e6,
+    eps: float = 0.622,
+) -> float:
+    return float(cp * P_Pa / (eps * lambda_v))
+
+
+def penman_monteith_LE_Wm2(
+    Rn_Wm2: float,
+    Ta_K: float,
+    VPD_Pa: float,
+    ra_s_m: float,
+    rc_s_m: float,
+    rho: float = 1.225,
+    cp: float = 1004.0,
+    gamma_PaK: float | None = None,
+    allow_negative: bool = False,
+) -> float:
+    """Ground-area Penman-Monteith latent heat flux in W/m2."""
+
+    ta_c = float(Ta_K) - 273.15
+    slope = slope_esat_Pa_per_K(ta_c)
+    gamma = psychrometric_constant_Pa_per_K() if gamma_PaK is None else float(gamma_PaK)
+    aerodynamic_resistance = max(1e-6, float(ra_s_m))
+    canopy_resistance = max(0.0, float(rc_s_m))
+    denominator = slope + gamma * (1.0 + canopy_resistance / aerodynamic_resistance)
+    if denominator <= 1e-12:
+        return 0.0
+
+    numerator = slope * float(Rn_Wm2) + float(rho) * (float(cp) * (float(VPD_Pa) / aerodynamic_resistance))
+    latent_heat_flux = numerator / denominator
+    if (not allow_negative) and latent_heat_flux < 0.0:
+        latent_heat_flux = 0.0
+    return float(latent_heat_flux)
+
+
+class TomatoModel:
+    """TOMICS-compatible tomato legacy model updated from model-foundry tomato_v1_2."""
 
     def __init__(
         self,
@@ -74,13 +119,73 @@ class TomatoModel:
             else {}
         )
 
+        self.photosyn_mode = "fvcb_canopy"
+        self.use_age_structured_sink = True
+
+        self.rho_a = 1.225
+        self.c_p = 1004.0
+        self.sigma = 5.67e-8
         self.lambda_v = 2.45e6
         self.alpha_c = 0.15
-        self.k_ext = 0.72
+        self.emissivity_c = 0.98
+        self.emissivity_cover = 0.84
         self.W_TO_UMOL_CONVERSION = 4.6
         self.PAR_FRACTION_OF_SW = 0.45
+        self.P_air = 101325.0
+        self.eps_air = 0.622
+        self.gamma = psychrometric_constant_Pa_per_K(
+            self.P_air,
+            self.c_p,
+            self.lambda_v,
+            self.eps_air,
+        )
+        self.allow_condensation = True
+        self.leaf_dimension = 0.15
+        self.k_ext = 0.72
+
+        self.fcvb_params = {
+            "V_Ha": 91185.0,
+            "R": 8.314,
+            "V_S": 650.0,
+            "V_Hd": 202900.0,
+            "J_Ha": 79500.0,
+            "J_S": 650.0,
+            "J_Hd": 201000.0,
+            "O": 210.0,
+            "a": 0.3,
+            "default_theta": 0.7,
+        }
+        self.joubert_params = {
+            "Vcmax": 99.25,
+            "Jmax": 190.68,
+            "Rd": 1.0,
+            "theta_J": 0.41,
+            "gamma_J": 0.9,
+            "c1": 19.02,
+            "dHa1_kJ": 37.83,
+            "c2": 12.3772,
+            "dHa2_kJ": 23.72,
+            "c3": 37.96,
+            "dHa3_kJ": 79.43,
+            "R1_kJ": 0.008314,
+            "O_i_kPa": 21.0,
+        }
+
+        self.MAINT_25C = {"lv": 0.03, "st": 0.015, "rt": 0.01, "fr": 0.01}
+        self.ASR = {"lv": 1.39, "st": 1.45, "rt": 1.39, "fr": 1.37}
+        self.Q10_maint = 2.0
+        self.f_Rm_RGR = 33.0
+
         self.harvest_truss_dm_g = 80.0
         self.root_frac_of_total_veg = 0.15 / 1.15
+        self.veg_sink_g_d_per_shoot = 2.8
+        self.pgr_params = {"a": 0.138, "b": 4.34, "c": 0.278, "d": 1.31}
+        self.tdvs_min = 0.0
+        self.tdvs_max = 1.0
+        self.LAI_max = 3.0
+        self.fr_T_min_valid = 18.0
+        self.fr_T_max_valid = 23.0
+        self.fr_clamp_to_valid = False
 
         self.plants_per_m2 = 1.836091
         self.shoots_per_plant = 1.0
@@ -103,6 +208,7 @@ class TomatoModel:
         self.W_rt = 10.0
         self.W_fr = 0.0
         self.W_fr_harvested = 0.0
+        self.reserve_ch2o_g = 0.0
 
         init_doy = self.start_date.timetuple().tm_yday
         sla_cm2_per_g = 266.0 + 88.0 * math.sin(2.0 * math.pi * (init_doy + 68) / 365.0)
@@ -124,6 +230,7 @@ class TomatoModel:
         self.convergence_status_Tc = False
         self.co2_flux_g_m2_s = 0.0
         self.dt_seconds = 0.0
+        self.water_supply_stress = self._resolve_water_supply_stress()
 
         self.daily_temp_accumulator: list[tuple[float, float]] = []
         self.daily_gross_ch2o_g = 0.0
@@ -142,6 +249,7 @@ class TomatoModel:
         self.truss_count = 0
         self._truss_fraction_acc = 0.0
         self.truss_cohorts: list[dict[str, object]] = []
+        self.pending_n_fruits: list[int] = []
 
         self.n_f = 2
         self.u_PAR = 0.0
@@ -155,9 +263,15 @@ class TomatoModel:
         self.part_stem = math.nan
         self.part_root = math.nan
         self.part_shoot = math.nan
+        self.part_veg = math.nan
+        self.vegetative_dw = self.W_lv + self.W_st + self.W_rt
+        self.fruit_dw = self.W_fr
 
         self._last_row_cols: set[str] = set()
         self._last_row_used_T_rad = False
+        self.eps_eff_last = 0.0
+        self.T_env_last_K = self.T_a
+        self.r_lw_net_last = 0.0
 
     def to_floor_from_plant(self, x_per_plant: float) -> float:
         return float(x_per_plant) * float(self.plants_per_m2)
@@ -309,7 +423,7 @@ class TomatoModel:
             "harvested_fruit_g_m2": check_and_clip_value(self.W_fr_harvested, 0.0, 1e7, 0.0),
             "fractional_cover": check_and_clip_value(self.f_c, 0.0, 1.0, 0.1),
             "SLA_m2_g": self.SLA,
-            "active_trusses": self._count_active_trusses(),
+            "active_trusses": float(self._count_active_trusses()),
             "alloc_frac_fruit": check_and_clip_value(self.part_fruit, 0.0, 1.0, math.nan),
             "alloc_frac_leaf": check_and_clip_value(self.part_leaf, 0.0, 1.0, math.nan),
             "alloc_frac_stem": check_and_clip_value(self.part_stem, 0.0, 1.0, math.nan),
@@ -354,7 +468,7 @@ class TomatoModel:
         }
 
     def run_timestep_calculations(self, dt_seconds: float, current_time: datetime) -> None:
-        """Advance one bounded timestep using the migrated lightweight flux contract."""
+        """Advance one timestep using the updated v1_2 canopy and sink logic."""
 
         dt = float(dt_seconds)
         if dt <= 0:
@@ -362,53 +476,116 @@ class TomatoModel:
 
         sim_date = current_time.date()
         if sim_date > self.current_date:
-            self._roll_daily_state(sim_date)
+            self.update_daily_boundary(sim_date)
             self.current_date = sim_date
 
         self.dt_seconds = dt
         self.LAI = self.calculate_current_lai()
         self.f_c = self.calculate_vegetation_cover()
+        self.water_supply_stress = self._resolve_water_supply_stress()
 
-        env = EnvStep(
-            t=current_time,
-            dt_s=dt,
-            T_air_C=self.T_a - 273.15,
-            PAR_umol=self.u_PAR,
-            CO2_ppm=self.u_CO2,
-            RH_percent=self.RH * 100.0,
-            wind_speed_ms=self.u,
-            SW_in_Wm2=self.SW_in_Wm2,
-            T_rad_C=self.T_rad_K - 273.15,
-            n_fruits_per_truss=self.n_f,
-        )
-        flux = run_flux_step(
-            env=env,
-            theta_substrate=float(self.theta_substrate),
-            moisture_response_fn=self.moisture_response_fn,
-        )
+        self.solve_coupled_energy_balance()
 
-        canopy_delta_c = min(6.0, max(0.0, self.u_PAR / 1200.0) * (0.4 + 0.6 * self.f_c) * (1.1 - self.RH))
-        self.T_c = self.T_a + canopy_delta_c
-        self.r_b = 70.0 / math.sqrt(max(self.u, 1e-6))
-        self.r_ah = 50.0 * math.sqrt(0.15 / max(self.u, 1e-6))
-        self.convergence_status_Tc = True
+        total_gross_photosynthesis_rate_umol, _, _ = self.calculate_canopy_photosynthesis(self.T_c)
+        instantaneous_rm_g_ch2o = self.calculate_instantaneous_respiration(self.T_c)
 
-        self.last_gsw_canopy = max(float(flux["g_w"]), 0.0)
-        self.co2_flux_g_m2_s = float(flux["a_n"])
-        self.LE_evap = max(float(flux["e"]), 0.0) * self.lambda_v / 1000.0
-        self.LE_cond = 0.0
-        self.LE = self.LE_evap
-        self.LE_raw = self.LE
-        self.H = max(0.0, canopy_delta_c) * (6.0 + 14.0 * self.f_c)
+        p_gross_g_co2 = total_gross_photosynthesis_rate_umol * 1e-6 * 44.01
+        r_g_co2 = instantaneous_rm_g_ch2o * (44.01 / 30.03)
+        self.co2_flux_g_m2_s = p_gross_g_co2 - r_g_co2
 
         self.daily_temp_accumulator.append((self.T_a, dt))
-        self.daily_gross_ch2o_g += max(0.0, self.co2_flux_g_m2_s) * 0.68
+        gross_ch2o_prod_g = (total_gross_photosynthesis_rate_umol * 1e-6 * 30.03) * dt
+        self.daily_gross_ch2o_g += max(0.0, gross_ch2o_prod_g)
         self.daily_par_umol_in_sum += max(0.0, self.u_PAR) * dt
-        intercepted_par_umol = max(0.0, self.u_PAR * (1.0 - math.exp(-self.k_ext * max(0.0, self.LAI))))
-        self.daily_par_umol_int_sum += intercepted_par_umol * dt
-        self.daily_transpiration_g += max(float(flux["e"]), 0.0) * dt
+        intercepted_par_umol_s = max(0.0, self.u_PAR * (1.0 - math.exp(-self.k_ext * max(0.0, self.LAI))))
+        self.daily_par_umol_int_sum += intercepted_par_umol_s * dt
 
-        self._apply_growth(current_time=current_time)
+        transp_rate_evap_g_s_m2 = (self.LE_evap / self.lambda_v * 1000.0) if self.lambda_v > 0 else 0.0
+        self.daily_transpiration_g += transp_rate_evap_g_s_m2 * dt
+
+        rm_base_g_s = self.calculate_instantaneous_respiration(self.T_c)
+        rgr_used = getattr(self, "last_RGR", 0.03)
+        rm_eff_factor = 1.0 - math.exp(-self.f_Rm_RGR * max(0.0, rgr_used))
+        rm_eff_g_s = rm_base_g_s * rm_eff_factor
+        net_ch2o_step_g = max(0.0, gross_ch2o_prod_g - rm_eff_g_s * dt)
+
+        t_air_c = self.T_a - 273.15
+        for cohort in self.truss_cohorts:
+            if not cohort.get("active", True):
+                continue
+            cohort["tdvs"] = self._advance_tdvs_with_fdvr(float(cohort.get("tdvs", 0.0)), t_air_c, dt)
+            if float(cohort["tdvs"]) >= self.tdvs_max:
+                cohort["active"] = False
+
+        sinks, per_truss_sinks = self._compute_sink_state()
+        alloc = self._resolve_allocation_fractions(current_time=current_time, sinks=sinks)
+
+        self.part_fruit = alloc["fruit"]
+        self.part_leaf = alloc["leaf"]
+        self.part_stem = alloc["stem"]
+        self.part_root = alloc["root"]
+        self.part_shoot = alloc["leaf"] + alloc["stem"]
+        self.part_veg = self.part_shoot + self.part_root
+
+        denom_cf = (
+            self.ASR["lv"] * self.part_leaf
+            + self.ASR["st"] * self.part_stem
+            + self.ASR["rt"] * self.part_root
+            + self.ASR["fr"] * self.part_fruit
+        )
+        c_f = 1.0 / denom_cf if denom_cf > 1e-12 else 0.0
+
+        s_total_dm_d = max(0.0, float(sinks["S_fr_g_d"]) + float(sinks["S_veg_g_d"]))
+        cap_dm_step = s_total_dm_d * (dt / 86400.0)
+
+        if c_f <= 1e-12:
+            dW_total_step = 0.0
+            self.reserve_ch2o_g = max(0.0, self.reserve_ch2o_g)
+        else:
+            ch2o_supply = max(0.0, net_ch2o_step_g + self.reserve_ch2o_g)
+            required_ch2o_for_cap = cap_dm_step / c_f
+            allowed_dm_by_supply = c_f * ch2o_supply
+            if allowed_dm_by_supply >= cap_dm_step:
+                dW_total_step = cap_dm_step
+                self.reserve_ch2o_g = max(0.0, ch2o_supply - required_ch2o_for_cap)
+            else:
+                dW_total_step = allowed_dm_by_supply
+                self.reserve_ch2o_g = 0.0
+
+        if dW_total_step > 0.0:
+            self.W_lv = max(0.0, self.W_lv + dW_total_step * self.part_leaf)
+            self.W_st = max(0.0, self.W_st + dW_total_step * self.part_stem)
+            self.W_rt = max(0.0, self.W_rt + dW_total_step * self.part_root)
+
+            dW_fr_total_step = dW_total_step * self.part_fruit
+            if dW_fr_total_step > 0.0 and float(sinks["S_fr_g_d"]) > 1e-9 and self.use_age_structured_sink:
+                total_sink = max(sum(per_truss_sinks), 1e-12)
+                for idx, cohort in enumerate(self.truss_cohorts):
+                    if not cohort.get("active", True):
+                        continue
+                    if idx >= len(per_truss_sinks):
+                        continue
+                    truss_sink_share = max(0.0, per_truss_sinks[idx]) / total_sink
+                    cohort["w_fr_cohort"] = float(cohort.get("w_fr_cohort", 0.0)) + dW_fr_total_step * truss_sink_share
+            elif dW_fr_total_step > 0.0:
+                self.W_fr += dW_fr_total_step
+
+            if self.use_age_structured_sink and float(sinks["S_fr_g_d"]) > 1e-9:
+                self.W_fr = sum(max(0.0, float(cohort.get("w_fr_cohort", 0.0))) for cohort in self.truss_cohorts)
+
+            if self.fixed_lai is None:
+                self.LAI = self.W_lv * self.SLA
+                if self.LAI > self.LAI_max and self.SLA > 1e-9:
+                    excess_lai = self.LAI - self.LAI_max
+                    excess_w_lv = excess_lai / self.SLA
+                    self.W_lv = max(0.0, self.W_lv - excess_w_lv)
+                    self.LAI = self.LAI_max
+
+            self.daily_dW_total += dW_total_step
+
+        self._harvest_matured_cohorts()
+        self.vegetative_dw = self.W_lv + self.W_st + self.W_rt
+        self.fruit_dw = self.W_fr
 
     def calculate_current_lai(self) -> float:
         if self.fixed_lai is not None:
@@ -420,6 +597,189 @@ class TomatoModel:
         if (not math.isfinite(lai)) or lai <= 1e-6:
             return 0.0
         return float(min(max(1.0 - math.exp(-self.k_ext * lai), 0.0), 1.0))
+
+    def solve_coupled_energy_balance(self) -> None:
+        initial_guess = np.asarray([self.T_a], dtype=float)
+        try:
+            solution, _, ier, message = fsolve(
+                self._energy_balance_residual,
+                initial_guess,
+                full_output=True,
+            )
+            if ier == 1:
+                self.T_c = float(solution[0])
+                self.convergence_status_Tc = True
+            else:
+                LOGGER.warning("Energy balance solver failed: %s. Falling back to T_c = T_a.", message)
+                self.T_c = float(self.T_a)
+                self.convergence_status_Tc = False
+        except Exception:
+            LOGGER.exception("Error during energy balance solving; falling back to air temperature.")
+            self.T_c = float(self.T_a)
+            self.convergence_status_Tc = False
+
+        self.H = self.calculate_sensible_heat(self.T_c)
+        rn = self.calculate_net_radiation(self.T_c)
+        self.LE = self.calculate_canopy_latent_heat(self.T_c, Rn_Wm2=rn)
+
+    def _energy_balance_residual(self, t_c_k_guess: object) -> float:
+        t_c_k = float(np.atleast_1d(np.asarray(t_c_k_guess, dtype=float))[0])
+        self.r_b = 70.0 / math.sqrt(max(self.u, 1e-6))
+        self.r_ah = 50.0 * math.sqrt(self.leaf_dimension / max(self.u, 1e-6))
+
+        rn = self.calculate_net_radiation(t_c_k)
+        h = self.calculate_sensible_heat(t_c_k)
+        le = self.calculate_canopy_latent_heat(t_c_k, Rn_Wm2=rn)
+        return float(rn - h - le)
+
+    def calculate_net_radiation(self, t_c_k: float) -> float:
+        sw_in = max(0.0, float(getattr(self, "SW_in_Wm2", 0.0)))
+        r_sw_abs = sw_in * (1.0 - self.alpha_c) * self.f_c
+
+        t_env = float(self.T_a)
+        if bool(getattr(self, "_last_row_used_T_rad", False)):
+            t_env = float(getattr(self, "T_rad_K", self.T_a))
+
+        eps_cover = min(max(float(getattr(self, "emissivity_cover", 0.84)), 1e-6), 1.0)
+        eps_leaf = min(max(float(self.emissivity_c), 1e-6), 1.0)
+        denom = (1.0 / eps_cover + 1.0 / eps_leaf - 1.0)
+        eps_eff = min(max(1.0 / max(1e-6, denom), 0.0), 1.0)
+        r_lw_net = eps_eff * self.sigma * (t_env**4 - float(t_c_k) ** 4) * self.f_c
+
+        self.eps_eff_last = eps_eff
+        self.T_env_last_K = t_env
+        self.r_lw_net_last = r_lw_net
+        return float(r_sw_abs + r_lw_net)
+
+    def calculate_sensible_heat(self, t_c_k: float) -> float:
+        if self.r_ah <= 1e-9:
+            return 0.0
+        return float(self.rho_a * self.c_p * (float(t_c_k) - self.T_a) / self.r_ah)
+
+    def calculate_canopy_latent_heat(self, t_c_k: float, Rn_Wm2: float | None = None) -> float:
+        if Rn_Wm2 is None:
+            Rn_Wm2 = self.calculate_net_radiation(t_c_k)
+
+        ta_c = self.T_a - 273.15
+        es_ta = esat_Pa_from_T_C(ta_c)
+        ea = es_ta * min(max(float(self.RH), 0.0), 1.0)
+
+        tc_c = float(t_c_k) - 273.15
+        es_tc = esat_Pa_from_T_C(tc_c)
+        vpd = es_tc - ea
+
+        _, _, gsw_canopy = self.calculate_canopy_photosynthesis(t_c_k)
+        gsw_canopy = max(float(gsw_canopy), 1e-9)
+        rc = 1.0 / gsw_canopy
+
+        le = penman_monteith_LE_Wm2(
+            Rn_Wm2=float(Rn_Wm2),
+            Ta_K=float(self.T_a),
+            VPD_Pa=float(vpd),
+            ra_s_m=float(self.r_ah),
+            rc_s_m=float(rc),
+            rho=float(self.rho_a),
+            cp=float(self.c_p),
+            gamma_PaK=float(self.gamma),
+            allow_negative=bool(getattr(self, "allow_condensation", True)),
+        )
+
+        self.LE_raw = float(le)
+        self.LE_evap = float(max(0.0, le))
+        self.LE_cond = float(max(0.0, -le))
+        return float(le)
+
+    def calculate_canopy_photosynthesis(self, t_c_k: float) -> tuple[float, float, float]:
+        if self.LAI <= 1e-9:
+            return 0.0, 0.0, 0.0
+
+        stress = self._resolve_water_supply_stress()
+        if self.photosyn_mode == "tomsim_canopy":
+            alpha = 0.02
+            pgc_max = 40.0
+            pg = pgc_max * (1.0 - math.exp(-alpha * max(0.0, self.u_PAR))) * stress
+            _, _, gsw = self.calculate_leaf_fvcb(t_c_k, self.u_PAR, self.Ci)
+            return float(pg), 0.0, float(gsw)
+
+        total_gross_a = 0.0
+        total_gsw = 0.0
+        lai_above = 0.0
+        n_layers = 10
+        lai_layer = self.LAI / n_layers
+        par_total_wm2 = self.u_PAR / self.W_TO_UMOL_CONVERSION
+
+        for _ in range(n_layers):
+            par_layer_wm2 = par_total_wm2 * math.exp(-self.k_ext * (lai_above + 0.5 * lai_layer))
+            par_layer_umol = par_layer_wm2 * self.W_TO_UMOL_CONVERSION
+            a, r_d, gsw = self.calculate_leaf_fvcb(t_c_k, par_layer_umol, self.Ci)
+            gross_a = max(0.0, a)
+            total_gross_a += gross_a * lai_layer
+            total_gsw += gsw * lai_layer
+            lai_above += lai_layer
+
+        self.last_gsw_canopy = total_gsw
+        return float(total_gross_a), 0.0, float(total_gsw)
+
+    def calculate_leaf_fvcb(self, T_K: float, PARi: float, Ci_initial: float) -> tuple[float, float, float]:
+        jp = self.joubert_params
+        Vcmax = float(jp["Vcmax"])
+        Jmax = float(jp["Jmax"])
+        Rd = float(jp["Rd"])
+        theta_J = float(jp["theta_J"])
+        c1 = float(jp["c1"])
+        dHa1 = float(jp["dHa1_kJ"])
+        c2 = float(jp["c2"])
+        dHa2 = float(jp["dHa2_kJ"])
+        c3 = float(jp["c3"])
+        dHa3 = float(jp["dHa3_kJ"])
+        R1 = float(jp["R1_kJ"])
+        Oi_kPa = float(jp["O_i_kPa"])
+
+        gamma_star = math.exp(c1 - (dHa1 / (R1 * T_K)))
+        Ko = math.exp(c2 - (dHa2 / (R1 * T_K)))
+        Kc = math.exp(c3 - (dHa3 / (R1 * T_K)))
+
+        alpha = float(self.fcvb_params.get("a", 0.3))
+        if theta_J <= 1e-12:
+            J = 0.0
+        else:
+            disc = (alpha * PARi + Jmax) ** 2 - 4.0 * theta_J * alpha * PARi * Jmax
+            J = (alpha * PARi + Jmax - math.sqrt(max(0.0, disc))) / (2.0 * theta_J)
+
+        Ci = max(1e-6, float(Ci_initial))
+        A = 0.0
+        gsw_mol = 0.019
+        for _ in range(100):
+            Ac = Vcmax * (Ci - gamma_star) / (Ci + Kc * (1.0 + Oi_kPa / max(1e-9, Ko))) - Rd
+            Aj = J * (Ci - gamma_star) / (4.0 * Ci + 8.0 * gamma_star) - Rd
+            A = max(0.0, min(Ac, Aj))
+
+            h_frac = min(max(float(self.RH), 0.0), 1.0)
+            gsw_mol = (((A * 26.85 * h_frac) / self.u_CO2) + 0.019) if self.u_CO2 > 0 else 0.019
+            gsw_mol = max(1e-9, gsw_mol)
+            gsc_mol = gsw_mol / 1.6
+            Ci_new = self.u_CO2 - A / gsc_mol if gsc_mol > 1e-9 else Ci
+            Ci_new = min(max(float(Ci_new), 1.0), self.u_CO2)
+            if abs(Ci_new - Ci) < 0.001:
+                Ci = Ci_new
+                break
+            Ci = Ci_new
+
+        water_stress = self._resolve_water_supply_stress()
+        A *= water_stress
+        gsw_ms = gsw_mol * (float(self.fcvb_params["R"]) * T_K / 101325.0) * water_stress
+        return float(A), float(Rd), float(gsw_ms)
+
+    def calculate_instantaneous_respiration(self, t_c_k: float) -> float:
+        t_c_c = float(t_c_k) - 273.15
+        q10 = self.Q10_maint ** ((t_c_c - 25.0) / 10.0)
+        rm_day = (
+            self.W_lv * self.MAINT_25C["lv"] * q10
+            + self.W_st * self.MAINT_25C["st"] * q10
+            + self.W_rt * self.MAINT_25C["rt"] * q10
+            + self.W_fr * self.MAINT_25C["fr"] * q10
+        )
+        return float(rm_day / (24.0 * 3600.0))
 
     def get_current_sim_time(self, time_step_hours: float) -> datetime:
         return self.start_date + timedelta(hours=float(time_step_hours))
@@ -454,63 +814,102 @@ class TomatoModel:
         if old_shoots_per_m2 > 0 and self.shoots_per_m2 <= 0:
             LOGGER.warning("shoots_per_m2 is now <= 0; per-shoot conversions will be invalid.")
 
-    def _roll_daily_state(self, sim_date: date) -> None:
-        days_elapsed = max(1, (sim_date - self.current_date).days)
-        self.last_daily_transpiration_g = self.daily_transpiration_g
-        self.last_daily_dW_total = self.daily_dW_total
-        self.last_daily_epsilon = self._calculate_current_epsilon()
+    def update_daily_boundary(self, sim_date: date) -> None:
+        """Update daily state, SLA, RGR, FR(T)-based truss appearance, and diagnostics."""
+
+        total_duration = sum(duration for _, duration in self.daily_temp_accumulator)
+        if total_duration > 0:
+            weighted_temp_sum = sum(temp_k * duration for temp_k, duration in self.daily_temp_accumulator)
+            avg_temp_k = weighted_temp_sum / total_duration
+        else:
+            avg_temp_k = self.T_a
+        avg_temp_c = avg_temp_k - 273.15
         self.daily_temp_accumulator = []
+
+        doy = sim_date.timetuple().tm_yday
+        sla_cm2_per_g = 266.0 + 88.0 * math.sin(2.0 * math.pi * (doy + 68) / 365.0)
+        self.SLA = max(0.0001, sla_cm2_per_g / 10000.0)
+        if self.fixed_lai is None:
+            self.LAI = self.W_lv * self.SLA
+
+        current_total_dm = self.W_lv + self.W_st + self.W_rt + self.W_fr
+        self.recent_total_dm_history.append(current_total_dm)
+        if len(self.recent_total_dm_history) > 8:
+            self.recent_total_dm_history = self.recent_total_dm_history[-8:]
+
+        if len(self.recent_total_dm_history) >= 6 and self.recent_total_dm_history[-6] > 0:
+            RGR = math.log(self.recent_total_dm_history[-1] / self.recent_total_dm_history[-6]) / 5.0
+        elif len(self.recent_total_dm_history) >= 2 and self.recent_total_dm_history[-2] > 0:
+            RGR = math.log(self.recent_total_dm_history[-1] / self.recent_total_dm_history[-2])
+        else:
+            RGR = 0.03
+        self.last_RGR = max(0.0, float(RGR))
+
+        t_for_fr = max(1.0, avg_temp_c)
+        if self.fr_clamp_to_valid:
+            t_for_fr = min(max(t_for_fr, self.fr_T_min_valid), self.fr_T_max_valid)
+        fr = max(0.0, -0.2903 + 0.1454 * math.log(max(1.0, t_for_fr)))
+        self._truss_fraction_acc += fr
+
+        while self._truss_fraction_acc >= 1.0:
+            self.truss_count += 1
+            self._truss_fraction_acc -= 1.0
+            if self.pending_n_fruits:
+                try:
+                    nfr = int(max(0, self.pending_n_fruits.pop(0)))
+                except Exception:
+                    nfr = int(self.n_f)
+            else:
+                nfr = int(self.n_f)
+            self.truss_cohorts.append(
+                {
+                    "tdvs": 0.0,
+                    "n_fruits": nfr,
+                    "w_fr_cohort": 0.0,
+                    "active": True,
+                    "mult": self.shoots_per_m2,
+                }
+            )
+
+        self._harvest_matured_cohorts()
+
+        intercepted_par_mj = self.daily_par_umol_int_sum * PHOTON_UMOL_TO_MJ
+        self.last_daily_dW_total = self.daily_dW_total
+        self.last_daily_epsilon = 0.0 if intercepted_par_mj <= 1e-9 else (self.daily_dW_total / intercepted_par_mj)
+        self.last_daily_transpiration_g = self.daily_transpiration_g
+
         self.daily_gross_ch2o_g = 0.0
         self.daily_par_umol_in_sum = 0.0
         self.daily_par_umol_int_sum = 0.0
         self.daily_dW_total = 0.0
         self.daily_transpiration_g = 0.0
 
-        self._truss_fraction_acc += days_elapsed / 5.0
-        while self._truss_fraction_acc >= 1.0:
-            self.truss_count += 1
-            self.truss_cohorts.append(
-                {
-                    "tdvs": 0.0,
-                    "n_fruits": int(self.n_f),
-                    "w_fr_cohort": 0.0,
-                    "active": True,
-                    "mult": self.shoots_per_m2,
-                }
-            )
-            self._truss_fraction_acc -= 1.0
+    def _roll_daily_state(self, sim_date: date) -> None:
+        """Compatibility wrapper around the v1_2 daily boundary update."""
 
-    def _apply_growth(self, *, current_time: datetime) -> None:
-        alloc = self._resolve_allocation_fractions(current_time)
-        self.part_fruit = alloc["fruit"]
-        self.part_leaf = alloc["leaf"]
-        self.part_stem = alloc["stem"]
-        self.part_root = alloc["root"]
-        self.part_shoot = alloc["leaf"] + alloc["stem"]
+        self.update_daily_boundary(sim_date)
 
-        dry_matter_gain = max(self.co2_flux_g_m2_s, 0.0) * 0.5
-        self.daily_dW_total += dry_matter_gain
+    def _compute_sink_state(self) -> tuple[dict[str, float], list[float]]:
+        if self.use_age_structured_sink:
+            per_truss_sinks = self._compute_per_truss_sinks_gd()
+            s_fr_g_d = sum(per_truss_sinks)
+        else:
+            active_trusses = self._count_active_trusses()
+            nominal_singlefruit_pgr = 1.0
+            s_fr_g_d = active_trusses * self.n_f * nominal_singlefruit_pgr
+            per_truss_sinks = []
 
-        self.W_fr += dry_matter_gain * self.part_fruit
-        self.W_lv += dry_matter_gain * self.part_leaf
-        self.W_st += dry_matter_gain * self.part_stem
-        self.W_rt += dry_matter_gain * self.part_root
+        s_veg_g_d = max(1e-9, float(self.to_floor_from_shoot(self.veg_sink_g_d_per_shoot)))
+        return {
+            "S_fr_g_d": max(0.0, float(s_fr_g_d)),
+            "S_veg_g_d": s_veg_g_d,
+        }, per_truss_sinks
 
-        if self.W_fr > self.harvest_truss_dm_g and self.truss_count > 0:
-            harvested = self.W_fr - self.harvest_truss_dm_g
-            self.W_fr = self.harvest_truss_dm_g
-            self.W_fr_harvested += harvested
-            if self.truss_cohorts:
-                self.truss_cohorts[0]["active"] = False
+    def _default_sink_proxy(self) -> dict[str, float]:
+        sinks, _ = self._compute_sink_state()
+        return sinks
 
-        self.LAI = self.calculate_current_lai()
-        total_dry_weight = self.W_lv + self.W_st + self.W_rt + self.W_fr
-        self.recent_total_dm_history.append(total_dry_weight)
-        if len(self.recent_total_dm_history) > 8:
-            self.recent_total_dm_history = self.recent_total_dm_history[-8:]
-
-    def _resolve_allocation_fractions(self, current_time: datetime) -> dict[str, float]:
-        sinks = self._default_sink_proxy()
+    def _resolve_allocation_fractions(self, *, current_time: datetime, sinks: dict[str, float]) -> dict[str, float]:
         env = EnvStep(
             t=current_time,
             dt_s=self.dt_seconds,
@@ -525,19 +924,22 @@ class TomatoModel:
         )
 
         alloc = self._allocation_from_policy(env=env, sinks=sinks)
-        if alloc is not None:
-            return alloc
+        if alloc is None:
+            s_fr_g_d = max(float(sinks["S_fr_g_d"]), 0.0)
+            s_veg_g_d = max(float(sinks["S_veg_g_d"]), 1e-9)
+            total = max(s_fr_g_d + s_veg_g_d, 1e-9)
+            f_fr_total = s_fr_g_d / total
+            f_veg_total = 1.0 - f_fr_total
+            f_rt = f_veg_total * self.root_frac_of_total_veg
+            f_shoot = f_veg_total - f_rt
+            alloc = {
+                "fruit": f_fr_total,
+                "leaf": f_shoot * 0.7,
+                "stem": f_shoot * 0.3,
+                "root": f_rt,
+            }
 
-        s_fr_g_d = sinks["S_fr_g_d"]
-        s_veg_g_d = max(sinks["S_veg_g_d"], 1e-9)
-        total = max(s_fr_g_d + s_veg_g_d, 1e-9)
-        f_fr_total = max(0.0, s_fr_g_d) / total
-        f_veg_total = 1.0 - f_fr_total
-        f_rt = f_veg_total * self.root_frac_of_total_veg
-        f_shoot = f_veg_total - f_rt
-        f_lv = f_shoot * 0.7
-        f_st = f_shoot * 0.3
-        return {"fruit": f_fr_total, "leaf": f_lv, "stem": f_st, "root": f_rt}
+        return self._normalize_allocation(alloc)
 
     def _allocation_from_policy(self, *, env: EnvStep, sinks: dict[str, float]) -> dict[str, float] | None:
         compute = getattr(self.partition_policy, "compute", None)
@@ -553,14 +955,14 @@ class TomatoModel:
                 params=self.partition_policy_params,
             )
         except Exception:
-            LOGGER.exception("Custom partition_policy.compute failed; falling back to default sink split.")
+            LOGGER.exception("Custom partition_policy.compute failed; falling back to sink-based split.")
             return None
 
         values = getattr(raw, "values", raw)
         if not isinstance(values, Mapping):
             return None
 
-        normalized = {_resolve_partition_key(key): float(value) for key, value in values.items()}
+        normalized = {_resolve_partition_key(key): _finite_float(value, default=0.0) for key, value in values.items()}
         if "fruit" not in normalized or "root" not in normalized:
             return None
 
@@ -582,24 +984,143 @@ class TomatoModel:
             }
         return None
 
-    def _default_sink_proxy(self) -> dict[str, float]:
-        fruit_bias = min(0.65, 0.08 * max(self.truss_count, 1) + 0.02 * max(self.n_f - 2, 0))
-        fruit_bias = max(0.0, fruit_bias)
-        return {
-            "S_fr_g_d": fruit_bias,
-            "S_veg_g_d": 1.0,
+    def _normalize_allocation(self, alloc: Mapping[str, object]) -> dict[str, float]:
+        cleaned = {
+            "fruit": max(_finite_float(alloc.get("fruit", 0.0), default=0.0), 0.0),
+            "leaf": max(_finite_float(alloc.get("leaf", 0.0), default=0.0), 0.0),
+            "stem": max(_finite_float(alloc.get("stem", 0.0), default=0.0), 0.0),
+            "root": max(_finite_float(alloc.get("root", 0.0), default=0.0), 0.0),
         }
+        total = sum(cleaned.values())
+        if total <= 1e-12:
+            return {"fruit": 0.0, "leaf": 0.7, "stem": 0.3, "root": 0.0}
+        return {key: value / total for key, value in cleaned.items()}
 
     def _calculate_current_epsilon(self) -> float:
-        par_mj = self.daily_par_umol_in_sum * PHOTON_UMOL_TO_MJ
-        if par_mj <= 1e-12:
+        intercepted_par_mj = self.daily_par_umol_int_sum * PHOTON_UMOL_TO_MJ
+        if intercepted_par_mj <= 1e-9:
             return float(self.last_daily_epsilon)
-        return float(max(self.daily_dW_total, 0.0) / par_mj)
+        return float(max(self.daily_dW_total, 0.0) / intercepted_par_mj)
 
-    def _count_active_trusses(self) -> float:
-        if not self.truss_cohorts:
+    def _compute_generative_sink_absolute_gd(self) -> float:
+        total_g_d = 0.0
+        for cohort in self.truss_cohorts:
+            if not cohort.get("active", True):
+                continue
+            tdvs = float(cohort.get("tdvs", 0.0))
+            if tdvs <= float(self.pgr_params["c"]):
+                continue
+            pgr_singlefruit = self._pgr_richards_raw(tdvs)
+            if pgr_singlefruit <= 0.0:
+                continue
+            mult = float(cohort.get("mult", 1.0))
+            total_g_d += mult * float(cohort.get("n_fruits", self.n_f)) * pgr_singlefruit
+        return max(0.0, total_g_d)
+
+    def _compute_per_truss_sinks_gd(self) -> list[float]:
+        sinks: list[float] = []
+        for cohort in self.truss_cohorts:
+            if not cohort.get("active", True):
+                sinks.append(0.0)
+                continue
+            tdvs = float(cohort.get("tdvs", 0.0))
+            if tdvs <= float(self.pgr_params["c"]):
+                sinks.append(0.0)
+                continue
+            pgr_singlefruit = self._pgr_richards_raw(tdvs)
+            if pgr_singlefruit <= 0.0:
+                sinks.append(0.0)
+                continue
+            mult = float(cohort.get("mult", 1.0))
+            truss_sink = mult * float(cohort.get("n_fruits", self.n_f)) * pgr_singlefruit
+            sinks.append(truss_sink)
+        return sinks
+
+    def _pgr_richards_raw(self, tdvs: float) -> float:
+        a = float(self.pgr_params.get("a", 0.138))
+        b = float(self.pgr_params.get("b", 4.34))
+        c = float(self.pgr_params.get("c", 0.278))
+        d = float(self.pgr_params.get("d", 1.31))
+
+        if d == 1.0:
             return 0.0
-        return float(sum(1 for cohort in self.truss_cohorts if bool(cohort.get("active", True))))
+
+        z = b * (float(tdvs) - c)
+        try:
+            e_z = math.exp(z)
+        except OverflowError:
+            e_z = float("inf")
+        e_neg_z = float("inf") if e_z == 0.0 else 1.0 / e_z
+
+        base = 1.0 + e_neg_z
+        exponent = 1.0 / (1.0 - d)
+        numerator = a * b * (base**exponent)
+        denominator = (d - 1.0) * (e_z + 1.0)
+        if denominator == 0.0:
+            return 0.0
+
+        return max(0.0, float(numerator / denominator))
+
+    def set_truss_n_f(self, idx: int, n_fruits: int) -> None:
+        if 0 <= idx < len(self.truss_cohorts):
+            self.truss_cohorts[idx]["n_fruits"] = int(max(0, n_fruits))
+
+    def bulk_set_truss_n_f(self, values: list[int], order: str = "oldest") -> None:
+        if not values:
+            return
+        idxs = range(len(self.truss_cohorts)) if order == "oldest" else reversed(range(len(self.truss_cohorts)))
+        for idx, value in zip(idxs, values):
+            self.truss_cohorts[idx]["n_fruits"] = int(max(0, value))
+
+    def queue_truss_n_f(self, values: list[int]) -> None:
+        if values:
+            self.pending_n_fruits.extend(int(max(0, value)) for value in values)
+
+    def _count_active_trusses(self) -> int:
+        return sum(1 for cohort in self.truss_cohorts if cohort.get("active", True))
+
+    def _advance_tdvs_with_fdvr(self, tdvs: float, T_C: float, dt_s: float) -> float:
+        t_ratio = max(float(T_C), 0.1) / 20.0
+        ln_term = math.log(t_ratio)
+        fdvr = 0.0181 + ln_term * (
+            0.0392 - 0.213 * tdvs + 0.451 * tdvs * tdvs - 0.240 * tdvs * tdvs * tdvs
+        )
+        tdvs_next = float(tdvs) + fdvr * (float(dt_s) / 86400.0)
+        if tdvs_next < self.tdvs_min:
+            tdvs_next = self.tdvs_min
+        if tdvs_next > self.tdvs_max:
+            tdvs_next = self.tdvs_max
+        return float(tdvs_next)
+
+    def _resolve_water_supply_stress(self) -> float:
+        theta = min(max(_finite_float(getattr(self, "theta_substrate", 0.33), default=0.33), 0.0), 1.0)
+        moisture_response_fn = getattr(self, "moisture_response_fn", None)
+        if callable(moisture_response_fn):
+            try:
+                return float(water_supply_stress_from_theta(theta, moisture_response_fn))
+            except Exception:
+                LOGGER.exception("moisture_response_fn failed; falling back to no stress.")
+        return 1.0
+
+    def _harvest_matured_cohorts(self) -> None:
+        matured_indices: list[int] = []
+        harvested_now = 0.0
+        for idx, cohort in enumerate(self.truss_cohorts):
+            tdvs = float(cohort.get("tdvs", 0.0))
+            is_active = bool(cohort.get("active", True))
+            truss_dm = max(0.0, float(cohort.get("w_fr_cohort", 0.0)))
+            if truss_dm >= self.harvest_truss_dm_g:
+                cohort["active"] = False
+                is_active = False
+            if (not is_active) or tdvs >= self.tdvs_max:
+                harvested_now += truss_dm
+                matured_indices.append(idx)
+
+        if matured_indices:
+            for idx in reversed(matured_indices):
+                del self.truss_cohorts[idx]
+            self.W_fr_harvested += harvested_now
+            self.W_fr = sum(max(0.0, float(cohort.get("w_fr_cohort", 0.0))) for cohort in self.truss_cohorts)
 
 
 def create_sample_input_csv(filename: str | Path = "sample_tomato_input.csv", days: int = 90) -> str:
@@ -608,6 +1129,7 @@ def create_sample_input_csv(filename: str | Path = "sample_tomato_input.csv", da
     output_path = Path(filename)
     start_date = datetime(2021, 2, 23)
     dates = [start_date + timedelta(hours=index) for index in range(days * 24)]
+    rng = np.random.default_rng(0)
 
     data: list[dict[str, object]] = []
     for dt in dates:
@@ -626,7 +1148,7 @@ def create_sample_input_csv(filename: str | Path = "sample_tomato_input.csv", da
 
         co2 = 400.0 + 100.0 * math.sin(2.0 * math.pi * hour / 24.0)
         rh = 65.0 + 25.0 * math.sin(2.0 * math.pi * (hour - 12) / 24.0)
-        wind_speed = 0.3 + 0.4 * float(np.random.random())
+        wind_speed = 0.3 + 0.4 * float(rng.random())
         data.append(
             {
                 "datetime": dt.strftime("%Y-%m-%d %H:%M:%S"),

--- a/tests/test_tomics_alloc_tomato_model.py
+++ b/tests/test_tomics_alloc_tomato_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +9,10 @@ import pandas.testing as pdt
 import pytest
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc import simulate
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.partitioning.fractions import (
+    AllocationFractions,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.partitioning.organ import Organ
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.models.tomato_legacy import (
     TomatoLegacyAdapter,
     TomatoModel,
@@ -115,3 +119,121 @@ def test_default_tomato_model_matches_adapter_path_on_same_forcing(tmp_path: Pat
             rtol=1e-9,
             atol=1e-9,
         )
+
+
+def test_tomato_model_daily_boundary_creates_fr_based_cohort_from_queue() -> None:
+    model = TomatoModel()
+    model.queue_truss_n_f([6])
+    model._truss_fraction_acc = 0.95
+    model.daily_temp_accumulator = [(25.0 + 273.15, 24.0 * 3600.0)]
+
+    model.update_daily_boundary(model.current_date + timedelta(days=1))
+
+    assert model.truss_count == 1
+    assert len(model.truss_cohorts) == 1
+    assert model.truss_cohorts[0]["n_fruits"] == 6
+    assert model.truss_cohorts[0]["mult"] == pytest.approx(model.shoots_per_m2)
+
+
+def test_tomato_model_generative_sink_scales_with_shoot_density() -> None:
+    model = TomatoModel()
+    tdvs = float(model.pgr_params["c"]) + 0.5
+    model.truss_cohorts = [
+        {
+            "tdvs": tdvs,
+            "n_fruits": 4,
+            "w_fr_cohort": 0.0,
+            "active": True,
+            "mult": model.shoots_per_m2,
+        }
+    ]
+
+    base_sink = model._compute_generative_sink_absolute_gd()
+    model.set_plant_density(shoots_per_m2=model.shoots_per_m2 * 2.0)
+    doubled_sink = model._compute_generative_sink_absolute_gd()
+
+    assert base_sink > 0.0
+    assert doubled_sink == pytest.approx(base_sink * 2.0)
+
+
+def test_tomato_model_water_stress_reduces_canopy_fluxes() -> None:
+    base_row = {
+        "T_air_C": 25.0,
+        "PAR_umol": 650.0,
+        "CO2_ppm": 420.0,
+        "RH_percent": 60.0,
+        "wind_speed_ms": 1.0,
+        "n_fruits_per_truss": 4.0,
+    }
+    current_time = datetime(2026, 1, 1, 12, 0, 0)
+
+    wet = TomatoModel()
+    wet.theta_substrate = 0.50
+    wet.update_inputs_from_row(base_row)
+    wet.run_timestep_calculations(3600.0, current_time)
+    wet_outputs = wet.get_current_outputs(current_time)
+
+    dry = TomatoModel()
+    dry.theta_substrate = 0.20
+    dry.update_inputs_from_row(base_row)
+    dry.run_timestep_calculations(3600.0, current_time)
+    dry_outputs = dry.get_current_outputs(current_time)
+
+    assert dry.water_supply_stress < wet.water_supply_stress
+    assert dry.co2_flux_g_m2_s < wet.co2_flux_g_m2_s
+    assert float(dry_outputs["transpiration_rate_g_s_m2"]) < float(wet_outputs["transpiration_rate_g_s_m2"])
+
+
+def test_tomato_model_does_not_grow_under_zero_par() -> None:
+    model = TomatoModel()
+    model.update_inputs_from_row(
+        {
+            "T_air_C": 25.0,
+            "PAR_umol": 0.0,
+            "CO2_ppm": 420.0,
+            "RH_percent": 60.0,
+            "wind_speed_ms": 1.0,
+            "n_fruits_per_truss": 4.0,
+        }
+    )
+
+    model.run_timestep_calculations(3600.0, datetime(2026, 1, 1, 0, 0, 0))
+
+    assert model.co2_flux_g_m2_s <= 0.0
+    assert model.daily_dW_total == pytest.approx(0.0, abs=1e-12)
+    assert model.W_lv == pytest.approx(50.0)
+    assert model.W_st == pytest.approx(20.0)
+    assert model.W_rt == pytest.approx(10.0)
+    assert model.W_fr == pytest.approx(0.0)
+
+
+def test_tomato_model_preserves_direct_fruit_growth_for_custom_policy() -> None:
+    class _DirectFruitPolicy:
+        name = "custom_direct_fruit"
+
+        def compute(self, **_: object) -> AllocationFractions:
+            return AllocationFractions(
+                values={
+                    Organ.FRUIT: 0.5,
+                    Organ.LEAF: 0.25,
+                    Organ.STEM: 0.15,
+                    Organ.ROOT: 0.10,
+                }
+            )
+
+    model = TomatoModel(partition_policy=_DirectFruitPolicy())
+    model.update_inputs_from_row(
+        {
+            "T_air_C": 25.0,
+            "PAR_umol": 600.0,
+            "CO2_ppm": 420.0,
+            "RH_percent": 60.0,
+            "wind_speed_ms": 1.0,
+            "n_fruits_per_truss": 4.0,
+        }
+    )
+
+    model.run_timestep_calculations(3600.0, datetime(2026, 1, 1, 12, 0, 0))
+
+    assert model.part_fruit == pytest.approx(0.5)
+    assert model.W_fr > 0.0


### PR DESCRIPTION
﻿## Summary
- update `TomatoModel` in `tomics/alloc/models/tomato_legacy` to reflect the newer `model-foundry` `tomato_v1_2.py` behavior while preserving TOMICS partition-policy integration
- add v1.2-aligned canopy energy-balance, canopy photosynthesis, sink-limited dry-matter growth, cohort TDVS/FR(T) daily boundary logic, and greenhouse water-stress scaling
- document new tomato legacy state variables in the glossary and add regression tests for FR-based cohort creation, generative sink density scaling, and water-stress canopy moderation

## Validation
- `poetry run pytest tests/test_tomics_alloc_tomato_model.py tests/test_tomics_alloc_partitioning.py tests/test_tomics_alloc_pipeline.py`
- `poetry run ruff check src/stomatal_optimiaztion/domains/tomato/tomics/alloc/models/tomato_legacy/tomato_model.py tests/test_tomics_alloc_tomato_model.py docs/variable_glossary.md`
- `poetry run pytest`
- `poetry run ruff check .`

Closes #229