### PR TITLE
[Harvest Validation] Clean harvested-vs-total observation semantics and enforce writeback audit guardrails

### DIFF
--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/calibration.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/calibration.py
@@ -19,6 +19,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_pro
     prepare_knu_bundle,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
     model_floor_area_cumulative_total_fruit,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.metrics import (
@@ -291,7 +292,7 @@ def _parameter_grid(config: dict[str, Any]) -> list[dict[str, float]]:
 def _candidate_series(observed_df: pd.DataFrame, run_df: pd.DataFrame) -> pd.Series:
     model_daily_df = model_floor_area_cumulative_total_fruit(run_df)
     indexed = model_daily_df.set_index("date")
-    return observed_df["date"].map(indexed["model_cumulative_total_fruit_dry_weight_floor_area"])
+    return observed_df["date"].map(indexed[MODEL_HARVESTED_CUMULATIVE_COLUMN])
 
 
 def _window_bundle(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/current_vs_promoted.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/current_vs_promoted.py
@@ -40,6 +40,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.artifact_sync 
     CanonicalWinnerIds,
     write_canonical_winner_manifest,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.metrics import (
     REPORTING_BASIS_FLOOR_AREA,
     canopy_collapse_days,
@@ -521,13 +524,13 @@ def _compute_run_metrics(
     ].reset_index(drop=True)
     bundle = compute_validation_bundle(
         prepared_bundle.observed_df.copy(),
-        candidate_series=validation_df["model_cumulative_total_fruit_dry_weight_floor_area"],
+        candidate_series=validation_df[MODEL_HARVESTED_CUMULATIVE_COLUMN],
         candidate_label=candidate_label,
         unit_declared_in_observation_file=prepared_bundle.data.observation_unit_label,
     )
     calibration_metrics = _window_metrics(
         prepared_bundle.observed_df,
-        candidate_series=validation_df["model_cumulative_total_fruit_dry_weight_floor_area"],
+        candidate_series=validation_df[MODEL_HARVESTED_CUMULATIVE_COLUMN],
         candidate_label=candidate_label,
         unit_label=prepared_bundle.data.observation_unit_label,
         start=prepared_bundle.validation_start,
@@ -535,7 +538,7 @@ def _compute_run_metrics(
     )
     holdout_metrics = _window_metrics(
         prepared_bundle.observed_df,
-        candidate_series=validation_df["model_cumulative_total_fruit_dry_weight_floor_area"],
+        candidate_series=validation_df[MODEL_HARVESTED_CUMULATIVE_COLUMN],
         candidate_label=candidate_label,
         unit_label=prepared_bundle.data.observation_unit_label,
         start=prepared_bundle.holdout_start,
@@ -565,7 +568,7 @@ def _compute_run_metrics(
         "final_total_dry_weight_floor_area": _nanlast(run_df, "total_dry_weight_g_m2"),
         "final_fruit_dry_weight_floor_area": _nanlast(
             validation_df,
-            "model_cumulative_total_fruit_dry_weight_floor_area",
+            MODEL_HARVESTED_CUMULATIVE_COLUMN,
         ),
         "fruit_anchor_error_vs_legacy": fruit_anchor_error,
         "canopy_collapse_days": canopy_collapse_days(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_family_eval.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_family_eval.py
@@ -27,6 +27,8 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines.tomato_legacy i
     resolve_forcing_path,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_DAILY_HARVEST_INCREMENT_COLUMN,
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
     model_floor_area_cumulative_total_fruit,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.metrics import (
@@ -339,8 +341,8 @@ def run_harvest_family_simulation(
     harvest_mass_balance_df = pd.DataFrame(mass_balance_rows)
     model_daily_df = model_floor_area_cumulative_total_fruit(run_df)
     indexed = model_daily_df.set_index("date")
-    candidate_series = observed_df["date"].map(indexed["model_cumulative_total_fruit_dry_weight_floor_area"])
-    candidate_daily_increment = observed_df["date"].map(indexed["model_daily_increment_floor_area"])
+    candidate_series = observed_df["date"].map(indexed[MODEL_HARVESTED_CUMULATIVE_COLUMN])
+    candidate_daily_increment = observed_df["date"].map(indexed[MODEL_DAILY_HARVEST_INCREMENT_COLUMN])
     bundle = compute_validation_bundle(
         observed_df.copy(),
         candidate_series=candidate_series,
@@ -424,7 +426,7 @@ def build_harvest_overlay_frame(validation_df: pd.DataFrame, *, source_label: st
         {
             "datetime": pd.to_datetime(validation_df["date"], errors="coerce"),
             "cumulative_total_fruit_floor_area": pd.to_numeric(
-                validation_df[f"{source_label}_cumulative_total_fruit_dry_weight_floor_area"],
+                validation_df[f"{source_label}_cumulative_harvested_fruit_dry_weight_floor_area"],
                 errors="coerce",
             ),
             "offset_adjusted_cumulative_total_fruit_floor_area": pd.to_numeric(
@@ -432,7 +434,7 @@ def build_harvest_overlay_frame(validation_df: pd.DataFrame, *, source_label: st
                 errors="coerce",
             ),
             "daily_increment_floor_area": pd.to_numeric(
-                validation_df[f"{source_label}_daily_increment_floor_area"],
+                validation_df[f"{source_label}_daily_harvest_increment_floor_area"],
                 errors="coerce",
             ),
         }

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 import pandas as pd
 
 
+MODEL_ONPLANT_FRUIT_COLUMN = "model_onplant_fruit_dry_weight_floor_area"
+MODEL_HARVESTED_CUMULATIVE_COLUMN = "model_cumulative_harvested_fruit_dry_weight_floor_area"
+MODEL_TOTAL_SYSTEM_FRUIT_COLUMN = "model_total_system_fruit_dry_weight_floor_area"
+MODEL_OBSERVED_TARGET_PROXY_COLUMN = "model_observed_target_proxy_floor_area"
+MODEL_DAILY_HARVEST_INCREMENT_COLUMN = "model_daily_harvest_increment_floor_area"
+DEPRECATED_MODEL_CUMULATIVE_TOTAL_COLUMN = "model_cumulative_total_fruit_dry_weight_floor_area"
+DEPRECATED_MODEL_TOTAL_LATENT_COLUMN = "model_total_latent_fruit_dry_weight_floor_area"
+DEPRECATED_MODEL_DAILY_INCREMENT_COLUMN = "model_daily_increment_floor_area"
+
+
 def daily_last(df: pd.DataFrame) -> pd.DataFrame:
     work = df.copy()
     work["datetime"] = pd.to_datetime(work["datetime"], errors="coerce")
@@ -20,20 +30,21 @@ def model_floor_area_cumulative_total_fruit(model_df: pd.DataFrame) -> pd.DataFr
     daily = daily_last(model_df)
     fruit = pd.to_numeric(daily.get("fruit_dry_weight_g_m2"), errors="coerce").fillna(0.0)
     harvested = pd.to_numeric(daily.get("harvested_fruit_g_m2"), errors="coerce").fillna(0.0)
-    total_latent = fruit + harvested
+    total_system = fruit + harvested
     out = pd.DataFrame(
         {
             "date": daily["date"],
-            "model_onplant_fruit_dry_weight_floor_area": fruit,
+            MODEL_ONPLANT_FRUIT_COLUMN: fruit,
             "model_harvested_fruit_floor_area": harvested,
-            "model_cumulative_harvested_fruit_dry_weight_floor_area": harvested,
-            "model_cumulative_total_fruit_dry_weight_floor_area": harvested,
-            "model_total_latent_fruit_dry_weight_floor_area": total_latent,
+            MODEL_HARVESTED_CUMULATIVE_COLUMN: harvested,
+            MODEL_OBSERVED_TARGET_PROXY_COLUMN: harvested,
+            MODEL_TOTAL_SYSTEM_FRUIT_COLUMN: total_system,
+            DEPRECATED_MODEL_CUMULATIVE_TOTAL_COLUMN: total_system,
+            DEPRECATED_MODEL_TOTAL_LATENT_COLUMN: total_system,
         }
     )
-    out["model_daily_increment_floor_area"] = _daily_increment_from_cumulative(
-        out["model_cumulative_harvested_fruit_dry_weight_floor_area"]
-    )
+    out[MODEL_DAILY_HARVEST_INCREMENT_COLUMN] = _daily_increment_from_cumulative(out[MODEL_HARVESTED_CUMULATIVE_COLUMN])
+    out[DEPRECATED_MODEL_DAILY_INCREMENT_COLUMN] = out[MODEL_DAILY_HARVEST_INCREMENT_COLUMN]
     return out
 
 
@@ -72,6 +83,14 @@ def observed_floor_area_yield(
 
 
 __all__ = [
+    "DEPRECATED_MODEL_CUMULATIVE_TOTAL_COLUMN",
+    "DEPRECATED_MODEL_DAILY_INCREMENT_COLUMN",
+    "DEPRECATED_MODEL_TOTAL_LATENT_COLUMN",
+    "MODEL_DAILY_HARVEST_INCREMENT_COLUMN",
+    "MODEL_HARVESTED_CUMULATIVE_COLUMN",
+    "MODEL_OBSERVED_TARGET_PROXY_COLUMN",
+    "MODEL_ONPLANT_FRUIT_COLUMN",
+    "MODEL_TOTAL_SYSTEM_FRUIT_COLUMN",
     "daily_last",
     "model_floor_area_cumulative_total_fruit",
     "observed_floor_area_yield",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_promotion_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_promotion_gate.py
@@ -28,6 +28,10 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_family
     build_harvest_overlay_frame,
     run_harvest_family_simulation,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_DAILY_HARVEST_INCREMENT_COLUMN,
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_mass_balance_eval import (
     winner_stability_score,
 )
@@ -64,8 +68,8 @@ def _window_metrics(validation_df: pd.DataFrame, *, start: pd.Timestamp, end: pd
                 "measured_daily_increment_floor_area",
             ]
         ].copy(),
-        candidate_series=window["model_cumulative_total_fruit_dry_weight_floor_area"],
-        candidate_daily_increment_series=window["model_daily_increment_floor_area"],
+        candidate_series=window[MODEL_HARVESTED_CUMULATIVE_COLUMN],
+        candidate_daily_increment_series=window[MODEL_DAILY_HARVEST_INCREMENT_COLUMN],
         candidate_label="model",
         unit_declared_in_observation_file="g/m^2",
     )
@@ -334,6 +338,10 @@ def run_harvest_promotion_gate(
                         "harvest_mass_balance_error": result.metrics["harvest_mass_balance_error"],
                         "latent_fruit_residual_end": result.metrics["latent_fruit_residual_end"],
                         "leaf_harvest_mass_balance_error": result.metrics["leaf_harvest_mass_balance_error"],
+                        "post_writeback_dropped_nonharvested_mass_g_m2": result.metrics[
+                            "post_writeback_dropped_nonharvested_mass_g_m2"
+                        ],
+                        "all_zero_harvest_series": result.metrics["all_zero_harvest_series"],
                         "wet_condition_root_excess_penalty": wet_penalty,
                         "score": score,
                         "selected_params_json": json.dumps(params, sort_keys=True),
@@ -355,6 +363,8 @@ def run_harvest_promotion_gate(
             max_canopy_collapse_days=("canopy_collapse_days", "max"),
             max_harvest_mass_balance_error=("harvest_mass_balance_error", "max"),
             max_leaf_harvest_mass_balance_error=("leaf_harvest_mass_balance_error", "max"),
+            max_post_writeback_dropped_nonharvested_mass_g_m2=("post_writeback_dropped_nonharvested_mass_g_m2", "max"),
+            any_all_zero_harvest_series=("all_zero_harvest_series", "max"),
             max_wet_condition_root_excess_penalty=("wet_condition_root_excess_penalty", "max"),
         )
         .reset_index(drop=True)
@@ -372,6 +382,7 @@ def run_harvest_promotion_gate(
         "fruit_anchor_error_vs_legacy_max": 0.03,
         "canopy_collapse_days_max": 0.0,
         "harvest_mass_balance_error_max": float(gate_cfg.get("harvest_mass_balance_error_max", 1e-4)),
+        "post_writeback_dropped_nonharvested_mass_g_m2_max": 0.0,
         "wet_condition_root_excess_penalty_max": float(gate_cfg.get("wet_root_penalty_max", 0.02)),
         "winner_stability_score_min": float(gate_cfg.get("winner_stability_score_min", 0.5)),
         "material_cumulative_rmse_margin": float(gate_cfg.get("material_cumulative_rmse_margin", 0.5)),
@@ -385,6 +396,9 @@ def run_harvest_promotion_gate(
             and float(candidate["max_fruit_anchor_error_vs_legacy"]) <= guardrails["fruit_anchor_error_vs_legacy_max"]
             and float(candidate["max_canopy_collapse_days"]) <= guardrails["canopy_collapse_days_max"]
             and float(candidate["max_harvest_mass_balance_error"]) <= guardrails["harvest_mass_balance_error_max"]
+            and float(candidate["max_post_writeback_dropped_nonharvested_mass_g_m2"])
+            <= guardrails["post_writeback_dropped_nonharvested_mass_g_m2_max"]
+            and not bool(candidate["any_all_zero_harvest_series"])
             and float(candidate["max_wet_condition_root_excess_penalty"]) <= guardrails["wet_condition_root_excess_penalty_max"]
             and float(candidate["winner_stability_score"]) >= guardrails["winner_stability_score_min"]
         )

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/observation_eval.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/observation_eval.py
@@ -13,6 +13,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_pro
     prepare_knu_bundle,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
     model_floor_area_cumulative_total_fruit,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.observation_model import (
@@ -151,7 +152,7 @@ def run_knu_observation_eval(*, config_path: str | Path) -> dict[str, object]:
         run_df = run_tomato_legacy_pipeline(run_cfg, repo_root=repo_root)
         model_daily_df = model_floor_area_cumulative_total_fruit(run_df)
         candidate_series = prepared_bundle.observed_df["date"].map(
-            model_daily_df.set_index("date")["model_cumulative_total_fruit_dry_weight_floor_area"]
+            model_daily_df.set_index("date")[MODEL_HARVESTED_CUMULATIVE_COLUMN]
         )
         bundle = compute_validation_bundle(
             prepared_bundle.observed_df.copy(),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/observation_model.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/observation_model.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_DAILY_HARVEST_INCREMENT_COLUMN,
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
+)
+
 
 REPORTING_BASIS_FLOOR_AREA = "floor_area_g_m2"
 
@@ -101,21 +106,41 @@ def merge_validation_series(
     observed_df: pd.DataFrame,
     model_daily_df: pd.DataFrame,
     *,
-    model_value_column: str = "model_cumulative_total_fruit_dry_weight_floor_area",
+    model_value_column: str = MODEL_HARVESTED_CUMULATIVE_COLUMN,
     source_label: str,
 ) -> pd.DataFrame:
     merged = observed_df.merge(
-        model_daily_df[["date", model_value_column, "model_daily_increment_floor_area"]],
+        model_daily_df[["date", model_value_column, MODEL_DAILY_HARVEST_INCREMENT_COLUMN]],
         on="date",
         how="left",
     )
     merged = merged.rename(
         columns={
-            model_value_column: f"{source_label}_cumulative_total_fruit_dry_weight_floor_area",
-            "model_daily_increment_floor_area": f"{source_label}_daily_increment_floor_area",
+            model_value_column: f"{source_label}_cumulative_harvested_fruit_dry_weight_floor_area",
+            MODEL_DAILY_HARVEST_INCREMENT_COLUMN: f"{source_label}_daily_harvest_increment_floor_area",
         }
     )
+    merged[f"{source_label}_cumulative_total_fruit_dry_weight_floor_area"] = merged[
+        f"{source_label}_cumulative_harvested_fruit_dry_weight_floor_area"
+    ]
+    merged[f"{source_label}_daily_increment_floor_area"] = merged[f"{source_label}_daily_harvest_increment_floor_area"]
     return merged
+
+
+def _resolve_measured_columns(observed_df: pd.DataFrame) -> tuple[str, str]:
+    cumulative_candidates = (
+        "measured_cumulative_harvested_fruit_dry_weight_floor_area",
+        "measured_cumulative_total_fruit_dry_weight_floor_area",
+    )
+    increment_candidates = (
+        "measured_daily_harvest_increment_floor_area",
+        "measured_daily_increment_floor_area",
+    )
+    cumulative_column = next((column for column in cumulative_candidates if column in observed_df.columns), None)
+    increment_column = next((column for column in increment_candidates if column in observed_df.columns), None)
+    if cumulative_column is None or increment_column is None:
+        raise KeyError(f"Missing measured validation columns in {list(observed_df.columns)!r}.")
+    return cumulative_column, increment_column
 
 
 def compute_validation_bundle(
@@ -127,35 +152,36 @@ def compute_validation_bundle(
     unit_declared_in_observation_file: str,
 ) -> ValidationSeriesBundle:
     merged = observed_df.copy()
-    cumulative_column = f"{candidate_label}_cumulative_total_fruit_dry_weight_floor_area"
-    merged[cumulative_column] = pd.to_numeric(candidate_series, errors="coerce")
-    merged["measured_offset_adjusted"] = _offset_adjusted(
-        merged["measured_cumulative_total_fruit_dry_weight_floor_area"]
-    )
-    merged[f"{candidate_label}_offset_adjusted"] = _offset_adjusted(merged[cumulative_column])
+    measured_cumulative_column, measured_increment_column = _resolve_measured_columns(merged)
+    harvested_column = f"{candidate_label}_cumulative_harvested_fruit_dry_weight_floor_area"
+    total_alias_column = f"{candidate_label}_cumulative_total_fruit_dry_weight_floor_area"
+    increment_column = f"{candidate_label}_daily_harvest_increment_floor_area"
+    merged[harvested_column] = pd.to_numeric(candidate_series, errors="coerce")
+    merged[total_alias_column] = merged[harvested_column]
+    merged["measured_offset_adjusted"] = _offset_adjusted(merged[measured_cumulative_column])
+    merged[f"{candidate_label}_offset_adjusted"] = _offset_adjusted(merged[harvested_column])
     if candidate_daily_increment_series is None:
-        merged[f"{candidate_label}_daily_increment_floor_area"] = pd.to_numeric(merged[cumulative_column], errors="coerce").diff()
+        merged[increment_column] = pd.to_numeric(merged[harvested_column], errors="coerce").diff()
     else:
-        merged[f"{candidate_label}_daily_increment_floor_area"] = pd.to_numeric(
+        merged[increment_column] = pd.to_numeric(
             candidate_daily_increment_series,
             errors="coerce",
         )
+    merged[f"{candidate_label}_daily_increment_floor_area"] = merged[increment_column]
 
     raw_metrics = _series_metrics(
-        merged["measured_cumulative_total_fruit_dry_weight_floor_area"],
-        merged[cumulative_column],
+        merged[measured_cumulative_column],
+        merged[harvested_column],
     )
     offset_metrics = _series_metrics(
         merged["measured_offset_adjusted"],
         merged[f"{candidate_label}_offset_adjusted"],
     )
     increment_metrics = _series_metrics(
-        merged["measured_daily_increment_floor_area"],
-        merged[f"{candidate_label}_daily_increment_floor_area"],
+        merged[measured_increment_column],
+        merged[increment_column],
     )
-    increment_error = (
-        merged[f"{candidate_label}_daily_increment_floor_area"] - merged["measured_daily_increment_floor_area"]
-    ).abs()
+    increment_error = (merged[increment_column] - merged[measured_increment_column]).abs()
     increment_error = pd.to_numeric(increment_error, errors="coerce")
     if merged.empty:
         final_bias = math.nan
@@ -165,18 +191,16 @@ def compute_validation_bundle(
         offset_adjustment_applied = False
     else:
         final_bias = float(
-            pd.to_numeric(merged[cumulative_column], errors="coerce").iloc[-1]
-            - pd.to_numeric(merged["measured_cumulative_total_fruit_dry_weight_floor_area"], errors="coerce").iloc[-1]
+            pd.to_numeric(merged[harvested_column], errors="coerce").iloc[-1]
+            - pd.to_numeric(merged[measured_cumulative_column], errors="coerce").iloc[-1]
         )
-        observed_final = float(
-            pd.to_numeric(merged["measured_cumulative_total_fruit_dry_weight_floor_area"], errors="coerce").iloc[-1]
-        )
+        observed_final = float(pd.to_numeric(merged[measured_cumulative_column], errors="coerce").iloc[-1])
         final_bias_pct = final_bias / observed_final * 100.0 if abs(observed_final) > 1e-9 else math.nan
         final_window_error = float(
             merged[f"{candidate_label}_offset_adjusted"].iloc[-1] - merged["measured_offset_adjusted"].iloc[-1]
         )
         offset_adjustment_applied = bool(
-            abs(float(pd.to_numeric(merged["measured_cumulative_total_fruit_dry_weight_floor_area"], errors="coerce").iloc[0])) > 1e-9
+            abs(float(pd.to_numeric(merged[measured_cumulative_column], errors="coerce").iloc[0])) > 1e-9
         )
 
     metrics = {
@@ -225,15 +249,23 @@ def resolve_validation_series_columns(
         prefixes.append("model")
 
     for prefix in prefixes:
-        cumulative_column = f"{prefix}_cumulative_total_fruit_dry_weight_floor_area"
+        cumulative_candidates = [
+            f"{prefix}_cumulative_harvested_fruit_dry_weight_floor_area",
+            f"{prefix}_cumulative_total_fruit_dry_weight_floor_area",
+        ]
         offset_column = f"{prefix}_offset_adjusted"
-        increment_column = f"{prefix}_daily_increment_floor_area"
-        if {
-            cumulative_column,
-            offset_column,
-            increment_column,
-        }.issubset(validation_df.columns):
-            return cumulative_column, offset_column, increment_column
+        increment_candidates = [
+            f"{prefix}_daily_harvest_increment_floor_area",
+            f"{prefix}_daily_increment_floor_area",
+        ]
+        for cumulative_column in cumulative_candidates:
+            for increment_column in increment_candidates:
+                if {
+                    cumulative_column,
+                    offset_column,
+                    increment_column,
+                }.issubset(validation_df.columns):
+                    return cumulative_column, offset_column, increment_column
     raise KeyError(
         "Could not resolve validation series columns "
         f"for source_label={source_label!r} in columns={list(validation_df.columns)!r}."

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/state_reconstruction.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/state_reconstruction.py
@@ -13,6 +13,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, l
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import run_tomato_legacy_pipeline
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_repo_root
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    MODEL_HARVESTED_CUMULATIVE_COLUMN,
     model_floor_area_cumulative_total_fruit,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.init_search import (
@@ -44,7 +45,7 @@ class ReconstructionResult:
 
 def _aligned_candidate_series(observed_df: pd.DataFrame, model_daily_df: pd.DataFrame) -> pd.Series:
     indexed = model_daily_df.set_index("date")
-    return observed_df["date"].map(indexed["model_cumulative_total_fruit_dry_weight_floor_area"])
+    return observed_df["date"].map(indexed[MODEL_HARVESTED_CUMULATIVE_COLUMN])
 
 
 def _initial_fruit_mass(initial_state_overrides: dict[str, object]) -> float:

--- a/tests/test_tomics_harvest_operator_contract.py
+++ b/tests/test_tomics_harvest_operator_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    model_floor_area_cumulative_total_fruit,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.observation_model import (
+    compute_validation_bundle,
+    resolve_validation_series_columns,
+)
+
+
+def test_compute_validation_bundle_writes_explicit_harvested_candidate_columns() -> None:
+    observed_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-08-08", "2024-08-09"]),
+            "measured_cumulative_harvested_fruit_dry_weight_floor_area": [0.0, 5.0],
+            "measured_daily_increment_floor_area": [pd.NA, 5.0],
+        }
+    )
+
+    bundle = compute_validation_bundle(
+        observed_df,
+        candidate_series=pd.Series([0.0, 4.0], dtype=float),
+        candidate_daily_increment_series=pd.Series([float("nan"), 4.0], dtype=float),
+        candidate_label="model",
+        unit_declared_in_observation_file="g/m^2",
+    )
+
+    assert "model_cumulative_harvested_fruit_dry_weight_floor_area" in bundle.merged_df.columns
+    assert "model_daily_harvest_increment_floor_area" in bundle.merged_df.columns
+    assert bundle.merged_df["model_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [0.0, 4.0]
+
+
+def test_validation_overlay_resolution_prefers_explicit_harvested_columns() -> None:
+    validation_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-08-08", "2024-08-09"]),
+            "model_cumulative_harvested_fruit_dry_weight_floor_area": [5.0, 7.0],
+            "model_cumulative_total_fruit_dry_weight_floor_area": [50.0, 70.0],
+            "model_offset_adjusted": [0.0, 2.0],
+            "model_daily_harvest_increment_floor_area": [pd.NA, 2.0],
+            "model_daily_increment_floor_area": [pd.NA, 20.0],
+        }
+    )
+
+    cumulative_column, offset_column, increment_column = resolve_validation_series_columns(
+        validation_df,
+        source_label="model",
+    )
+
+    assert cumulative_column == "model_cumulative_harvested_fruit_dry_weight_floor_area"
+    assert offset_column == "model_offset_adjusted"
+    assert increment_column == "model_daily_harvest_increment_floor_area"
+
+
+def test_deprecated_total_alias_tracks_total_system_mass_while_target_proxy_stays_harvested() -> None:
+    run_df = pd.DataFrame(
+        {
+            "datetime": pd.to_datetime(["2024-08-08", "2024-08-09"]),
+            "fruit_dry_weight_g_m2": [4.0, 6.0],
+            "harvested_fruit_g_m2": [0.0, 5.0],
+        }
+    )
+
+    model_df = model_floor_area_cumulative_total_fruit(run_df)
+
+    assert model_df["model_observed_target_proxy_floor_area"].tolist() == [0.0, 5.0]
+    assert model_df["model_total_system_fruit_dry_weight_floor_area"].tolist() == [4.0, 11.0]
+    assert model_df["model_cumulative_total_fruit_dry_weight_floor_area"].tolist() == [4.0, 11.0]

--- a/tests/test_tomics_knu_harvest_runner_smoke.py
+++ b/tests/test_tomics_knu_harvest_runner_smoke.py
@@ -174,5 +174,10 @@ def assert_harvest_promotion_gate_runner_writes_scorecard_outputs_from_sanitized
     guardrails = json.loads((output_root / "promotion_guardrails.json").read_text(encoding="utf-8"))
 
     assert {"shipped_tomics", "current_selected", "promoted_selected"}.issubset(set(scorecard_df["candidate_label"]))
+    assert {
+        "max_post_writeback_dropped_nonharvested_mass_g_m2",
+        "any_all_zero_harvest_series",
+    }.issubset(scorecard_df.columns)
     assert "Recommendation:" in decision
     assert set(guardrails).issuperset({"guardrails", "current_selected", "promoted_selected", "recommendation"})
+    assert "post_writeback_dropped_nonharvested_mass_g_m2_max" in guardrails["guardrails"]

--- a/tests/test_tomics_knu_observation_operator.py
+++ b/tests/test_tomics_knu_observation_operator.py
@@ -20,11 +20,13 @@ def test_harvest_observation_operator_uses_harvested_mass_not_latent_total() -> 
         }
     )
     observed = model_floor_area_cumulative_total_fruit(run_df)
-    assert observed["model_cumulative_total_fruit_dry_weight_floor_area"].tolist() == [0.0, 5.0, 9.0]
-    assert observed["model_total_latent_fruit_dry_weight_floor_area"].tolist() == [4.0, 11.0, 16.0]
-    assert pd.isna(observed["model_daily_increment_floor_area"].iloc[0])
-    assert float(observed["model_daily_increment_floor_area"].iloc[1]) == 5.0
-    assert float(observed["model_daily_increment_floor_area"].iloc[2]) == 4.0
+    assert observed["model_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [0.0, 5.0, 9.0]
+    assert observed["model_observed_target_proxy_floor_area"].tolist() == [0.0, 5.0, 9.0]
+    assert observed["model_total_system_fruit_dry_weight_floor_area"].tolist() == [4.0, 11.0, 16.0]
+    assert observed["model_cumulative_total_fruit_dry_weight_floor_area"].tolist() == [4.0, 11.0, 16.0]
+    assert pd.isna(observed["model_daily_harvest_increment_floor_area"].iloc[0])
+    assert float(observed["model_daily_harvest_increment_floor_area"].iloc[1]) == 5.0
+    assert float(observed["model_daily_harvest_increment_floor_area"].iloc[2]) == 4.0
 
 
 def test_validation_bundle_preserves_split_boundary_daily_increment_when_series_is_precomputed() -> None:
@@ -44,8 +46,8 @@ def test_validation_bundle_preserves_split_boundary_daily_increment_when_series_
         candidate_label="model",
         unit_declared_in_observation_file="g/m^2",
     )
-    assert float(bundle.merged_df["model_daily_increment_floor_area"].iloc[0]) == 4.0
-    assert float(bundle.merged_df["model_daily_increment_floor_area"].iloc[1]) == 2.0
+    assert float(bundle.merged_df["model_daily_harvest_increment_floor_area"].iloc[0]) == 4.0
+    assert float(bundle.merged_df["model_daily_harvest_increment_floor_area"].iloc[1]) == 2.0
 
 
 def test_validation_overlay_frame_uses_candidate_specific_columns() -> None:
@@ -56,11 +58,15 @@ def test_validation_overlay_frame_uses_candidate_specific_columns() -> None:
             "measured_offset_adjusted": [0.0, 1.0],
             "measured_daily_increment_floor_area": [pd.NA, 1.0],
             "estimated_cumulative_total_fruit_dry_weight_floor_area": [3.0, 4.0],
+            "estimated_cumulative_harvested_fruit_dry_weight_floor_area": [3.0, 4.0],
             "estimated_offset_adjusted": [0.0, 1.0],
             "estimated_daily_increment_floor_area": [pd.NA, 1.0],
-            "model_cumulative_total_fruit_dry_weight_floor_area": [5.0, 7.0],
+            "estimated_daily_harvest_increment_floor_area": [pd.NA, 1.0],
+            "model_cumulative_total_fruit_dry_weight_floor_area": [50.0, 70.0],
+            "model_cumulative_harvested_fruit_dry_weight_floor_area": [5.0, 7.0],
             "model_offset_adjusted": [0.0, 2.0],
             "model_daily_increment_floor_area": [pd.NA, 2.0],
+            "model_daily_harvest_increment_floor_area": [pd.NA, 2.0],
         }
     )
     model_frame = validation_overlay_frame(validation_df, source_label="shipped_tomics")


### PR DESCRIPTION
Closes #249

Stacked on #248.

This PR keeps the harvested cumulative target explicit across validation entrypoints, retains deprecated aliases for compatibility, and enforces the post-writeback audit guardrails in harvest promotion scorecards.