### PR TITLE
[Harvest Runtime] Complete native post-maturity harvest state and partial-outflow semantics

### DIFF
--- a/docs/architecture/tomics-harvest-architecture-pipeline.md
+++ b/docs/architecture/tomics-harvest-architecture-pipeline.md
@@ -48,6 +48,17 @@ Harvest families map into `h1` and `h2`; Kuijpers itself is not treated as a sta
   - fixed boxcar fruit train with explicit last-stage outflow semantics
   - explicit `MCLeafHar`-style pruning path via max-LAI pruning flow
 
+## Runtime completion rules
+
+Issue `#253` adds the missing runtime state needed to stop the four harvest families from collapsing onto the same proxy post-maturity surface.
+
+- fruit entities now carry post-maturity lifecycle axes such as `matured_at`, `days_since_maturity`, `mature_pool_residence_days`, and `final_stage_residence_days`
+- `harvest_delay_days` is treated as a post-maturity residence gate, not as threshold inflation
+- mature or sink-inactive fruit can remain on-plant until a harvest event occurs
+- partial fruit outflow leaves residual on-plant fruit mass in place until residual mass is effectively zero
+- common-structure `h1` / `h2` are wired to step harvest fluxes, not cumulative harvested pools
+- validation scoring reads explicit harvested cumulative output and keeps legacy total-fruit aliases only for compatibility
+
 ## Pipeline stages
 
 ### HF0

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/adapters.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/adapters.py
@@ -42,9 +42,16 @@ def _apply_fruit_events(
             continue
         available = float(updated.loc[mask, "fruit_dm_g_m2"].iloc[0])
         harvested = min(max(float(event.dry_weight_g_m2), 0.0), max(available, 0.0))
-        updated.loc[mask, "fruit_dm_g_m2"] = max(available - harvested, 0.0)
-        updated.loc[mask, "onplant_flag"] = False
-        updated.loc[mask, "harvested_flag"] = True
+        remaining = max(available - harvested, 0.0)
+        is_onplant = remaining > 1e-12
+        updated.loc[mask, "fruit_dm_g_m2"] = remaining
+        updated.loc[mask, "onplant_flag"] = is_onplant
+        updated.loc[mask, "harvested_flag"] = not is_onplant
+        updated.loc[mask, "harvest_ready_flag"] = is_onplant
+        if is_onplant:
+            updated.loc[mask, "mature_flag"] = True
+            if "final_stage_flag" in updated.columns:
+                updated.loc[mask, "final_stage_flag"] = updated.loc[mask, "final_stage_flag"].fillna(False)
     return updated
 
 
@@ -111,8 +118,22 @@ def build_harvest_update(
         ),
         **dict(extra_diagnostics or {}),
     }
+    partial_events = [event for event in fruit_events if bool(getattr(event, "partial_outflow_flag", False))]
+    remaining_final_stage_mass = 0.0
+    if "final_stage_flag" in updated_state.fruit_entities.columns and not updated_state.fruit_entities.empty:
+        final_stage_mask = updated_state.fruit_entities["final_stage_flag"].fillna(False).astype(bool)
+        remaining_final_stage_mass = float(
+            pd.to_numeric(
+                updated_state.fruit_entities.loc[final_stage_mask, "fruit_dm_g_m2"],
+                errors="coerce",
+            ).fillna(0.0).sum()
+        )
     diagnostics["fruit_events"] = fruit_events
     diagnostics["leaf_events"] = leaf_events
+    diagnostics["partial_fruit_outflow_flag"] = bool(partial_events)
+    diagnostics["partial_event_count"] = len(partial_events)
+    diagnostics["remaining_final_stage_mass_g_m2"] = remaining_final_stage_mass
+    diagnostics["offplant_with_positive_mass_flag"] = bool(diagnostics.get("offplant_with_positive_mass_flag", False))
     return HarvestUpdate(
         updated_state=updated_state,
         fruit_harvest_flux_g_m2_d=float(sum(max(float(event.dry_weight_g_m2), 0.0) for event in fruit_events)),
@@ -142,6 +163,41 @@ def run_harvest_step(
         },
     }
     leaf_update = leaf_policy.step(fruit_update.updated_state, leaf_env, dt_days)
+    final_diagnostics = dict(leaf_update.diagnostics)
+    for key in (
+        "fruit_events",
+        "fruit_harvest_event_count",
+        "fruit_harvest_flux_g_m2_d",
+        "partial_fruit_outflow_flag",
+        "partial_event_count",
+        "remaining_final_stage_mass_g_m2",
+        "offplant_with_positive_mass_flag",
+        "pre_onplant_fruit_g_m2",
+        "post_onplant_fruit_g_m2",
+        "harvested_fruit_flux_g_m2",
+        "partial_outflow_mass_residual_g_m2",
+        "dropped_nonharvested_mass_g_m2",
+        "latent_fruit_residual_end",
+        "duplicate_harvest_flag",
+        "negative_mass_flag",
+        "fruit_harvest_family",
+        "delay_mode",
+        "readiness_basis",
+        "proxy_mode_used",
+        "explicit_outflow_used",
+        "residence_outflow_used",
+        "final_stage_mass_g_m2",
+        "mature_pool_mass_g_m2",
+        "mature_pool_residence_days",
+        "fds_proxy_used",
+    ):
+        if key in fruit_update.diagnostics:
+            final_diagnostics[key] = fruit_update.diagnostics[key]
+    final_diagnostics["leaf_events"] = leaf_update.diagnostics.get("leaf_events", [])
+    final_diagnostics["harvest_mass_balance_error"] = max(
+        float(fruit_update.mass_balance_error),
+        float(leaf_update.mass_balance_error),
+    )
     final_update = HarvestUpdate(
         updated_state=leaf_update.updated_state,
         fruit_harvest_flux_g_m2_d=fruit_update.fruit_harvest_flux_g_m2_d,
@@ -149,7 +205,7 @@ def run_harvest_step(
         fruit_harvest_event_count=fruit_update.fruit_harvest_event_count,
         leaf_harvest_event_count=leaf_update.leaf_harvest_event_count,
         mass_balance_error=max(float(fruit_update.mass_balance_error), float(leaf_update.mass_balance_error)),
-        diagnostics={**fruit_update.diagnostics, **leaf_update.diagnostics},
+        diagnostics=final_diagnostics,
     )
     return CombinedHarvestResult(
         fruit_update=fruit_update,

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/contracts.py
@@ -17,8 +17,21 @@ HARVEST_FRUIT_COLUMNS = [
     "fds",
     "fruit_dm_g_m2",
     "fruit_count",
+    "sink_active_flag",
+    "mature_flag",
+    "harvest_ready_flag",
     "onplant_flag",
     "harvested_flag",
+    "anthesis_at",
+    "matured_at",
+    "days_since_anthesis",
+    "days_since_maturity",
+    "mature_pool_flag",
+    "mature_pool_residence_days",
+    "final_stage_flag",
+    "final_stage_residence_days",
+    "explicit_outflow_capacity_g_m2_d",
+    "proxy_state_flag",
     "potential_weight_proxy_g_m2",
 ]
 
@@ -65,7 +78,11 @@ class HarvestState:
     stem_root_state: dict[str, float] | None
     harvested_fruit_cumulative_g_m2: float
     harvested_leaf_cumulative_g_m2: float
-    diagnostics: dict[str, float] = field(default_factory=dict)
+    # Standard diagnostics keys may include:
+    # - family_state_mode
+    # - native_family_state_available
+    # - synthetic_fruit_state_flag
+    diagnostics: dict[str, float | int | str | bool] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "fruit_entities", _ensure_frame(self.fruit_entities, HARVEST_FRUIT_COLUMNS))
@@ -116,6 +133,9 @@ class FruitHarvestEvent:
     fdmc_used: float | None
     fresh_weight_equivalent_g_m2: float | None
     dry_weight_g_m2: float
+    removes_entity: bool = True
+    removal_fraction: float = 1.0
+    partial_outflow_flag: bool = False
     notes: str = ""
 
 
@@ -138,7 +158,7 @@ class HarvestUpdate:
     fruit_harvest_event_count: int
     leaf_harvest_event_count: int
     mass_balance_error: float
-    diagnostics: dict[str, float] = field(default_factory=dict)
+    diagnostics: dict[str, float | int | str | bool] = field(default_factory=dict)
 
 
 class HarvestPolicy(Protocol):

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_dekoning.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_dekoning.py
@@ -29,23 +29,47 @@ class DeKoningFdsHarvestPolicy:
     def step(self, state: HarvestState, env: dict[str, float], dt_days: float):
         frame = state.fruit_entities.copy()
         if frame.empty:
-            return build_harvest_update(state, extra_diagnostics={"fruit_harvest_family": self.family})
-        threshold = self.config.fds_harvest_threshold + self.config.harvest_delay_days * self.config.fds_delay_per_day
+            return build_harvest_update(
+                state,
+                extra_diagnostics={
+                    "fruit_harvest_family": self.family,
+                    "delay_mode": "residence_clock",
+                    "readiness_basis": "fds_plus_post_maturity_residence",
+                },
+            )
         frame["fds"] = pd.to_numeric(frame.get("fds"), errors="coerce").fillna(0.0)
+        frame["days_since_maturity"] = pd.to_numeric(frame.get("days_since_maturity"), errors="coerce").fillna(0.0)
         frame["fruit_dm_g_m2"] = pd.to_numeric(frame.get("fruit_dm_g_m2"), errors="coerce").fillna(0.0)
         frame["fruit_count"] = pd.to_numeric(frame.get("fruit_count"), errors="coerce").fillna(0.0)
         events: list[FruitHarvestEvent] = []
         dayno = float(pd.Timestamp(state.datetime).dayofyear)
         tf = float(env.get("T_air_C", env.get("TF", 23.0)))
+        proxy_mode_used = False
         for row in frame.itertuples(index=False):
-            if not bool(getattr(row, "onplant_flag", True)):
+            onplant_flag = getattr(row, "onplant_flag", True)
+            harvested_flag = getattr(row, "harvested_flag", False)
+            proxy_state_flag = getattr(row, "proxy_state_flag", False)
+            if pd.isna(onplant_flag):
+                onplant_flag = True
+            if pd.isna(harvested_flag):
+                harvested_flag = False
+            if pd.isna(proxy_state_flag):
+                proxy_state_flag = False
+            if not bool(onplant_flag) or bool(harvested_flag):
                 continue
             fds_value = float(getattr(row, "fds", 0.0))
-            if not ready_dekoning_fds(fds_value, threshold=threshold):
+            maturity_days = float(getattr(row, "days_since_maturity", 0.0))
+            if not ready_dekoning_fds(
+                fds_value,
+                threshold=self.config.fds_harvest_threshold,
+                days_since_maturity=maturity_days,
+                harvest_delay_days=self.config.harvest_delay_days,
+            ):
                 continue
             dry_weight = max(float(getattr(row, "fruit_dm_g_m2", 0.0)), 0.0)
             if dry_weight <= 0.0:
                 continue
+            proxy_mode_used = proxy_mode_used or bool(proxy_state_flag)
             fdmc_used = fdmc_family_dispatch(
                 self.config.fdmc_mode,
                 fds=fds_value,
@@ -66,10 +90,23 @@ class DeKoningFdsHarvestPolicy:
                     fdmc_used=fdmc_used,
                     fresh_weight_equivalent_g_m2=fresh_weight,
                     dry_weight_g_m2=dry_weight,
-                    notes="FDS-based research harvest with De Koning FDMC helpers.",
+                    removes_entity=True,
+                    removal_fraction=1.0,
+                    partial_outflow_flag=False,
+                    notes="FDS-based research harvest with De Koning FDMC helpers and post-maturity residence-clock gating.",
                 )
             )
-        return build_harvest_update(state, fruit_events=events, extra_diagnostics={"fruit_harvest_family": self.family})
+        return build_harvest_update(
+            state,
+            fruit_events=events,
+            extra_diagnostics={
+                "fruit_harvest_family": self.family,
+                "delay_mode": "residence_clock",
+                "readiness_basis": "fds_plus_post_maturity_residence",
+                "proxy_mode_used": proxy_mode_used,
+                "fds_proxy_used": proxy_mode_used,
+            },
+        )
 
 
 DeKoningFruitHarvestPolicy = DeKoningFdsHarvestPolicy

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_tomgro.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_tomgro.py
@@ -12,6 +12,7 @@ from .readiness import ready_tomgro_ageclass
 @dataclass(slots=True)
 class TomgroHarvestConfig:
     mature_class_index: int = 20
+    harvest_delay_days: float = 0.0
     mature_pool_harvest_mode: str = "whole_mature_class"
 
 
@@ -26,17 +27,36 @@ class TomgroAgeclassHarvestPolicy:
         if frame.empty:
             return build_harvest_update(state, extra_diagnostics={"fruit_harvest_family": self.family})
         frame["age_class"] = pd.to_numeric(frame.get("age_class"), errors="coerce").fillna(0.0)
+        frame["mature_pool_residence_days"] = pd.to_numeric(frame.get("mature_pool_residence_days"), errors="coerce").fillna(
+            pd.to_numeric(frame.get("days_since_maturity"), errors="coerce").fillna(0.0)
+        )
         frame["fruit_dm_g_m2"] = pd.to_numeric(frame.get("fruit_dm_g_m2"), errors="coerce").fillna(0.0)
         total_proxy_outflow = max(float(env.get("mature_pool_delta_g_m2", 0.0)), 0.0)
-        mature_frame = frame.loc[frame["age_class"].apply(lambda value: ready_tomgro_ageclass(value, self.config.mature_class_index))]
+        mature_frame = frame.loc[
+            frame.apply(
+                lambda row: bool(row.get("onplant_flag", True))
+                and not bool(row.get("harvested_flag", False))
+                and ready_tomgro_ageclass(
+                    row["age_class"],
+                    self.config.mature_class_index,
+                    mature_pool_residence_days=float(row["mature_pool_residence_days"]),
+                    harvest_delay_days=self.config.harvest_delay_days,
+                ),
+                axis=1,
+            )
+        ]
         mature_total = float(mature_frame["fruit_dm_g_m2"].sum())
         events: list[FruitHarvestEvent] = []
+        mature_pool_mass = mature_total
+        proxy_mode_used = bool(mature_frame.get("proxy_state_flag", pd.Series(dtype=bool)).fillna(False).astype(bool).any())
         for row in mature_frame.itertuples(index=False):
             dry_weight = max(float(getattr(row, "fruit_dm_g_m2", 0.0)), 0.0)
             if dry_weight <= 0.0:
                 continue
             if self.config.mature_pool_harvest_mode == "mature_pool_delta" and total_proxy_outflow > 0.0 and mature_total > 0.0:
                 dry_weight = min(dry_weight, total_proxy_outflow * (dry_weight / mature_total))
+            removal_fraction = 0.0 if dry_weight <= 0.0 else min(dry_weight / max(float(getattr(row, "fruit_dm_g_m2", 0.0)), 1e-12), 1.0)
+            partial_flag = removal_fraction < 0.999999
             events.append(
                 FruitHarvestEvent(
                     date=state.datetime,
@@ -48,10 +68,22 @@ class TomgroAgeclassHarvestPolicy:
                     fdmc_used=None,
                     fresh_weight_equivalent_g_m2=None,
                     dry_weight_g_m2=dry_weight,
+                    removes_entity=not partial_flag,
+                    removal_fraction=removal_fraction,
+                    partial_outflow_flag=partial_flag,
                     notes="Research proxy: mature age class or mature-pool outflow harvest.",
                 )
             )
-        return build_harvest_update(state, fruit_events=events, extra_diagnostics={"fruit_harvest_family": self.family})
+        return build_harvest_update(
+            state,
+            fruit_events=events,
+            extra_diagnostics={
+                "fruit_harvest_family": self.family,
+                "mature_pool_mass_g_m2": mature_pool_mass,
+                "mature_pool_residence_days": float(mature_frame["mature_pool_residence_days"].max()) if not mature_frame.empty else 0.0,
+                "proxy_mode_used": proxy_mode_used,
+            },
+        )
 
 
 __all__ = ["TomgroAgeclassHarvestPolicy", "TomgroHarvestConfig"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_tomsim.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_tomsim.py
@@ -23,18 +23,38 @@ class TomsimTrussHarvestPolicy:
         self.config = config or TomsimHarvestConfig(**params)
 
     def step(self, state: HarvestState, env: dict[str, float], dt_days: float):
-        threshold = self.config.tdvs_harvest_threshold + self.config.harvest_delay_days * self.config.tdvs_delay_per_day
         frame = state.fruit_entities.copy()
         if frame.empty:
-            return build_harvest_update(state, extra_diagnostics={"fruit_harvest_family": self.family})
+            return build_harvest_update(
+                state,
+                extra_diagnostics={
+                    "fruit_harvest_family": self.family,
+                    "delay_mode": "residence_clock",
+                    "readiness_basis": "tdvs_plus_post_maturity_residence",
+                },
+            )
         frame["tdvs"] = pd.to_numeric(frame.get("tdvs"), errors="coerce").fillna(0.0)
+        frame["days_since_maturity"] = pd.to_numeric(frame.get("days_since_maturity"), errors="coerce").fillna(0.0)
         frame["fruit_dm_g_m2"] = pd.to_numeric(frame.get("fruit_dm_g_m2"), errors="coerce").fillna(0.0)
         frame["fruit_count"] = pd.to_numeric(frame.get("fruit_count"), errors="coerce").fillna(0.0)
         events: list[FruitHarvestEvent] = []
         for row in frame.itertuples(index=False):
-            if not bool(getattr(row, "onplant_flag", True)):
+            onplant_flag = getattr(row, "onplant_flag", True)
+            harvested_flag = getattr(row, "harvested_flag", False)
+            if pd.isna(onplant_flag):
+                onplant_flag = True
+            if pd.isna(harvested_flag):
+                harvested_flag = False
+            if not bool(onplant_flag) or bool(harvested_flag):
                 continue
-            if not ready_tomsim_truss(getattr(row, "tdvs", 0.0), threshold=threshold):
+            tdvs_value = float(getattr(row, "tdvs", 0.0))
+            maturity_days = float(getattr(row, "days_since_maturity", 0.0))
+            if not ready_tomsim_truss(
+                tdvs_value,
+                threshold=self.config.tdvs_harvest_threshold,
+                days_since_maturity=maturity_days,
+                harvest_delay_days=self.config.harvest_delay_days,
+            ):
                 continue
             dry_weight = max(float(getattr(row, "fruit_dm_g_m2", 0.0)), 0.0)
             if dry_weight <= 0.0:
@@ -46,14 +66,25 @@ class TomsimTrussHarvestPolicy:
                     family=self.family,
                     harvest_flux_g_m2=dry_weight,
                     harvest_count=float(getattr(row, "fruit_count", 0.0)),
-                    harvest_ready_score=float(getattr(row, "tdvs", 0.0)),
+                    harvest_ready_score=tdvs_value,
                     fdmc_used=None,
                     fresh_weight_equivalent_g_m2=None,
                     dry_weight_g_m2=dry_weight,
-                    notes="Whole ready truss harvest.",
+                    removes_entity=True,
+                    removal_fraction=1.0,
+                    partial_outflow_flag=False,
+                    notes="Whole ready truss harvest with post-maturity residence-clock gating.",
                 )
             )
-        return build_harvest_update(state, fruit_events=events, extra_diagnostics={"fruit_harvest_family": self.family})
+        return build_harvest_update(
+            state,
+            fruit_events=events,
+            extra_diagnostics={
+                "fruit_harvest_family": self.family,
+                "delay_mode": "residence_clock",
+                "readiness_basis": "tdvs_plus_post_maturity_residence",
+            },
+        )
 
 
 __all__ = ["TomsimHarvestConfig", "TomsimTrussHarvestPolicy"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_vanthoor.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/fruit_harvest_vanthoor.py
@@ -13,6 +13,8 @@ from .readiness import ready_vanthoor_stage
 class VanthoorHarvestConfig:
     n_dev: int = 5
     outflow_fraction_per_day: float = 1.0
+    harvest_delay_days: float = 0.0
+    residence_outflow_days: float | None = None
     harvest_outflow_mode: str = "explicit_last_stage_outflow"
 
 
@@ -25,28 +27,67 @@ class VanthoorBoxcarHarvestPolicy:
     def step(self, state: HarvestState, env: dict[str, float], dt_days: float):
         frame = state.fruit_entities.copy()
         if frame.empty:
-            return build_harvest_update(state, extra_diagnostics={"fruit_harvest_family": self.family})
+            return build_harvest_update(
+                state,
+                extra_diagnostics={
+                    "fruit_harvest_family": self.family,
+                    "proxy_mode_used": False,
+                    "explicit_outflow_used": False,
+                    "residence_outflow_used": False,
+                },
+            )
         frame["stage_index"] = pd.to_numeric(frame.get("stage_index"), errors="coerce").fillna(0.0)
         frame["fruit_dm_g_m2"] = pd.to_numeric(frame.get("fruit_dm_g_m2"), errors="coerce").fillna(0.0)
+        frame["final_stage_residence_days"] = pd.to_numeric(
+            frame.get("final_stage_residence_days"),
+            errors="coerce",
+        ).fillna(0.0)
+        frame["explicit_outflow_capacity_g_m2_d"] = pd.to_numeric(
+            frame.get("explicit_outflow_capacity_g_m2_d"),
+            errors="coerce",
+        ).fillna(0.0)
+        frame["onplant_flag"] = frame.get("onplant_flag", True).fillna(True).astype(bool)
+        frame["harvested_flag"] = frame.get("harvested_flag", False).fillna(False).astype(bool)
+        explicit_outflow = max(float(env.get("MCFruitHar_g_m2_d", env.get("DMHar_g_m2_d", 0.0))), 0.0)
+        if explicit_outflow <= 0.0:
+            explicit_outflow = max(float((frame["explicit_outflow_capacity_g_m2_d"] * max(float(dt_days), 0.0)).sum()), 0.0)
         final_stage = frame.loc[
-            frame["stage_index"].apply(
-                lambda value: ready_vanthoor_stage(value, self.config.n_dev, env.get("MCFruitHar_g_m2_d"))
+            frame.apply(
+                lambda row: bool(row["onplant_flag"])
+                and (not bool(row["harvested_flag"]))
+                and ready_vanthoor_stage(
+                    row["stage_index"],
+                    self.config.n_dev,
+                    explicit_outflow=row["explicit_outflow_capacity_g_m2_d"] if explicit_outflow <= 0.0 else explicit_outflow,
+                    final_stage_residence_days=row["final_stage_residence_days"],
+                    harvest_delay_days=self.config.harvest_delay_days,
+                ),
+                axis=1,
             )
         ].copy()
         total_final_mass = float(final_stage["fruit_dm_g_m2"].sum())
-        explicit_outflow = max(float(env.get("MCFruitHar_g_m2_d", env.get("DMHar_g_m2_d", 0.0))), 0.0)
+        residence_outflow_days = self.config.residence_outflow_days
+        if residence_outflow_days is None:
+            fraction = max(float(self.config.outflow_fraction_per_day), 1e-9)
+            residence_outflow_days = 1.0 / fraction
+        residence_days = max(float(residence_outflow_days), 1e-9)
+        explicit_outflow_used = explicit_outflow > 0.0 and total_final_mass > 0.0
+        residence_outflow_used = (not explicit_outflow_used) and total_final_mass > 0.0
+        proxy_mode_used = bool(frame.get("proxy_state_flag", pd.Series(dtype=bool)).fillna(False).astype(bool).any())
         events: list[FruitHarvestEvent] = []
         for row in final_stage.itertuples(index=False):
             available = max(float(getattr(row, "fruit_dm_g_m2", 0.0)), 0.0)
             if available <= 0.0:
                 continue
-            if explicit_outflow > 0.0 and total_final_mass > 0.0:
-                dry_weight = explicit_outflow * (available / total_final_mass) * max(float(dt_days), 1.0)
+            if explicit_outflow_used:
+                dry_weight = explicit_outflow * (available / total_final_mass) * max(float(dt_days), 0.0)
             else:
-                dry_weight = available * max(min(self.config.outflow_fraction_per_day * max(float(dt_days), 1.0), 1.0), 0.0)
+                dry_weight = available * max(min(max(float(dt_days), 0.0) / residence_days, 1.0), 0.0)
             dry_weight = min(dry_weight, available)
             if dry_weight <= 0.0:
                 continue
+            removal_fraction = 0.0 if available <= 1e-12 else min(max(dry_weight / available, 0.0), 1.0)
+            partial_outflow = removal_fraction < 0.999999
             events.append(
                 FruitHarvestEvent(
                     date=state.datetime,
@@ -58,10 +99,23 @@ class VanthoorBoxcarHarvestPolicy:
                     fdmc_used=None,
                     fresh_weight_equivalent_g_m2=None,
                     dry_weight_g_m2=dry_weight,
+                    removes_entity=not partial_outflow,
+                    removal_fraction=removal_fraction,
+                    partial_outflow_flag=partial_outflow,
                     notes="Explicit last-stage harvest outflow proxy for Vanthoor boxcar fruit train.",
                 )
             )
-        return build_harvest_update(state, fruit_events=events, extra_diagnostics={"fruit_harvest_family": self.family})
+        return build_harvest_update(
+            state,
+            fruit_events=events,
+            extra_diagnostics={
+                "fruit_harvest_family": self.family,
+                "final_stage_mass_g_m2": total_final_mass,
+                "explicit_outflow_used": explicit_outflow_used,
+                "residence_outflow_used": residence_outflow_used,
+                "proxy_mode_used": proxy_mode_used,
+            },
+        )
 
 
 __all__ = ["VanthoorBoxcarHarvestPolicy", "VanthoorHarvestConfig"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/mass_balance.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/mass_balance.py
@@ -16,6 +16,16 @@ def _sum_positive(frame: pd.DataFrame, column: str) -> float:
     return float(values.clip(lower=0.0).sum())
 
 
+def _sum_onplant_positive(frame: pd.DataFrame, column: str) -> float:
+    if frame.empty or column not in frame.columns:
+        return 0.0
+    onplant_mask = frame.get("onplant_flag", True)
+    if not isinstance(onplant_mask, pd.Series):
+        onplant_mask = pd.Series([bool(onplant_mask)] * len(frame), index=frame.index)
+    values = pd.to_numeric(frame.loc[onplant_mask.fillna(True).astype(bool), column], errors="coerce").fillna(0.0)
+    return float(values.clip(lower=0.0).sum())
+
+
 def harvest_mass_balance_error(
     before_state: HarvestState,
     after_state: HarvestState,
@@ -45,6 +55,17 @@ def negative_mass_flag(state: HarvestState) -> bool:
     return bool(fruit_negative or leaf_negative)
 
 
+def offplant_with_positive_mass_flag(state: HarvestState) -> bool:
+    if state.fruit_entities.empty or "fruit_dm_g_m2" not in state.fruit_entities.columns:
+        return False
+    onplant_mask = state.fruit_entities.get("onplant_flag", True)
+    if not isinstance(onplant_mask, pd.Series):
+        onplant_mask = pd.Series([bool(onplant_mask)] * len(state.fruit_entities), index=state.fruit_entities.index)
+    offplant_mask = ~onplant_mask.fillna(True).astype(bool)
+    values = pd.to_numeric(state.fruit_entities.loc[offplant_mask, "fruit_dm_g_m2"], errors="coerce").fillna(0.0)
+    return bool((values > 1e-12).any())
+
+
 def mass_balance_metrics(
     before_state: HarvestState,
     after_state: HarvestState,
@@ -52,8 +73,24 @@ def mass_balance_metrics(
     fruit_events: list[FruitHarvestEvent],
     leaf_events: list[LeafHarvestEvent],
 ) -> dict[str, float | bool]:
+    pre_onplant_fruit = _sum_onplant_positive(before_state.fruit_entities, "fruit_dm_g_m2")
+    post_onplant_fruit = _sum_onplant_positive(after_state.fruit_entities, "fruit_dm_g_m2")
+    harvested_flux = float(sum(max(float(event.dry_weight_g_m2), 0.0) for event in fruit_events))
+    partial_event_ids = {event.entity_id for event in fruit_events if bool(getattr(event, "partial_outflow_flag", False))}
+    partial_residual = 0.0
+    if partial_event_ids and not after_state.fruit_entities.empty:
+        partial_mask = after_state.fruit_entities["entity_id"].astype(str).isin({str(value) for value in partial_event_ids})
+        partial_residual = float(
+            pd.to_numeric(after_state.fruit_entities.loc[partial_mask, "fruit_dm_g_m2"], errors="coerce").fillna(0.0).sum()
+        )
     return {
         "harvest_mass_balance_error": harvest_mass_balance_error(before_state, after_state, fruit_events, leaf_events),
+        "pre_onplant_fruit_g_m2": pre_onplant_fruit,
+        "post_onplant_fruit_g_m2": post_onplant_fruit,
+        "harvested_fruit_flux_g_m2": harvested_flux,
+        "partial_outflow_mass_residual_g_m2": partial_residual,
+        "dropped_nonharvested_mass_g_m2": max(pre_onplant_fruit - post_onplant_fruit - harvested_flux, 0.0),
+        "offplant_with_positive_mass_flag": offplant_with_positive_mass_flag(after_state),
         "latent_fruit_residual_end": _sum_positive(after_state.fruit_entities, "fruit_dm_g_m2"),
         "leaf_harvest_mass_balance_error": abs(
             _sum_positive(before_state.leaf_entities, "leaf_dm_g_m2")
@@ -79,4 +116,5 @@ __all__ = [
     "harvest_mass_balance_error",
     "mass_balance_metrics",
     "negative_mass_flag",
+    "offplant_with_positive_mass_flag",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/readiness.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/readiness.py
@@ -1,26 +1,55 @@
 from __future__ import annotations
 
 
-def ready_tomsim_truss(tdvs: float, threshold: float = 1.0) -> bool:
-    return float(tdvs) >= float(threshold)
+def _delay_gate(days_since_maturity: float, harvest_delay_days: float) -> bool:
+    return float(days_since_maturity) + 1e-9 >= max(float(harvest_delay_days), 0.0)
 
 
-def ready_tomgro_ageclass(age_class: float, mature_class_index: int) -> bool:
-    return float(age_class) >= float(mature_class_index)
+def ready_tomsim_truss(
+    tdvs: float,
+    threshold: float = 1.0,
+    *,
+    days_since_maturity: float = 0.0,
+    harvest_delay_days: float = 0.0,
+) -> bool:
+    return float(tdvs) >= float(threshold) and _delay_gate(days_since_maturity, harvest_delay_days)
 
 
-def ready_dekoning_fds(fds: float, threshold: float = 1.0) -> bool:
-    return float(fds) >= float(threshold)
+def ready_tomgro_ageclass(
+    age_class: float,
+    mature_class_index: int,
+    *,
+    mature_pool_residence_days: float = 0.0,
+    harvest_delay_days: float = 0.0,
+) -> bool:
+    return float(age_class) >= float(mature_class_index) and _delay_gate(
+        mature_pool_residence_days,
+        harvest_delay_days,
+    )
+
+
+def ready_dekoning_fds(
+    fds: float,
+    threshold: float = 1.0,
+    *,
+    days_since_maturity: float = 0.0,
+    harvest_delay_days: float = 0.0,
+) -> bool:
+    return float(fds) >= float(threshold) and _delay_gate(days_since_maturity, harvest_delay_days)
 
 
 def ready_vanthoor_stage(
     stage_index: float,
     n_dev: int,
+    *,
     explicit_outflow: float | None = None,
+    final_stage_residence_days: float = 0.0,
+    harvest_delay_days: float = 0.0,
 ) -> bool:
+    ready_base = float(stage_index) >= float(max(int(n_dev), 1))
     if explicit_outflow is not None and float(explicit_outflow) > 0.0:
-        return True
-    return float(stage_index) >= float(max(int(n_dev), 1))
+        ready_base = True
+    return ready_base and _delay_gate(final_stage_residence_days, harvest_delay_days)
 
 
 __all__ = [

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/state_normalizer.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/harvest/state_normalizer.py
@@ -22,9 +22,90 @@ def _float_from(series: pd.Series, key: str, default: float = 0.0) -> float:
     return float(default if pd.isna(numeric) else numeric)
 
 
-def _parse_truss_payload(series: pd.Series) -> pd.DataFrame:
+def _bool_from(value: object, default: bool) -> bool:
+    if value is None or value is pd.NA:
+        return bool(default)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes"}:
+            return True
+        if lowered in {"false", "0", "no"}:
+            return False
+    try:
+        return bool(value)
+    except Exception:
+        return bool(default)
+
+
+def _int_stage_from_tdvs(tdvs: float, *, max_stage: int) -> int:
+    return int(min(max_stage, max(1, round(max(tdvs, 0.0) * max_stage))))
+
+
+def _prior_fruit_lookup(prior_row: pd.Series | None) -> pd.DataFrame:
+    if prior_row is None:
+        return pd.DataFrame(columns=FRUIT_ENTITY_COLUMNS)
+    payload = prior_row.get("__harvest_state_fruit_entities")
+    if isinstance(payload, pd.DataFrame):
+        return ensure_entity_frame(payload, FRUIT_ENTITY_COLUMNS)
+    prior_json = prior_row.get("truss_cohorts_json", "")
+    if not isinstance(prior_json, str) or not prior_json.strip():
+        return pd.DataFrame(columns=FRUIT_ENTITY_COLUMNS)
+    try:
+        parsed = json.loads(prior_json)
+    except json.JSONDecodeError:
+        parsed = []
+    if not isinstance(parsed, list):
+        return pd.DataFrame(columns=FRUIT_ENTITY_COLUMNS)
+    return ensure_entity_frame(pd.DataFrame([row for row in parsed if isinstance(row, dict)]), FRUIT_ENTITY_COLUMNS)
+
+
+def _merge_prior_runtime_fields(frame: pd.DataFrame, prior_frame: pd.DataFrame) -> pd.DataFrame:
+    if frame.empty or prior_frame.empty or "entity_id" not in frame.columns or "entity_id" not in prior_frame.columns:
+        return frame
+    prior_indexed = prior_frame.copy()
+    prior_indexed["entity_id"] = prior_indexed["entity_id"].astype(str)
+    prior_indexed = prior_indexed.set_index("entity_id")
+    runtime_columns = [
+        "sink_active_flag",
+        "mature_flag",
+        "harvest_ready_flag",
+        "onplant_flag",
+        "harvested_flag",
+        "anthesis_at",
+        "matured_at",
+        "days_since_anthesis",
+        "days_since_maturity",
+        "mature_pool_flag",
+        "mature_pool_residence_days",
+        "final_stage_flag",
+        "final_stage_residence_days",
+        "explicit_outflow_capacity_g_m2_d",
+        "proxy_state_flag",
+    ]
+    out = frame.copy()
+    out["entity_id"] = out["entity_id"].astype(str)
+    for column in runtime_columns:
+        if column not in out.columns:
+            out[column] = pd.NA
+        mapped = out["entity_id"].map(prior_indexed[column]) if column in prior_indexed.columns else pd.Series(pd.NA, index=out.index)
+        out[column] = out[column].where(out[column].notna(), mapped)
+    return out
+
+
+def _parse_truss_payload(
+    series: pd.Series,
+    *,
+    prior_fruit_entities: pd.DataFrame,
+    allow_bulk_proxy: bool,
+) -> tuple[pd.DataFrame, dict[str, float | int | str | bool]]:
     payload = series.get("truss_cohorts_json", "")
     records: list[dict[str, object]] = []
+    diagnostics: dict[str, float | int | str | bool] = {
+        "family_state_mode": "native_payload",
+        "native_family_state_available": True,
+        "synthetic_fruit_state_flag": False,
+        "tdvs_proxy_used": False,
+    }
     if isinstance(payload, str) and payload.strip():
         try:
             parsed = json.loads(payload)
@@ -32,35 +113,109 @@ def _parse_truss_payload(series: pd.Series) -> pd.DataFrame:
             parsed = []
         if isinstance(parsed, list):
             records = [record for record in parsed if isinstance(record, dict)]
+
     if not records:
         fruit_dm = _float_from(series, "fruit_dry_weight_g_m2", 0.0)
         if fruit_dm <= 0.0:
-            return pd.DataFrame(columns=FRUIT_ENTITY_COLUMNS)
+            diagnostics["native_family_state_available"] = False
+            return pd.DataFrame(columns=FRUIT_ENTITY_COLUMNS), diagnostics
+        diagnostics.update(
+            {
+                "family_state_mode": "shared_tdvs_proxy",
+                "native_family_state_available": False,
+                "synthetic_fruit_state_flag": True,
+                "tdvs_proxy_used": True,
+            }
+        )
+        semantics = str(series.get("harvest_family_semantics", "bulk_fruit"))
+        if (not allow_bulk_proxy) and semantics not in {"tomsim_truss", "bulk_fruit"}:
+            diagnostics["proxy_mode_used"] = True
         records = [
             {
                 "entity_id": "fruit_bulk_001",
-                "family_semantics": str(series.get("harvest_family_semantics", "bulk_fruit")),
+                "family_semantics": semantics,
                 "truss_id": 1.0,
                 "fruit_position": 1.0,
                 "age_class": _float_from(series, "age_class", 1.0),
                 "stage_index": _float_from(series, "stage_index", 1.0),
                 "tdvs": _float_from(series, "mean_truss_tdvs", 0.0),
-                "fds": _float_from(series, "mean_truss_tdvs", 0.0),
+                "fds": pd.NA,
                 "fruit_dm_g_m2": fruit_dm,
                 "fruit_count": max(_float_from(series, "n_fruits_per_truss", 1.0), 1.0),
+                "sink_active_flag": True,
+                "mature_flag": False,
+                "harvest_ready_flag": False,
                 "onplant_flag": True,
                 "harvested_flag": False,
+                "days_since_anthesis": 0.0,
+                "days_since_maturity": 0.0,
+                "mature_pool_flag": False,
+                "mature_pool_residence_days": 0.0,
+                "final_stage_flag": False,
+                "final_stage_residence_days": 0.0,
+                "explicit_outflow_capacity_g_m2_d": 0.0,
+                "proxy_state_flag": True,
                 "potential_weight_proxy_g_m2": fruit_dm,
             }
         ]
+
     frame = pd.DataFrame(records)
     if "family_semantics" not in frame.columns:
         frame["family_semantics"] = str(series.get("harvest_family_semantics", "unknown"))
-    if "onplant_flag" not in frame.columns:
-        frame["onplant_flag"] = True
-    if "harvested_flag" not in frame.columns:
-        frame["harvested_flag"] = False
-    return ensure_entity_frame(frame, FRUIT_ENTITY_COLUMNS)
+    frame = ensure_entity_frame(frame, FRUIT_ENTITY_COLUMNS)
+    frame = _merge_prior_runtime_fields(frame, prior_fruit_entities)
+
+    tdvs_numeric = pd.to_numeric(frame.get("tdvs"), errors="coerce").fillna(0.0)
+    if frame.get("fds").isna().all():
+        diagnostics["tdvs_proxy_used"] = True
+        frame["fds"] = tdvs_numeric
+        frame["proxy_state_flag"] = True
+    else:
+        frame["fds"] = pd.to_numeric(frame.get("fds"), errors="coerce")
+        missing_fds = frame["fds"].isna()
+        if bool(missing_fds.any()):
+            diagnostics["tdvs_proxy_used"] = True
+            frame.loc[missing_fds, "fds"] = tdvs_numeric.loc[missing_fds]
+            frame.loc[missing_fds, "proxy_state_flag"] = True
+
+    frame["tdvs"] = tdvs_numeric
+    if frame.get("age_class").isna().all():
+        frame["age_class"] = tdvs_numeric.apply(lambda value: float(_int_stage_from_tdvs(value, max_stage=20)))
+    if frame.get("stage_index").isna().all():
+        frame["stage_index"] = tdvs_numeric.apply(lambda value: float(_int_stage_from_tdvs(value, max_stage=5)))
+    frame["fruit_dm_g_m2"] = pd.to_numeric(frame.get("fruit_dm_g_m2"), errors="coerce").fillna(0.0)
+    frame["fruit_count"] = pd.to_numeric(frame.get("fruit_count"), errors="coerce").fillna(0.0)
+    frame["days_since_anthesis"] = pd.to_numeric(frame.get("days_since_anthesis"), errors="coerce").fillna(0.0)
+    frame["days_since_maturity"] = pd.to_numeric(frame.get("days_since_maturity"), errors="coerce").fillna(0.0)
+    frame["mature_pool_residence_days"] = pd.to_numeric(frame.get("mature_pool_residence_days"), errors="coerce").fillna(
+        frame["days_since_maturity"]
+    )
+    frame["final_stage_residence_days"] = pd.to_numeric(frame.get("final_stage_residence_days"), errors="coerce").fillna(
+        frame["days_since_maturity"]
+    )
+    frame["explicit_outflow_capacity_g_m2_d"] = pd.to_numeric(
+        frame.get("explicit_outflow_capacity_g_m2_d"),
+        errors="coerce",
+    ).fillna(0.0)
+    frame["sink_active_flag"] = frame["sink_active_flag"].map(lambda value: _bool_from(value, True))
+    frame["mature_flag"] = frame["mature_flag"].map(lambda value: _bool_from(value, False))
+    frame["harvest_ready_flag"] = frame["harvest_ready_flag"].map(lambda value: _bool_from(value, False))
+    frame["onplant_flag"] = frame["onplant_flag"].map(lambda value: _bool_from(value, True))
+    frame["harvested_flag"] = frame["harvested_flag"].map(lambda value: _bool_from(value, False))
+    frame["mature_pool_flag"] = frame["mature_pool_flag"].map(lambda value: _bool_from(value, False))
+    frame["final_stage_flag"] = frame["final_stage_flag"].map(lambda value: _bool_from(value, False))
+    frame["proxy_state_flag"] = frame["proxy_state_flag"].map(lambda value: _bool_from(value, False))
+    frame["potential_weight_proxy_g_m2"] = pd.to_numeric(
+        frame.get("potential_weight_proxy_g_m2"),
+        errors="coerce",
+    ).fillna(frame["fruit_dm_g_m2"])
+    diagnostics["synthetic_fruit_state_flag"] = bool(frame["proxy_state_flag"].any()) or bool(
+        diagnostics["synthetic_fruit_state_flag"]
+    )
+    if diagnostics["synthetic_fruit_state_flag"]:
+        diagnostics["family_state_mode"] = "shared_tdvs_proxy"
+    diagnostics["native_family_state_available"] = not bool(diagnostics["synthetic_fruit_state_flag"])
+    return frame, diagnostics
 
 
 def _synthesize_leaf_entities(series: pd.Series, fruit_entities: pd.DataFrame) -> pd.DataFrame:
@@ -106,6 +261,7 @@ def normalize_harvest_state(
     *,
     plants_per_m2: float = 1.836091,
     floor_area_basis: bool = True,
+    allow_bulk_proxy: bool = True,
 ) -> HarvestState:
     current = _as_series(current_row)
     prior = _as_series(prior_row)
@@ -114,7 +270,12 @@ def normalize_harvest_state(
         dt_days = max((current_time - pd.Timestamp(prior.get("datetime"))).total_seconds() / 86400.0, 0.0)
     else:
         dt_days = max(_float_from(current, "dt_days", 1.0), 1e-9)
-    fruit_entities = _parse_truss_payload(current)
+    prior_fruit_entities = _prior_fruit_lookup(prior)
+    fruit_entities, fruit_diagnostics = _parse_truss_payload(
+        current,
+        prior_fruit_entities=prior_fruit_entities,
+        allow_bulk_proxy=allow_bulk_proxy,
+    )
     leaf_entities = _synthesize_leaf_entities(current, fruit_entities)
     stem_root_state = {
         "stem_dry_weight_g_m2": _float_from(current, "stem_dry_weight_g_m2", 0.0),
@@ -122,11 +283,12 @@ def normalize_harvest_state(
         "reserve_pool_g_m2": _float_from(current, "reserve_pool_g_m2", 0.0),
         "buffer_pool_g_m2": _float_from(current, "buffer_pool_g_m2", 0.0),
     }
-    diagnostics = {
+    diagnostics: dict[str, float | int | str | bool] = {
         "truss_count": _float_from(current, "truss_count", float(len(fruit_entities))),
         "active_trusses": _float_from(current, "active_trusses", float(len(fruit_entities))),
         "fruit_harvest_g_m2_step": _float_from(current, "fruit_harvest_g_m2_step", 0.0),
         "leaf_harvest_g_m2_step": _float_from(current, "leaf_harvest_g_m2_step", 0.0),
+        **fruit_diagnostics,
     }
     return HarvestState(
         datetime=current_time,
@@ -150,12 +312,14 @@ def snapshot_to_harvest_state(
     *,
     plants_per_m2: float = 1.836091,
     floor_area_basis: bool = True,
+    allow_bulk_proxy: bool = True,
 ) -> HarvestState:
     return normalize_harvest_state(
         current_row,
         prior_row=prior_row,
         plants_per_m2=plants_per_m2,
         floor_area_basis=floor_area_basis,
+        allow_bulk_proxy=allow_bulk_proxy,
     )
 
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/partitioning/common_structure.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/components/partitioning/common_structure.py
@@ -36,6 +36,7 @@ def build_common_structure_snapshot(
     fruit_harvest_g: float,
     leaf_harvest_g: float,
 ) -> dict[str, float]:
+    """Build a Kuijpers-style snapshot where h1/h2 are step harvest fluxes, not cumulative pools."""
     total_structural = max(float(structural_biomass_g or 0.0), 0.0)
     fruit_mass = max(float(fruit_biomass_g or 0.0), 0.0)
     leaf_mass = max(float(leaf_biomass_g or 0.0), 0.0)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/models/tomato_legacy/tomato_model.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/models/tomato_legacy/tomato_model.py
@@ -317,8 +317,8 @@ class TomatoModel:
             growth_respiration_g=0.0,
             growth_g=0.0,
             maintenance_g=0.0,
-            fruit_harvest_g=self.W_fr_harvested,
-            leaf_harvest_g=0.0,
+            fruit_harvest_g=self.last_fruit_harvest_g,
+            leaf_harvest_g=self.last_leaf_harvest_g,
         )
         self._apply_initial_state_overrides()
         self._tomics_research_prev_root_fraction = None
@@ -329,6 +329,179 @@ class TomatoModel:
         self.eps_eff_last = 0.0
         self.T_env_last_K = self.T_a
         self.r_lw_net_last = 0.0
+
+    @staticmethod
+    def _cohort_timestamp_iso(value: object) -> str | None:
+        if value is None:
+            return None
+        try:
+            ts = pd.Timestamp(value)
+        except Exception:
+            return None
+        if pd.isna(ts):
+            return None
+        return ts.isoformat()
+
+    @staticmethod
+    def _cohort_timestamp_or_none(value: object) -> str | None:
+        if isinstance(value, str) and value.strip():
+            return value
+        return TomatoModel._cohort_timestamp_iso(value)
+
+    @staticmethod
+    def _cohort_bool(value: object, default: bool) -> bool:
+        if value is None or value is pd.NA:
+            return bool(default)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+        try:
+            return bool(value)
+        except Exception:
+            return bool(default)
+
+    def _derived_age_class(self, tdvs: float) -> int:
+        return int(min(20, max(1, math.ceil(max(0.0, float(tdvs)) * 20.0))))
+
+    def _derived_stage_index(self, tdvs: float) -> int:
+        return int(min(5, max(1, math.ceil(max(0.0, float(tdvs)) * 5.0))))
+
+    def _ensure_cohort_runtime_fields(
+        self,
+        cohort: dict[str, object],
+        *,
+        current_time: datetime | None = None,
+    ) -> dict[str, object]:
+        tdvs = max(0.0, _finite_float(cohort.get("tdvs"), default=0.0))
+        harvested_flag = self._cohort_bool(cohort.get("harvested_flag"), False)
+        sink_active_flag = self._cohort_bool(cohort.get("sink_active_flag", cohort.get("active", True)), True)
+        onplant_default = (not harvested_flag) and (
+            max(0.0, _finite_float(cohort.get("w_fr_cohort"), default=0.0)) > 1e-12 or sink_active_flag
+        )
+        onplant_flag = self._cohort_bool(cohort.get("onplant_flag"), onplant_default)
+        mature_flag = self._cohort_bool(
+            cohort.get("mature_flag"),
+            tdvs >= self.tdvs_max or ((not sink_active_flag) and onplant_flag),
+        )
+        anthesis_at = self._cohort_timestamp_or_none(cohort.get("anthesis_at"))
+        matured_at = self._cohort_timestamp_or_none(cohort.get("matured_at"))
+        if anthesis_at is None and current_time is not None and tdvs > 0.0:
+            anthesis_at = self._cohort_timestamp_iso(current_time)
+        age_class_native = int(
+            max(
+                1,
+                round(
+                    _finite_float(
+                        cohort.get("age_class_native", cohort.get("age_class")),
+                        default=float(self._derived_age_class(tdvs)),
+                    )
+                ),
+            )
+        )
+        stage_index_native = int(
+            max(
+                1,
+                round(
+                    _finite_float(
+                        cohort.get("stage_index_native", cohort.get("stage_index")),
+                        default=float(self._derived_stage_index(tdvs)),
+                    )
+                ),
+            )
+        )
+        days_since_maturity = max(_finite_float(cohort.get("days_since_maturity"), default=0.0), 0.0)
+        mature_pool_flag = self._cohort_bool(
+            cohort.get("mature_pool_flag"),
+            mature_flag or age_class_native >= self._derived_age_class(self.tdvs_max),
+        )
+        final_stage_flag = self._cohort_bool(
+            cohort.get("final_stage_flag"),
+            mature_flag or stage_index_native >= self._derived_stage_index(self.tdvs_max),
+        )
+        cohort.update(
+            {
+                "active": sink_active_flag,
+                "sink_active_flag": sink_active_flag,
+                "mature_flag": mature_flag,
+                "harvest_ready_flag": self._cohort_bool(cohort.get("harvest_ready_flag"), mature_flag and onplant_flag),
+                "onplant_flag": onplant_flag,
+                "harvested_flag": harvested_flag,
+                "anthesis_at": anthesis_at,
+                "matured_at": matured_at,
+                "days_since_anthesis": max(_finite_float(cohort.get("days_since_anthesis"), default=0.0), 0.0),
+                "days_since_maturity": days_since_maturity,
+                "fds": max(0.0, _finite_float(cohort.get("fds"), default=tdvs)),
+                "age_class_native": age_class_native,
+                "stage_index_native": stage_index_native,
+                "mature_pool_flag": mature_pool_flag,
+                "mature_pool_residence_days": max(
+                    _finite_float(
+                        cohort.get("mature_pool_residence_days"),
+                        default=(days_since_maturity if mature_pool_flag else 0.0),
+                    ),
+                    0.0,
+                ),
+                "final_stage_flag": final_stage_flag,
+                "final_stage_residence_days": max(
+                    _finite_float(
+                        cohort.get("final_stage_residence_days"),
+                        default=(days_since_maturity if final_stage_flag else 0.0),
+                    ),
+                    0.0,
+                ),
+                "explicit_outflow_capacity_g_m2_d": max(
+                    _finite_float(cohort.get("explicit_outflow_capacity_g_m2_d"), default=0.0),
+                    0.0,
+                ),
+                "proxy_state_flag": self._cohort_bool(cohort.get("proxy_state_flag"), False),
+            }
+        )
+        return cohort
+
+    def _mark_cohort_mature_onplant(self, cohort: dict[str, object], current_time: datetime) -> None:
+        self._ensure_cohort_runtime_fields(cohort, current_time=current_time)
+        if cohort.get("matured_at") is None:
+            cohort["matured_at"] = self._cohort_timestamp_iso(current_time)
+            cohort["days_since_maturity"] = 0.0
+        cohort["active"] = False
+        cohort["sink_active_flag"] = False
+        cohort["mature_flag"] = True
+        cohort["onplant_flag"] = not self._cohort_bool(cohort.get("harvested_flag"), False)
+        cohort["harvest_ready_flag"] = bool(cohort["onplant_flag"])
+        cohort["mature_pool_flag"] = True
+        cohort["final_stage_flag"] = True
+
+    def _update_cohort_runtime_state(self, current_time: datetime, dt_days: float) -> None:
+        dt_days = max(float(dt_days), 0.0)
+        for cohort in self.truss_cohorts:
+            self._ensure_cohort_runtime_fields(cohort, current_time=current_time)
+            if bool(cohort.get("onplant_flag", False)) and not bool(cohort.get("harvested_flag", False)):
+                cohort["days_since_anthesis"] = max(
+                    _finite_float(cohort.get("days_since_anthesis"), default=0.0) + dt_days,
+                    0.0,
+                )
+            was_mature = bool(cohort.get("mature_flag", False))
+            tdvs = max(0.0, _finite_float(cohort.get("tdvs"), default=0.0))
+            if tdvs >= self.tdvs_max or (not bool(cohort.get("active", True)) and bool(cohort.get("onplant_flag", True))):
+                self._mark_cohort_mature_onplant(cohort, current_time)
+                if was_mature and bool(cohort.get("onplant_flag", False)) and not bool(cohort.get("harvested_flag", False)):
+                    cohort["days_since_maturity"] = max(
+                        _finite_float(cohort.get("days_since_maturity"), default=0.0) + dt_days,
+                        0.0,
+                    )
+            cohort["mature_pool_residence_days"] = (
+                max(_finite_float(cohort.get("days_since_maturity"), default=0.0), 0.0)
+                if bool(cohort.get("mature_pool_flag", False))
+                else 0.0
+            )
+            cohort["final_stage_residence_days"] = (
+                max(_finite_float(cohort.get("days_since_maturity"), default=0.0), 0.0)
+                if bool(cohort.get("final_stage_flag", False))
+                else 0.0
+            )
 
     def _apply_initial_state_overrides(self) -> None:
         overrides = getattr(self, "initial_state_overrides", {}) or {}
@@ -400,8 +573,56 @@ class TomatoModel:
                         "w_fr_cohort": max(0.0, _finite_float(raw.get("w_fr_cohort"), default=0.0)),
                         "active": bool(raw.get("active", True)),
                         "mult": max(0.0, _finite_float(raw.get("mult"), default=float(self.shoots_per_m2))),
+                        "fds": max(0.0, _finite_float(raw.get("fds"), default=_finite_float(raw.get("tdvs"), default=0.0))),
+                        "onplant_flag": bool(raw.get("onplant_flag", True)),
+                        "harvested_flag": bool(raw.get("harvested_flag", False)),
+                        "sink_active_flag": bool(raw.get("sink_active_flag", raw.get("active", True))),
+                        "mature_flag": bool(raw.get("mature_flag", False)),
+                        "harvest_ready_flag": bool(raw.get("harvest_ready_flag", False)),
+                        "anthesis_at": self._cohort_timestamp_or_none(raw.get("anthesis_at")),
+                        "matured_at": self._cohort_timestamp_or_none(raw.get("matured_at")),
+                        "days_since_anthesis": max(_finite_float(raw.get("days_since_anthesis"), default=0.0), 0.0),
+                        "days_since_maturity": max(_finite_float(raw.get("days_since_maturity"), default=0.0), 0.0),
+                        "age_class_native": int(
+                            max(
+                                1,
+                                round(
+                                    _finite_float(
+                                        raw.get("age_class_native", raw.get("age_class")),
+                                        default=float(self._derived_age_class(_finite_float(raw.get("tdvs"), default=0.0))),
+                                    )
+                                ),
+                            )
+                        ),
+                        "stage_index_native": int(
+                            max(
+                                1,
+                                round(
+                                    _finite_float(
+                                        raw.get("stage_index_native", raw.get("stage_index")),
+                                        default=float(self._derived_stage_index(_finite_float(raw.get("tdvs"), default=0.0))),
+                                    )
+                                ),
+                            )
+                        ),
+                        "mature_pool_flag": bool(raw.get("mature_pool_flag", False)),
+                        "mature_pool_residence_days": max(
+                            _finite_float(raw.get("mature_pool_residence_days"), default=0.0),
+                            0.0,
+                        ),
+                        "final_stage_flag": bool(raw.get("final_stage_flag", False)),
+                        "final_stage_residence_days": max(
+                            _finite_float(raw.get("final_stage_residence_days"), default=0.0),
+                            0.0,
+                        ),
+                        "explicit_outflow_capacity_g_m2_d": max(
+                            _finite_float(raw.get("explicit_outflow_capacity_g_m2_d"), default=0.0),
+                            0.0,
+                        ),
+                        "proxy_state_flag": bool(raw.get("proxy_state_flag", False)),
                     }
                 )
+                self._ensure_cohort_runtime_fields(normalized[-1], current_time=self.start_date)
             self.truss_cohorts = normalized
             self._next_truss_entity_id = len(normalized) + 1
             if "truss_count" not in overrides:
@@ -424,8 +645,8 @@ class TomatoModel:
             growth_respiration_g=0.0,
             growth_g=0.0,
             maintenance_g=0.0,
-            fruit_harvest_g=self.W_fr_harvested,
-            leaf_harvest_g=0.0,
+            fruit_harvest_g=self.last_fruit_harvest_g,
+            leaf_harvest_g=self.last_leaf_harvest_g,
         )
 
     def to_floor_from_plant(self, x_per_plant: float) -> float:
@@ -577,24 +798,73 @@ class TomatoModel:
         transpiration_amount_g_m2 = transp_rate_evap_g_s_m2 * self.dt_seconds
         cond_rate_g_s_m2 = (self.LE_cond / self.lambda_v * 1000.0) if self.lambda_v > 0 else 0.0
         cond_amount_g_m2 = cond_rate_g_s_m2 * self.dt_seconds
-        truss_payload = [
-            {
-                "entity_id": str(cohort.get("entity_id", f"truss_{index + 1:04d}")),
-                "truss_id": index + 1,
-                "fruit_position": float(max(1, int(round(float(cohort.get('n_fruits', self.n_f or 1)))) // 2)),
-                "age_class": float(min(20, max(1, math.ceil(max(0.0, float(cohort.get("tdvs", 0.0))) * 20.0)))),
-                "stage_index": float(min(5, max(1, math.ceil(max(0.0, float(cohort.get("tdvs", 0.0))) * 5.0)))),
-                "tdvs": float(max(0.0, float(cohort.get("tdvs", 0.0)))),
-                "fds": float(max(0.0, float(cohort.get("tdvs", 0.0)))),
-                "fruit_dm_g_m2": float(max(0.0, float(cohort.get("w_fr_cohort", 0.0)))),
-                "fruit_count": float(max(0.0, float(cohort.get("n_fruits", self.n_f)))),
-                "mult": float(max(0.0, float(cohort.get("mult", self.shoots_per_m2)))),
-                "onplant_flag": bool(cohort.get("active", True)),
-                "harvested_flag": False,
-                "potential_weight_proxy_g_m2": float(max(0.0, float(cohort.get("w_fr_cohort", 0.0)))),
-            }
-            for index, cohort in enumerate(self.truss_cohorts)
-        ]
+        truss_payload: list[dict[str, object]] = []
+        for index, cohort in enumerate(self.truss_cohorts):
+            self._ensure_cohort_runtime_fields(cohort, current_time=current_time)
+            tdvs = max(0.0, _finite_float(cohort.get("tdvs"), default=0.0))
+            age_class_native = int(
+                max(
+                    1,
+                    round(
+                        _finite_float(
+                            cohort.get("age_class_native"),
+                            default=float(self._derived_age_class(tdvs)),
+                        )
+                    ),
+                )
+            )
+            stage_index_native = int(
+                max(
+                    1,
+                    round(
+                        _finite_float(
+                            cohort.get("stage_index_native"),
+                            default=float(self._derived_stage_index(tdvs)),
+                        )
+                    ),
+                )
+            )
+            truss_payload.append(
+                {
+                    "entity_id": str(cohort.get("entity_id", f"truss_{index + 1:04d}")),
+                    "truss_id": index + 1,
+                    "fruit_position": float(max(1, int(round(float(cohort.get("n_fruits", self.n_f or 1)))) // 2)),
+                    "age_class": float(age_class_native),
+                    "stage_index": float(stage_index_native),
+                    "age_class_native": float(age_class_native),
+                    "stage_index_native": float(stage_index_native),
+                    "tdvs": tdvs,
+                    "fds": max(0.0, _finite_float(cohort.get("fds"), default=tdvs)),
+                    "fruit_dm_g_m2": float(max(0.0, float(cohort.get("w_fr_cohort", 0.0)))),
+                    "fruit_count": float(max(0.0, float(cohort.get("n_fruits", self.n_f)))),
+                    "mult": float(max(0.0, float(cohort.get("mult", self.shoots_per_m2)))),
+                    "sink_active_flag": bool(cohort.get("sink_active_flag", cohort.get("active", True))),
+                    "mature_flag": bool(cohort.get("mature_flag", False)),
+                    "harvest_ready_flag": bool(cohort.get("harvest_ready_flag", False)),
+                    "onplant_flag": bool(cohort.get("onplant_flag", True)),
+                    "harvested_flag": bool(cohort.get("harvested_flag", False)),
+                    "anthesis_at": cohort.get("anthesis_at"),
+                    "matured_at": cohort.get("matured_at"),
+                    "days_since_anthesis": max(_finite_float(cohort.get("days_since_anthesis"), default=0.0), 0.0),
+                    "days_since_maturity": max(_finite_float(cohort.get("days_since_maturity"), default=0.0), 0.0),
+                    "mature_pool_flag": bool(cohort.get("mature_pool_flag", False)),
+                    "mature_pool_residence_days": max(
+                        _finite_float(cohort.get("mature_pool_residence_days"), default=0.0),
+                        0.0,
+                    ),
+                    "final_stage_flag": bool(cohort.get("final_stage_flag", False)),
+                    "final_stage_residence_days": max(
+                        _finite_float(cohort.get("final_stage_residence_days"), default=0.0),
+                        0.0,
+                    ),
+                    "explicit_outflow_capacity_g_m2_d": max(
+                        _finite_float(cohort.get("explicit_outflow_capacity_g_m2_d"), default=0.0),
+                        0.0,
+                    ),
+                    "proxy_state_flag": bool(cohort.get("proxy_state_flag", False)),
+                    "potential_weight_proxy_g_m2": float(max(0.0, float(cohort.get("w_fr_cohort", 0.0)))),
+                }
+            )
         mean_truss_tdvs = (
             float(np.mean([float(cohort.get("tdvs", 0.0)) for cohort in self.truss_cohorts]))
             if self.truss_cohorts
@@ -793,8 +1063,11 @@ class TomatoModel:
         dt = float(dt_seconds)
         if dt <= 0:
             raise ValueError(f"dt_seconds must be > 0, got {dt_seconds!r}.")
+        dt_days = dt / 86400.0
         self.last_fruit_harvest_g = 0.0
         self.last_leaf_harvest_g = 0.0
+        for cohort in self.truss_cohorts:
+            self._ensure_cohort_runtime_fields(cohort, current_time=current_time)
 
         sim_date = current_time.date()
         if sim_date > self.current_date:
@@ -843,11 +1116,15 @@ class TomatoModel:
 
         t_air_c = self.T_a - 273.15
         for cohort in self.truss_cohorts:
-            if not cohort.get("active", True):
+            self._ensure_cohort_runtime_fields(cohort, current_time=current_time)
+            if not bool(cohort.get("sink_active_flag", cohort.get("active", True))):
                 continue
             cohort["tdvs"] = self._advance_tdvs_with_fdvr(float(cohort.get("tdvs", 0.0)), t_air_c, dt)
             if float(cohort["tdvs"]) >= self.tdvs_max:
                 cohort["active"] = False
+                cohort["sink_active_flag"] = False
+                self._mark_cohort_mature_onplant(cohort, current_time)
+        self._update_cohort_runtime_state(current_time, dt_days)
 
         sinks, per_truss_sinks = self._compute_sink_state()
         active_trusses = self._count_active_trusses()
@@ -950,8 +1227,8 @@ class TomatoModel:
             growth_respiration_g=max(0.0, dW_total_step / max(c_f, 1e-9) - dW_total_step),
             growth_g=max(0.0, dW_total_step),
             maintenance_g=max(0.0, rm_eff_g_s * dt),
-            fruit_harvest_g=self.W_fr_harvested,
-            leaf_harvest_g=0.0,
+            fruit_harvest_g=self.last_fruit_harvest_g,
+            leaf_harvest_g=self.last_leaf_harvest_g,
         )
 
     def calculate_current_lai(self) -> float:
@@ -1236,14 +1513,28 @@ class TomatoModel:
             else:
                 nfr = int(self.n_f)
             self.truss_cohorts.append(
-                {
-                    "entity_id": f"truss_{self._next_truss_entity_id:04d}",
-                    "tdvs": 0.0,
-                    "n_fruits": nfr,
-                    "w_fr_cohort": 0.0,
-                    "active": True,
-                    "mult": self.shoots_per_m2,
-                }
+                self._ensure_cohort_runtime_fields(
+                    {
+                        "entity_id": f"truss_{self._next_truss_entity_id:04d}",
+                        "tdvs": 0.0,
+                        "fds": 0.0,
+                        "n_fruits": nfr,
+                        "w_fr_cohort": 0.0,
+                        "active": True,
+                        "mult": self.shoots_per_m2,
+                        "onplant_flag": True,
+                        "harvested_flag": False,
+                        "sink_active_flag": True,
+                        "mature_flag": False,
+                        "harvest_ready_flag": False,
+                        "anthesis_at": self._cohort_timestamp_iso(datetime.combine(sim_date, datetime.min.time())),
+                        "matured_at": None,
+                        "days_since_anthesis": 0.0,
+                        "days_since_maturity": 0.0,
+                        "proxy_state_flag": False,
+                    },
+                    current_time=datetime.combine(sim_date, datetime.min.time()),
+                )
             )
             self._next_truss_entity_id += 1
 
@@ -1506,13 +1797,19 @@ class TomatoModel:
         matured_indices: list[int] = []
         harvested_now = 0.0
         for idx, cohort in enumerate(self.truss_cohorts):
+            self._ensure_cohort_runtime_fields(cohort, current_time=datetime.combine(self.current_date, datetime.min.time()))
             tdvs = float(cohort.get("tdvs", 0.0))
-            is_active = bool(cohort.get("active", True))
+            is_active = bool(cohort.get("sink_active_flag", cohort.get("active", True)))
             truss_dm = max(0.0, float(cohort.get("w_fr_cohort", 0.0)))
             if truss_dm >= self.harvest_truss_dm_g:
                 cohort["active"] = False
+                cohort["sink_active_flag"] = False
                 is_active = False
             if (not is_active) or tdvs >= self.tdvs_max:
+                self._mark_cohort_mature_onplant(cohort, datetime.combine(self.current_date, datetime.min.time()))
+                cohort["onplant_flag"] = False
+                cohort["harvested_flag"] = True
+                cohort["harvest_ready_flag"] = True
                 harvested_now += truss_dm
                 matured_indices.append(idx)
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_family_eval.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_family_eval.py
@@ -55,6 +55,16 @@ def _as_dict(raw: object) -> dict[str, Any]:
 
 def _daily_env_summary(day_rows: list[dict[str, object]], *, ec: float = 0.3) -> dict[str, float]:
     frame = pd.DataFrame(day_rows)
+    explicit_outflow = (
+        float(pd.to_numeric(frame.get("MCFruitHar_g_m2_d"), errors="coerce").fillna(0.0).max())
+        if "MCFruitHar_g_m2_d" in frame
+        else 0.0
+    )
+    dry_matter_outflow = (
+        float(pd.to_numeric(frame.get("DMHar_g_m2_d"), errors="coerce").fillna(0.0).max())
+        if "DMHar_g_m2_d" in frame
+        else explicit_outflow
+    )
     summary = {
         "T_air_C": float(pd.to_numeric(frame.get("T_air_C"), errors="coerce").dropna().mean()) if "T_air_C" in frame else 23.0,
         "TF": float(pd.to_numeric(frame.get("T_air_C"), errors="coerce").dropna().mean()) if "T_air_C" in frame else 23.0,
@@ -65,8 +75,9 @@ def _daily_env_summary(day_rows: list[dict[str, object]], *, ec: float = 0.3) ->
         )
         if "fruit_harvest_g_m2_step" in frame
         else 0.0,
-        "MCFruitHar_g_m2_d": 0.0,
-        "DMHar_g_m2_d": 0.0,
+        "MCFruitHar_g_m2_d": max(explicit_outflow, 0.0),
+        "DMHar_g_m2_d": max(dry_matter_outflow, 0.0),
+        "proxy_outflow_missing_flag": bool(explicit_outflow <= 0.0 and dry_matter_outflow <= 0.0),
     }
     return summary
 
@@ -78,11 +89,33 @@ def _fruit_entities_to_model_cohorts(state: pd.DataFrame, *, shoots_per_m2: floa
     frame["fruit_dm_g_m2"] = pd.to_numeric(frame["fruit_dm_g_m2"], errors="coerce").fillna(0.0)
     frame["fruit_count"] = pd.to_numeric(frame["fruit_count"], errors="coerce").fillna(0.0)
     frame["tdvs"] = pd.to_numeric(frame["tdvs"], errors="coerce").fillna(0.0)
+    frame["fds"] = pd.to_numeric(frame.get("fds"), errors="coerce").fillna(frame["tdvs"])
     if "mult" in frame.columns:
         frame["mult"] = pd.to_numeric(frame["mult"], errors="coerce").fillna(float(shoots_per_m2))
     else:
         frame["mult"] = float(shoots_per_m2)
+    frame["days_since_anthesis"] = pd.to_numeric(frame.get("days_since_anthesis"), errors="coerce").fillna(0.0)
+    frame["days_since_maturity"] = pd.to_numeric(frame.get("days_since_maturity"), errors="coerce").fillna(0.0)
+    frame["mature_pool_residence_days"] = pd.to_numeric(
+        frame.get("mature_pool_residence_days"),
+        errors="coerce",
+    ).fillna(frame["days_since_maturity"])
+    frame["final_stage_residence_days"] = pd.to_numeric(
+        frame.get("final_stage_residence_days"),
+        errors="coerce",
+    ).fillna(frame["days_since_maturity"])
+    frame["explicit_outflow_capacity_g_m2_d"] = pd.to_numeric(
+        frame.get("explicit_outflow_capacity_g_m2_d"),
+        errors="coerce",
+    ).fillna(0.0)
     frame["onplant_flag"] = frame["onplant_flag"].fillna(True).astype(bool)
+    frame["harvested_flag"] = frame.get("harvested_flag", False).fillna(False).astype(bool)
+    frame["sink_active_flag"] = frame.get("sink_active_flag", True).fillna(True).astype(bool)
+    frame["mature_flag"] = frame.get("mature_flag", False).fillna(False).astype(bool)
+    frame["harvest_ready_flag"] = frame.get("harvest_ready_flag", False).fillna(False).astype(bool)
+    frame["mature_pool_flag"] = frame.get("mature_pool_flag", False).fillna(False).astype(bool)
+    frame["final_stage_flag"] = frame.get("final_stage_flag", False).fillna(False).astype(bool)
+    frame["proxy_state_flag"] = frame.get("proxy_state_flag", False).fillna(False).astype(bool)
     frame = frame.loc[frame["fruit_dm_g_m2"] > 1e-12].copy()
     cohorts: list[dict[str, object]] = []
     for row in frame.itertuples(index=False):
@@ -92,10 +125,28 @@ def _fruit_entities_to_model_cohorts(state: pd.DataFrame, *, shoots_per_m2: floa
             {
                 "entity_id": str(row.entity_id),
                 "tdvs": float(getattr(row, "tdvs", 0.0)),
+                "fds": float(getattr(row, "fds", 0.0)),
                 "n_fruits": int(max(round(float(getattr(row, "fruit_count", 0.0))), 0)),
                 "w_fr_cohort": float(getattr(row, "fruit_dm_g_m2", 0.0)),
-                "active": True,
+                "active": bool(getattr(row, "sink_active_flag", True)),
                 "mult": float(getattr(row, "mult", shoots_per_m2)),
+                "sink_active_flag": bool(getattr(row, "sink_active_flag", True)),
+                "mature_flag": bool(getattr(row, "mature_flag", False)),
+                "harvest_ready_flag": bool(getattr(row, "harvest_ready_flag", False)),
+                "onplant_flag": bool(getattr(row, "onplant_flag", True)),
+                "harvested_flag": bool(getattr(row, "harvested_flag", False)),
+                "anthesis_at": getattr(row, "anthesis_at", None),
+                "matured_at": getattr(row, "matured_at", None),
+                "days_since_anthesis": float(getattr(row, "days_since_anthesis", 0.0)),
+                "days_since_maturity": float(getattr(row, "days_since_maturity", 0.0)),
+                "age_class_native": int(max(round(float(getattr(row, "age_class", 1.0))), 1)),
+                "stage_index_native": int(max(round(float(getattr(row, "stage_index", 1.0))), 1)),
+                "mature_pool_flag": bool(getattr(row, "mature_pool_flag", False)),
+                "mature_pool_residence_days": float(getattr(row, "mature_pool_residence_days", 0.0)),
+                "final_stage_flag": bool(getattr(row, "final_stage_flag", False)),
+                "final_stage_residence_days": float(getattr(row, "final_stage_residence_days", 0.0)),
+                "explicit_outflow_capacity_g_m2_d": float(getattr(row, "explicit_outflow_capacity_g_m2_d", 0.0)),
+                "proxy_state_flag": bool(getattr(row, "proxy_state_flag", False)),
             }
         )
     return cohorts
@@ -118,7 +169,12 @@ def _apply_harvest_update_to_model(
     )
     model.truss_count = len(model.truss_cohorts)
     model.W_fr = float(sum(max(float(cohort.get("w_fr_cohort", 0.0)), 0.0) for cohort in model.truss_cohorts))
-    model.W_lv = max(float(getattr(model, "W_lv", 0.0)) - float(update.leaf_harvest_flux_g_m2_d), 0.0)
+    if not update.updated_state.leaf_entities.empty:
+        model.W_lv = float(
+            pd.to_numeric(update.updated_state.leaf_entities["leaf_dm_g_m2"], errors="coerce").fillna(0.0).sum()
+        )
+    else:
+        model.W_lv = max(float(getattr(model, "W_lv", 0.0)) - float(update.leaf_harvest_flux_g_m2_d), 0.0)
     if getattr(model, "fixed_lai", None) is None:
         model.LAI = max(float(update.updated_state.lai or 0.0), 0.0)
     model.vegetative_dw = float(model.W_lv + model.W_st + model.W_rt)
@@ -198,7 +254,17 @@ def run_harvest_family_simulation(
             prior_row=previous_daily_row,
             plants_per_m2=plants_per_m2,
             floor_area_basis=True,
+            allow_bulk_proxy=(fruit_harvest_family == "tomsim_truss"),
         )
+        fruit_frame = state.fruit_entities.copy()
+        fruit_mass = pd.to_numeric(fruit_frame.get("fruit_dm_g_m2"), errors="coerce").fillna(0.0)
+        onplant_mask = fruit_frame.get("onplant_flag", pd.Series(dtype=bool)).fillna(False).astype(bool)
+        mature_mask = fruit_frame.get("mature_flag", pd.Series(dtype=bool)).fillna(False).astype(bool)
+        ready_mask = fruit_frame.get("harvest_ready_flag", pd.Series(dtype=bool)).fillna(False).astype(bool)
+        pre_onplant_total = float(fruit_mass.loc[onplant_mask].sum()) if not fruit_frame.empty else 0.0
+        pre_total_system = pre_onplant_total + float(state.harvested_fruit_cumulative_g_m2)
+        mature_onplant_mass = float(fruit_mass.loc[mature_mask & onplant_mask].sum()) if not fruit_frame.empty else 0.0
+        eligible_harvest_mass = float(fruit_mass.loc[ready_mask & onplant_mask].sum()) if not fruit_frame.empty else 0.0
         env = _daily_env_summary(day_rows)
         result = run_harvest_step(
             fruit_policy=fruit_policy,
@@ -208,12 +274,40 @@ def run_harvest_family_simulation(
             dt_days=float(state.dt_days),
         )
         _apply_harvest_update_to_model(adapter=adapter, update=result.final_update)
+        model = adapter.model
+        if model is None:
+            raise RuntimeError("TomatoLegacyAdapter model is not initialized.")
+        post_total_system = float(getattr(model, "W_fr", 0.0) + getattr(model, "W_fr_harvested", 0.0))
+        post_writeback_dropped_mass = max(pre_total_system - post_total_system, 0.0)
+        mature_after = result.final_update.updated_state.fruit_entities.copy()
+        mature_after_mask = mature_after.get("mature_flag", pd.Series(dtype=bool)).fillna(False).astype(bool)
+        onplant_after_mask = mature_after.get("onplant_flag", pd.Series(dtype=bool)).fillna(False).astype(bool)
+        unharvested_mature_streak_days = (
+            float(
+                pd.to_numeric(
+                    mature_after.loc[mature_after_mask & onplant_after_mask, "days_since_maturity"],
+                    errors="coerce",
+                ).fillna(0.0).max()
+            )
+            if not mature_after.empty and (mature_after_mask & onplant_after_mask).any()
+            else 0.0
+        )
+        result.final_update.diagnostics["pre_writeback_total_system_fruit_g_m2"] = pre_total_system
+        result.final_update.diagnostics["post_writeback_total_system_fruit_g_m2"] = post_total_system
+        result.final_update.diagnostics["post_writeback_dropped_nonharvested_mass_g_m2"] = post_writeback_dropped_mass
+        result.final_update.diagnostics["eligible_harvest_mass_g_m2"] = eligible_harvest_mass
+        result.final_update.diagnostics["mature_onplant_mass_g_m2"] = mature_onplant_mass
+        result.final_update.diagnostics["harvested_flux_g_m2_d"] = float(result.final_update.fruit_harvest_flux_g_m2_d)
+        result.final_update.diagnostics["unharvested_mature_streak_days"] = unharvested_mature_streak_days
         rebuilt = _rebuild_daily_row(adapter, pd.Timestamp(current_row["datetime"]), current_row)
         rebuilt["fruit_harvest_family"] = fruit_harvest_family
         rebuilt["leaf_harvest_family"] = leaf_harvest_family
         rebuilt["fdmc_mode"] = fdmc_mode
         rows[-1] = rebuilt
-        previous_daily_row = rebuilt
+        previous_daily_row = {
+            **rebuilt,
+            "__harvest_state_fruit_entities": result.final_update.updated_state.fruit_entities.copy(),
+        }
         mass_balance_rows.append(
             {
                 "date": pd.Timestamp(rebuilt["datetime"]).normalize(),
@@ -224,6 +318,30 @@ def run_harvest_family_simulation(
                 ),
                 "fruit_harvest_flux_g_m2_d": float(result.final_update.fruit_harvest_flux_g_m2_d),
                 "leaf_harvest_flux_g_m2_d": float(result.final_update.leaf_harvest_flux_g_m2_d),
+                "pre_writeback_total_system_fruit_g_m2": float(
+                    result.final_update.diagnostics.get("pre_writeback_total_system_fruit_g_m2", 0.0)
+                ),
+                "post_writeback_total_system_fruit_g_m2": float(
+                    result.final_update.diagnostics.get("post_writeback_total_system_fruit_g_m2", 0.0)
+                ),
+                "post_writeback_dropped_nonharvested_mass_g_m2": float(
+                    result.final_update.diagnostics.get("post_writeback_dropped_nonharvested_mass_g_m2", 0.0)
+                ),
+                "eligible_harvest_mass_g_m2": float(result.final_update.diagnostics.get("eligible_harvest_mass_g_m2", 0.0)),
+                "mature_onplant_mass_g_m2": float(result.final_update.diagnostics.get("mature_onplant_mass_g_m2", 0.0)),
+                "harvested_flux_g_m2_d": float(result.final_update.diagnostics.get("harvested_flux_g_m2_d", 0.0)),
+                "unharvested_mature_streak_days": float(
+                    result.final_update.diagnostics.get("unharvested_mature_streak_days", 0.0)
+                ),
+                "partial_outflow_flag": bool(result.final_update.diagnostics.get("partial_fruit_outflow_flag", False)),
+                "offplant_with_positive_mass_flag": bool(
+                    result.final_update.diagnostics.get("offplant_with_positive_mass_flag", False)
+                ),
+                "family_state_mode": str(result.final_update.updated_state.diagnostics.get("family_state_mode", "")),
+                "proxy_mode_used": bool(
+                    result.final_update.updated_state.diagnostics.get("synthetic_fruit_state_flag", False)
+                    or result.final_update.diagnostics.get("proxy_mode_used", False)
+                ),
             }
         )
         if getattr(result.fruit_update, "diagnostics", None):
@@ -252,7 +370,7 @@ def run_harvest_family_simulation(
     harvest_mass_balance_df = pd.DataFrame(mass_balance_rows)
     model_daily_df = model_floor_area_cumulative_total_fruit(run_df)
     indexed = model_daily_df.set_index("date")
-    candidate_series = observed_df["date"].map(indexed["model_cumulative_total_fruit_dry_weight_floor_area"])
+    candidate_series = observed_df["date"].map(indexed["model_cumulative_harvested_fruit_dry_weight_floor_area"])
     candidate_daily_increment = observed_df["date"].map(indexed["model_daily_increment_floor_area"])
     bundle = compute_validation_bundle(
         observed_df.copy(),
@@ -295,6 +413,35 @@ def run_harvest_family_simulation(
         )
         if not model_daily_df.empty
         else math.nan,
+        "proxy_mode_used": bool(pd.Series(harvest_mass_balance_df.get("proxy_mode_used")).fillna(False).astype(bool).any())
+        if not harvest_mass_balance_df.empty
+        else False,
+        "family_state_mode": str(harvest_mass_balance_df.get("family_state_mode", pd.Series(dtype=str)).dropna().iloc[-1])
+        if not harvest_mass_balance_df.empty and harvest_mass_balance_df.get("family_state_mode") is not None and not harvest_mass_balance_df["family_state_mode"].dropna().empty
+        else "",
+        "partial_outflow_flag": bool(
+            pd.Series(harvest_mass_balance_df.get("partial_outflow_flag")).fillna(False).astype(bool).any()
+        )
+        if not harvest_mass_balance_df.empty
+        else False,
+        "offplant_with_positive_mass_flag": bool(
+            pd.Series(harvest_mass_balance_df.get("offplant_with_positive_mass_flag")).fillna(False).astype(bool).any()
+        )
+        if not harvest_mass_balance_df.empty
+        else False,
+        "post_writeback_dropped_nonharvested_mass_g_m2": float(
+            pd.to_numeric(
+                harvest_mass_balance_df.get("post_writeback_dropped_nonharvested_mass_g_m2"),
+                errors="coerce",
+            ).fillna(0.0).max()
+        )
+        if not harvest_mass_balance_df.empty
+        else 0.0,
+        "unharvested_mature_streak_days": float(
+            pd.to_numeric(harvest_mass_balance_df.get("unharvested_mature_streak_days"), errors="coerce").fillna(0.0).max()
+        )
+        if not harvest_mass_balance_df.empty
+        else 0.0,
     }
     return HarvestFamilyRunResult(
         run_df=run_df,
@@ -308,11 +455,14 @@ def run_harvest_family_simulation(
 
 
 def build_harvest_overlay_frame(validation_df: pd.DataFrame, *, source_label: str = "model") -> pd.DataFrame:
+    harvested_column = f"{source_label}_cumulative_harvested_fruit_dry_weight_floor_area"
+    if harvested_column not in validation_df.columns:
+        harvested_column = f"{source_label}_cumulative_total_fruit_dry_weight_floor_area"
     return pd.DataFrame(
         {
             "datetime": pd.to_datetime(validation_df["date"], errors="coerce"),
             "cumulative_total_fruit_floor_area": pd.to_numeric(
-                validation_df[f"{source_label}_cumulative_total_fruit_dry_weight_floor_area"],
+                validation_df[harvested_column],
                 errors="coerce",
             ),
             "offset_adjusted_cumulative_total_fruit_floor_area": pd.to_numeric(
@@ -343,7 +493,7 @@ def build_harvest_mass_balance_overlay_frame(harvest_mass_balance_df: pd.DataFra
             "datetime": pd.to_datetime(frame["date"], errors="coerce"),
             "cumulative_total_fruit_floor_area": pd.to_numeric(frame["harvest_mass_balance_error"], errors="coerce"),
             "offset_adjusted_cumulative_total_fruit_floor_area": pd.to_numeric(
-                frame["latent_fruit_residual_end"],
+                frame.get("post_writeback_dropped_nonharvested_mass_g_m2", frame["latent_fruit_residual_end"]),
                 errors="coerce",
             ),
             "daily_increment_floor_area": pd.to_numeric(frame["leaf_harvest_mass_balance_error"], errors="coerce"),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py
@@ -20,15 +20,17 @@ def model_floor_area_cumulative_total_fruit(model_df: pd.DataFrame) -> pd.DataFr
     daily = daily_last(model_df)
     fruit = pd.to_numeric(daily.get("fruit_dry_weight_g_m2"), errors="coerce").fillna(0.0)
     harvested = pd.to_numeric(daily.get("harvested_fruit_g_m2"), errors="coerce").fillna(0.0)
-    total_latent = fruit + harvested
+    total_system = fruit + harvested
     out = pd.DataFrame(
         {
             "date": daily["date"],
             "model_onplant_fruit_dry_weight_floor_area": fruit,
             "model_harvested_fruit_floor_area": harvested,
             "model_cumulative_harvested_fruit_dry_weight_floor_area": harvested,
+            "model_observed_target_proxy_floor_area": harvested,
+            "model_total_system_fruit_dry_weight_floor_area": total_system,
             "model_cumulative_total_fruit_dry_weight_floor_area": harvested,
-            "model_total_latent_fruit_dry_weight_floor_area": total_latent,
+            "model_total_latent_fruit_dry_weight_floor_area": total_system,
         }
     )
     out["model_daily_increment_floor_area"] = _daily_increment_from_cumulative(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_promotion_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_promotion_gate.py
@@ -64,7 +64,7 @@ def _window_metrics(validation_df: pd.DataFrame, *, start: pd.Timestamp, end: pd
                 "measured_daily_increment_floor_area",
             ]
         ].copy(),
-        candidate_series=window["model_cumulative_total_fruit_dry_weight_floor_area"],
+        candidate_series=window["model_cumulative_harvested_fruit_dry_weight_floor_area"],
         candidate_daily_increment_series=window["model_daily_increment_floor_area"],
         candidate_label="model",
         unit_declared_in_observation_file="g/m^2",
@@ -334,6 +334,20 @@ def run_harvest_promotion_gate(
                         "harvest_mass_balance_error": result.metrics["harvest_mass_balance_error"],
                         "latent_fruit_residual_end": result.metrics["latent_fruit_residual_end"],
                         "leaf_harvest_mass_balance_error": result.metrics["leaf_harvest_mass_balance_error"],
+                        "post_writeback_dropped_nonharvested_mass_g_m2": result.metrics.get(
+                            "post_writeback_dropped_nonharvested_mass_g_m2",
+                            0.0,
+                        ),
+                        "offplant_with_positive_mass_flag": bool(
+                            result.metrics.get("offplant_with_positive_mass_flag", False)
+                        ),
+                        "all_zero_harvest_series": bool(
+                            pd.to_numeric(
+                                result.model_daily_df["model_cumulative_harvested_fruit_dry_weight_floor_area"],
+                                errors="coerce",
+                            ).fillna(0.0).max()
+                            <= 1e-12
+                        ),
                         "wet_condition_root_excess_penalty": wet_penalty,
                         "score": score,
                         "selected_params_json": json.dumps(params, sort_keys=True),
@@ -355,6 +369,9 @@ def run_harvest_promotion_gate(
             max_canopy_collapse_days=("canopy_collapse_days", "max"),
             max_harvest_mass_balance_error=("harvest_mass_balance_error", "max"),
             max_leaf_harvest_mass_balance_error=("leaf_harvest_mass_balance_error", "max"),
+            max_post_writeback_dropped_nonharvested_mass_g_m2=("post_writeback_dropped_nonharvested_mass_g_m2", "max"),
+            any_offplant_with_positive_mass_flag=("offplant_with_positive_mass_flag", "max"),
+            any_all_zero_harvest_series=("all_zero_harvest_series", "max"),
             max_wet_condition_root_excess_penalty=("wet_condition_root_excess_penalty", "max"),
         )
         .reset_index(drop=True)
@@ -376,6 +393,7 @@ def run_harvest_promotion_gate(
         "winner_stability_score_min": float(gate_cfg.get("winner_stability_score_min", 0.5)),
         "material_cumulative_rmse_margin": float(gate_cfg.get("material_cumulative_rmse_margin", 0.5)),
         "material_daily_rmse_margin": float(gate_cfg.get("material_daily_rmse_margin", 0.25)),
+        "post_writeback_dropped_nonharvested_mass_g_m2_max": 0.0,
     }
 
     def _passes(candidate: pd.Series) -> bool:
@@ -385,6 +403,10 @@ def run_harvest_promotion_gate(
             and float(candidate["max_fruit_anchor_error_vs_legacy"]) <= guardrails["fruit_anchor_error_vs_legacy_max"]
             and float(candidate["max_canopy_collapse_days"]) <= guardrails["canopy_collapse_days_max"]
             and float(candidate["max_harvest_mass_balance_error"]) <= guardrails["harvest_mass_balance_error_max"]
+            and float(candidate["max_post_writeback_dropped_nonharvested_mass_g_m2"])
+            <= guardrails["post_writeback_dropped_nonharvested_mass_g_m2_max"]
+            and (not bool(candidate["any_offplant_with_positive_mass_flag"]))
+            and (not bool(candidate["any_all_zero_harvest_series"]))
             and float(candidate["max_wet_condition_root_excess_penalty"]) <= guardrails["wet_condition_root_excess_penalty_max"]
             and float(candidate["winner_stability_score"]) >= guardrails["winner_stability_score_min"]
         )

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/observation_model.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/observation_model.py
@@ -101,7 +101,7 @@ def merge_validation_series(
     observed_df: pd.DataFrame,
     model_daily_df: pd.DataFrame,
     *,
-    model_value_column: str = "model_cumulative_total_fruit_dry_weight_floor_area",
+    model_value_column: str = "model_cumulative_harvested_fruit_dry_weight_floor_area",
     source_label: str,
 ) -> pd.DataFrame:
     merged = observed_df.merge(
@@ -109,12 +109,11 @@ def merge_validation_series(
         on="date",
         how="left",
     )
-    merged = merged.rename(
-        columns={
-            model_value_column: f"{source_label}_cumulative_total_fruit_dry_weight_floor_area",
-            "model_daily_increment_floor_area": f"{source_label}_daily_increment_floor_area",
-        }
-    )
+    harvested_column = f"{source_label}_cumulative_harvested_fruit_dry_weight_floor_area"
+    merged = merged.rename(columns={model_value_column: harvested_column})
+    merged[f"{source_label}_cumulative_total_fruit_dry_weight_floor_area"] = merged[harvested_column]
+    merged[f"{source_label}_daily_increment_floor_area"] = merged["model_daily_increment_floor_area"]
+    merged = merged.drop(columns=["model_daily_increment_floor_area"])
     return merged
 
 
@@ -127,14 +126,16 @@ def compute_validation_bundle(
     unit_declared_in_observation_file: str,
 ) -> ValidationSeriesBundle:
     merged = observed_df.copy()
+    harvested_column = f"{candidate_label}_cumulative_harvested_fruit_dry_weight_floor_area"
     cumulative_column = f"{candidate_label}_cumulative_total_fruit_dry_weight_floor_area"
-    merged[cumulative_column] = pd.to_numeric(candidate_series, errors="coerce")
+    merged[harvested_column] = pd.to_numeric(candidate_series, errors="coerce")
+    merged[cumulative_column] = merged[harvested_column]
     merged["measured_offset_adjusted"] = _offset_adjusted(
         merged["measured_cumulative_total_fruit_dry_weight_floor_area"]
     )
-    merged[f"{candidate_label}_offset_adjusted"] = _offset_adjusted(merged[cumulative_column])
+    merged[f"{candidate_label}_offset_adjusted"] = _offset_adjusted(merged[harvested_column])
     if candidate_daily_increment_series is None:
-        merged[f"{candidate_label}_daily_increment_floor_area"] = pd.to_numeric(merged[cumulative_column], errors="coerce").diff()
+        merged[f"{candidate_label}_daily_increment_floor_area"] = pd.to_numeric(merged[harvested_column], errors="coerce").diff()
     else:
         merged[f"{candidate_label}_daily_increment_floor_area"] = pd.to_numeric(
             candidate_daily_increment_series,
@@ -143,7 +144,7 @@ def compute_validation_bundle(
 
     raw_metrics = _series_metrics(
         merged["measured_cumulative_total_fruit_dry_weight_floor_area"],
-        merged[cumulative_column],
+        merged[harvested_column],
     )
     offset_metrics = _series_metrics(
         merged["measured_offset_adjusted"],
@@ -165,7 +166,7 @@ def compute_validation_bundle(
         offset_adjustment_applied = False
     else:
         final_bias = float(
-            pd.to_numeric(merged[cumulative_column], errors="coerce").iloc[-1]
+            pd.to_numeric(merged[harvested_column], errors="coerce").iloc[-1]
             - pd.to_numeric(merged["measured_cumulative_total_fruit_dry_weight_floor_area"], errors="coerce").iloc[-1]
         )
         observed_final = float(
@@ -225,7 +226,10 @@ def resolve_validation_series_columns(
         prefixes.append("model")
 
     for prefix in prefixes:
-        cumulative_column = f"{prefix}_cumulative_total_fruit_dry_weight_floor_area"
+        harvested_column = f"{prefix}_cumulative_harvested_fruit_dry_weight_floor_area"
+        cumulative_column = harvested_column
+        if harvested_column not in validation_df.columns:
+            cumulative_column = f"{prefix}_cumulative_total_fruit_dry_weight_floor_area"
         offset_column = f"{prefix}_offset_adjusted"
         increment_column = f"{prefix}_daily_increment_floor_area"
         if {

--- a/tests/test_tomics_common_structure_harvest_flux_semantics.py
+++ b/tests/test_tomics_common_structure_harvest_flux_semantics.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.partitioning.common_structure import (
+    build_common_structure_snapshot,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.models.tomato_legacy.tomato_model import TomatoModel
+
+
+def test_common_structure_snapshot_uses_step_harvest_flux_arguments() -> None:
+    snapshot = build_common_structure_snapshot(
+        assimilate_buffer_g=1.0,
+        leaf_biomass_g=2.0,
+        stem_root_biomass_g=3.0,
+        fruit_biomass_g=4.0,
+        photosynthesis_g=5.0,
+        growth_respiration_g=0.5,
+        growth_g=1.5,
+        maintenance_g=0.25,
+        fruit_harvest_g=2.5,
+        leaf_harvest_g=0.75,
+    )
+
+    assert math.isclose(snapshot["h1_fruit_harvest_g_m2_step"], 2.5)
+    assert math.isclose(snapshot["h2_leaf_harvest_g_m2_step"], 0.75)
+
+
+def test_tomato_model_common_structure_uses_step_flux_not_cumulative_harvest_pool() -> None:
+    model = TomatoModel(internal_harvest_enabled=False)
+    model.W_fr_harvested = 42.0
+    forcing_row = pd.Series(
+        {
+            "datetime": pd.Timestamp("2024-08-10 00:00:00"),
+            "T_air_C": 24.0,
+            "PAR_umol": 0.0,
+            "CO2_ppm": 400.0,
+            "RH_percent": 70.0,
+            "wind_speed_ms": 0.3,
+            "n_fruits_per_truss": 4,
+        }
+    )
+
+    model.update_inputs_from_row(forcing_row)
+    model.run_timestep_calculations(3600.0, pd.Timestamp(forcing_row["datetime"]).to_pydatetime())
+
+    assert math.isclose(model.W_fr_harvested, 42.0)
+    assert math.isclose(model.common_structure_snapshot["h1_fruit_harvest_g_m2_step"], 0.0)

--- a/tests/test_tomics_harvest_family_state_axes.py
+++ b/tests/test_tomics_harvest_family_state_axes.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.contracts import HarvestState
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_dekoning import (
+    DeKoningFdsHarvestPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_tomgro import (
+    TomgroAgeclassHarvestPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_tomsim import (
+    TomsimTrussHarvestPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_vanthoor import (
+    VanthoorBoxcarHarvestPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.state_normalizer import (
+    normalize_harvest_state,
+)
+
+
+def _current_row_from_payload(payload: list[dict[str, object]], *, semantics: str = "native_family") -> pd.Series:
+    return pd.Series(
+        {
+            "datetime": pd.Timestamp("2024-08-10"),
+            "fruit_dry_weight_g_m2": sum(float(row.get("fruit_dm_g_m2", 0.0)) for row in payload),
+            "leaf_dry_weight_g_m2": 1.0,
+            "LAI": 2.0,
+            "truss_cohorts_json": json.dumps(payload),
+            "harvest_family_semantics": semantics,
+            "mean_truss_tdvs": 0.7,
+            "n_fruits_per_truss": 4,
+            "harvested_fruit_g_m2": 0.0,
+        }
+    )
+
+
+def _make_state(row: dict[str, object]) -> HarvestState:
+    return HarvestState(
+        datetime=pd.Timestamp("2024-08-10"),
+        dt_days=1.0,
+        floor_area_basis=True,
+        plants_per_m2=1.836091,
+        lai=2.0,
+        cbuf_g_m2=0.0,
+        fruit_entities=pd.DataFrame([row]),
+        leaf_entities=pd.DataFrame(),
+        stem_root_state={"stem_dry_weight_g_m2": 1.0, "root_dry_weight_g_m2": 1.0},
+        harvested_fruit_cumulative_g_m2=0.0,
+        harvested_leaf_cumulative_g_m2=0.0,
+        diagnostics={},
+    )
+
+
+def _advance_state_one_day(state: HarvestState) -> HarvestState:
+    fruit_entities = state.fruit_entities.copy()
+    for column in ("days_since_maturity", "mature_pool_residence_days", "final_stage_residence_days"):
+        if column in fruit_entities.columns:
+            fruit_entities[column] = pd.to_numeric(fruit_entities[column], errors="coerce").fillna(0.0) + 1.0
+    return replace(
+        state,
+        datetime=state.datetime + pd.Timedelta(days=1),
+        dt_days=1.0,
+        fruit_entities=fruit_entities,
+    )
+
+
+def test_state_normalizer_preserves_native_runtime_axes_when_payload_is_available() -> None:
+    current = _current_row_from_payload(
+        [
+            {
+                "entity_id": "fruit_1",
+                "tdvs": 0.65,
+                "fds": 1.05,
+                "fruit_dm_g_m2": 5.0,
+                "fruit_count": 2.0,
+                "sink_active_flag": False,
+                "mature_flag": True,
+                "harvest_ready_flag": True,
+                "onplant_flag": True,
+                "harvested_flag": False,
+                "matured_at": "2024-08-08T00:00:00",
+                "days_since_maturity": 2.0,
+                "mature_pool_flag": True,
+                "mature_pool_residence_days": 2.0,
+                "final_stage_flag": True,
+                "final_stage_residence_days": 2.0,
+                "explicit_outflow_capacity_g_m2_d": 0.5,
+                "proxy_state_flag": False,
+            }
+        ],
+        semantics="dekoning_fds",
+    )
+
+    state = normalize_harvest_state(current, allow_bulk_proxy=False)
+    row = state.fruit_entities.iloc[0]
+
+    assert float(row["fds"]) == 1.05
+    assert float(row["tdvs"]) == 0.65
+    assert float(row["days_since_maturity"]) == 2.0
+    assert bool(row["proxy_state_flag"]) is False
+    assert state.diagnostics["family_state_mode"] == "native_payload"
+    assert bool(state.diagnostics["native_family_state_available"]) is True
+    assert bool(state.diagnostics["synthetic_fruit_state_flag"]) is False
+
+
+def test_state_normalizer_marks_shared_tdvs_proxy_when_bulk_fallback_is_used() -> None:
+    current = pd.Series(
+        {
+            "datetime": pd.Timestamp("2024-08-10"),
+            "fruit_dry_weight_g_m2": 4.0,
+            "leaf_dry_weight_g_m2": 1.0,
+            "LAI": 2.0,
+            "harvest_family_semantics": "vanthoor_boxcar",
+            "mean_truss_tdvs": 0.8,
+            "n_fruits_per_truss": 4,
+            "harvested_fruit_g_m2": 0.0,
+        }
+    )
+
+    state = normalize_harvest_state(current, allow_bulk_proxy=False)
+    row = state.fruit_entities.iloc[0]
+
+    assert bool(row["proxy_state_flag"]) is True
+    assert state.diagnostics["family_state_mode"] == "shared_tdvs_proxy"
+    assert bool(state.diagnostics["synthetic_fruit_state_flag"]) is True
+    assert bool(state.diagnostics["native_family_state_available"]) is False
+
+
+def test_harvest_family_runtime_axes_make_daily_series_distinguishable() -> None:
+    tomsim_policy = TomsimTrussHarvestPolicy(tdvs_harvest_threshold=1.0, harvest_delay_days=1.0)
+    dekoning_policy = DeKoningFdsHarvestPolicy(fds_harvest_threshold=1.0, harvest_delay_days=1.0)
+    tomgro_policy = TomgroAgeclassHarvestPolicy(mature_class_index=20, mature_pool_harvest_mode="mature_pool_delta")
+    vanthoor_policy = VanthoorBoxcarHarvestPolicy(n_dev=5, outflow_fraction_per_day=0.5)
+
+    tomsim_state = _make_state(
+        {
+            "entity_id": "tomsim",
+            "tdvs": 1.0,
+            "days_since_maturity": 1.0,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 4.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+    dekoning_state = _make_state(
+        {
+            "entity_id": "dekoning",
+            "fds": 1.0,
+            "days_since_maturity": 0.0,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 1.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+    tomgro_state = _make_state(
+        {
+            "entity_id": "tomgro",
+            "age_class": 20.0,
+            "mature_pool_flag": True,
+            "mature_pool_residence_days": 1.0,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 2.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+    vanthoor_state = _make_state(
+        {
+            "entity_id": "vanthoor",
+            "stage_index": 5.0,
+            "final_stage_flag": True,
+            "final_stage_residence_days": 1.0,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 2.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+
+    series = {}
+    current_state = tomsim_state
+    series["tomsim"] = []
+    for _ in range(2):
+        update = tomsim_policy.step(current_state, env={}, dt_days=1.0)
+        series["tomsim"].append(round(update.fruit_harvest_flux_g_m2_d, 6))
+        current_state = _advance_state_one_day(update.updated_state)
+
+    current_state = dekoning_state
+    series["dekoning"] = []
+    for _ in range(2):
+        update = dekoning_policy.step(current_state, env={"T_air_C": 24.0}, dt_days=1.0)
+        series["dekoning"].append(round(update.fruit_harvest_flux_g_m2_d, 6))
+        current_state = _advance_state_one_day(update.updated_state)
+
+    current_state = tomgro_state
+    series["tomgro"] = []
+    for _ in range(2):
+        update = tomgro_policy.step(current_state, env={"mature_pool_delta_g_m2": 2.0}, dt_days=1.0)
+        series["tomgro"].append(round(update.fruit_harvest_flux_g_m2_d, 6))
+        current_state = _advance_state_one_day(update.updated_state)
+
+    current_state = vanthoor_state
+    series["vanthoor"] = []
+    for _ in range(2):
+        update = vanthoor_policy.step(current_state, env={}, dt_days=1.0)
+        series["vanthoor"].append(round(update.fruit_harvest_flux_g_m2_d, 6))
+        current_state = _advance_state_one_day(update.updated_state)
+
+    unique_series = {tuple(values) for values in series.values()}
+    assert len(unique_series) == 4

--- a/tests/test_tomics_harvest_operator_semantics.py
+++ b/tests/test_tomics_harvest_operator_semantics.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    model_floor_area_cumulative_total_fruit,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.observation_model import (
+    compute_validation_bundle,
+    resolve_validation_series_columns,
+)
+
+
+def test_harvest_operator_exports_explicit_harvested_and_total_system_columns() -> None:
+    run_df = pd.DataFrame(
+        {
+            "datetime": pd.to_datetime(["2024-08-08", "2024-08-09", "2024-08-10"]),
+            "fruit_dry_weight_g_m2": [4.0, 6.0, 7.0],
+            "harvested_fruit_g_m2": [0.0, 5.0, 9.0],
+        }
+    )
+
+    observed = model_floor_area_cumulative_total_fruit(run_df)
+
+    assert observed["model_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [0.0, 5.0, 9.0]
+    assert observed["model_total_system_fruit_dry_weight_floor_area"].tolist() == [4.0, 11.0, 16.0]
+    assert observed["model_observed_target_proxy_floor_area"].tolist() == [0.0, 5.0, 9.0]
+    assert observed["model_cumulative_total_fruit_dry_weight_floor_area"].tolist() == [0.0, 5.0, 9.0]
+
+
+def test_validation_bundle_prefers_explicit_harvested_cumulative_column() -> None:
+    observed_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-08-08", "2024-08-09", "2024-08-10"]),
+            "measured_cumulative_total_fruit_dry_weight_floor_area": [0.0, 3.0, 5.0],
+            "measured_daily_increment_floor_area": [pd.NA, 3.0, 2.0],
+        }
+    )
+
+    bundle = compute_validation_bundle(
+        observed_df,
+        candidate_series=pd.Series([0.0, 2.5, 5.5], dtype=float),
+        candidate_daily_increment_series=pd.Series([float("nan"), 2.5, 3.0], dtype=float),
+        candidate_label="model",
+        unit_declared_in_observation_file="g/m^2",
+    )
+
+    cumulative_column, _, _ = resolve_validation_series_columns(bundle.merged_df, source_label="model")
+
+    assert cumulative_column == "model_cumulative_harvested_fruit_dry_weight_floor_area"
+    assert "model_cumulative_harvested_fruit_dry_weight_floor_area" in bundle.merged_df.columns

--- a/tests/test_tomics_harvest_partial_outflow.py
+++ b/tests/test_tomics_harvest_partial_outflow.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.contracts import HarvestState
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_tomgro import (
+    TomgroAgeclassHarvestPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_vanthoor import (
+    VanthoorBoxcarHarvestPolicy,
+)
+
+
+def _make_state(fruit_row: dict[str, object]) -> HarvestState:
+    return HarvestState(
+        datetime=pd.Timestamp("2024-08-10"),
+        dt_days=1.0,
+        floor_area_basis=True,
+        plants_per_m2=1.836091,
+        lai=2.0,
+        cbuf_g_m2=0.0,
+        fruit_entities=pd.DataFrame([fruit_row]),
+        leaf_entities=pd.DataFrame(),
+        stem_root_state={"stem_dry_weight_g_m2": 1.0, "root_dry_weight_g_m2": 1.0},
+        harvested_fruit_cumulative_g_m2=0.0,
+        harvested_leaf_cumulative_g_m2=0.0,
+        diagnostics={},
+    )
+
+
+def test_vanthoor_partial_outflow_keeps_residual_mass_on_plant() -> None:
+    state = _make_state(
+        {
+            "entity_id": "final_stage_fruit",
+            "stage_index": 5.0,
+            "final_stage_flag": True,
+            "final_stage_residence_days": 1.0,
+            "fruit_dm_g_m2": 8.0,
+            "fruit_count": 2.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+    update = VanthoorBoxcarHarvestPolicy(n_dev=5, outflow_fraction_per_day=0.5).step(state, env={}, dt_days=1.0)
+
+    row = update.updated_state.fruit_entities.iloc[0]
+    event = update.diagnostics["fruit_events"][0]
+
+    assert update.fruit_harvest_event_count == 1
+    assert 0.0 < float(row["fruit_dm_g_m2"]) < 8.0
+    assert bool(row["onplant_flag"]) is True
+    assert bool(row["harvested_flag"]) is False
+    assert event.partial_outflow_flag is True
+    assert event.removes_entity is False
+    assert bool(update.diagnostics["partial_fruit_outflow_flag"]) is True
+
+
+def test_tomgro_mature_pool_delta_can_harvest_partially_across_multiple_days() -> None:
+    policy = TomgroAgeclassHarvestPolicy(mature_class_index=20, mature_pool_harvest_mode="mature_pool_delta")
+    state = _make_state(
+        {
+            "entity_id": "mature_pool",
+            "age_class": 20.0,
+            "mature_pool_flag": True,
+            "mature_pool_residence_days": 1.0,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 2.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+
+    first = policy.step(state, env={"mature_pool_delta_g_m2": 2.0}, dt_days=1.0)
+    second = policy.step(first.updated_state, env={"mature_pool_delta_g_m2": 2.0}, dt_days=1.0)
+
+    first_row = first.updated_state.fruit_entities.iloc[0]
+    second_row = second.updated_state.fruit_entities.iloc[0]
+
+    assert math.isclose(first.fruit_harvest_flux_g_m2_d, 2.0)
+    assert math.isclose(float(first_row["fruit_dm_g_m2"]), 4.0)
+    assert bool(first_row["onplant_flag"]) is True
+    assert bool(first_row["harvested_flag"]) is False
+
+    assert math.isclose(second.fruit_harvest_flux_g_m2_d, 2.0)
+    assert math.isclose(float(second_row["fruit_dm_g_m2"]), 2.0)
+    assert bool(second_row["onplant_flag"]) is True
+    assert bool(second_row["harvested_flag"]) is False

--- a/tests/test_tomics_harvest_policies.py
+++ b/tests/test_tomics_harvest_policies.py
@@ -62,7 +62,7 @@ def _leaf_lookup(frame: pd.DataFrame, entity_id: str) -> pd.Series:
     return row.iloc[0]
 
 
-def assert_tomsim_harvest_waits_for_ready_truss_and_removes_whole_truss_mass() -> None:
+def test_tomsim_harvest_waits_for_ready_truss_and_removes_whole_truss_mass() -> None:
     state = _make_state(
         fruit_rows=[
             {
@@ -98,7 +98,7 @@ def assert_tomsim_harvest_waits_for_ready_truss_and_removes_whole_truss_mass() -
     assert math.isclose(float(waiting_row["fruit_dm_g_m2"]), 2.0)
 
 
-def assert_tomgro_harvest_uses_only_mature_age_classes_and_scales_to_mature_pool_delta() -> None:
+def test_tomgro_harvest_uses_only_mature_age_classes_and_scales_to_mature_pool_delta() -> None:
     state = _make_state(
         fruit_rows=[
             {
@@ -141,7 +141,7 @@ def assert_tomgro_harvest_uses_only_mature_age_classes_and_scales_to_mature_pool
     assert math.isclose(float(mature_b["fruit_dm_g_m2"]), 2.0)
 
 
-def assert_dekoning_harvest_requires_fds_threshold_and_records_fdmc_outputs() -> None:
+def test_dekoning_harvest_requires_fds_threshold_and_records_fdmc_outputs() -> None:
     state = _make_state(
         fruit_rows=[
             {
@@ -177,7 +177,7 @@ def assert_dekoning_harvest_requires_fds_threshold_and_records_fdmc_outputs() ->
     assert math.isclose(float(green["fruit_dm_g_m2"]), 2.4)
 
 
-def assert_vanthoor_harvest_uses_last_stage_when_no_explicit_outflow_is_supplied() -> None:
+def test_vanthoor_harvest_uses_last_stage_when_no_explicit_outflow_is_supplied() -> None:
     state = _make_state(
         fruit_rows=[
             {
@@ -219,7 +219,7 @@ def assert_vanthoor_harvest_uses_last_stage_when_no_explicit_outflow_is_supplied
     assert math.isclose(float(stage_5_b["fruit_dm_g_m2"]), 1.0)
 
 
-def assert_linked_truss_stage_leaf_harvest_follows_linked_tdvs_threshold() -> None:
+def test_linked_truss_stage_leaf_harvest_follows_linked_tdvs_threshold() -> None:
     state = _make_state(
         fruit_rows=[
             {"entity_id": "fruit_1", "truss_id": 1, "tdvs": 0.95, "fruit_dm_g_m2": 1.0, "onplant_flag": True},
@@ -260,7 +260,7 @@ def assert_linked_truss_stage_leaf_harvest_follows_linked_tdvs_threshold() -> No
     assert math.isclose(float(update.updated_state.lai), 1.9)
 
 
-def assert_vegetative_unit_leaf_harvest_uses_corresponding_truss_colour_proxy() -> None:
+def test_vegetative_unit_leaf_harvest_uses_corresponding_truss_colour_proxy() -> None:
     state = _make_state(
         fruit_rows=[
             {"entity_id": "fruit_a", "truss_id": 1, "fds": 0.92, "fruit_dm_g_m2": 1.0, "onplant_flag": True},
@@ -299,7 +299,7 @@ def assert_vegetative_unit_leaf_harvest_uses_corresponding_truss_colour_proxy() 
     assert math.isclose(float(retained_leaf["leaf_dm_g_m2"]), 1.1)
 
 
-def assert_max_lai_pruning_flow_can_partially_remove_leaf_mass_to_hit_target_lai() -> None:
+def test_max_lai_pruning_flow_can_partially_remove_leaf_mass_to_hit_target_lai() -> None:
     state = _make_state(
         fruit_rows=[{"entity_id": "fruit", "truss_id": 1, "tdvs": 0.5, "fruit_dm_g_m2": 1.0, "onplant_flag": True}],
         leaf_rows=[
@@ -336,3 +336,27 @@ def assert_max_lai_pruning_flow_can_partially_remove_leaf_mass_to_hit_target_lai
     assert math.isclose(float(top_leaf["leaf_dm_g_m2"]), 0.8)
     assert math.isclose(float(lower_leaf["leaf_dm_g_m2"]), 1.0)
     assert math.isclose(float(update.updated_state.lai), 3.0)
+
+
+# Backward-compatible aliases for thin wrapper test modules.
+assert_tomsim_harvest_waits_for_ready_truss_and_removes_whole_truss_mass = (
+    test_tomsim_harvest_waits_for_ready_truss_and_removes_whole_truss_mass
+)
+assert_tomgro_harvest_uses_only_mature_age_classes_and_scales_to_mature_pool_delta = (
+    test_tomgro_harvest_uses_only_mature_age_classes_and_scales_to_mature_pool_delta
+)
+assert_dekoning_harvest_requires_fds_threshold_and_records_fdmc_outputs = (
+    test_dekoning_harvest_requires_fds_threshold_and_records_fdmc_outputs
+)
+assert_vanthoor_harvest_uses_last_stage_when_no_explicit_outflow_is_supplied = (
+    test_vanthoor_harvest_uses_last_stage_when_no_explicit_outflow_is_supplied
+)
+assert_linked_truss_stage_leaf_harvest_follows_linked_tdvs_threshold = (
+    test_linked_truss_stage_leaf_harvest_follows_linked_tdvs_threshold
+)
+assert_vegetative_unit_leaf_harvest_uses_corresponding_truss_colour_proxy = (
+    test_vegetative_unit_leaf_harvest_uses_corresponding_truss_colour_proxy
+)
+assert_max_lai_pruning_flow_can_partially_remove_leaf_mass_to_hit_target_lai = (
+    test_max_lai_pruning_flow_can_partially_remove_leaf_mass_to_hit_target_lai
+)

--- a/tests/test_tomics_harvest_positive_delay.py
+++ b/tests/test_tomics_harvest_positive_delay.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.contracts import HarvestState
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_dekoning import (
+    DeKoningFdsHarvestPolicy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.components.harvest.fruit_harvest_tomsim import (
+    TomsimTrussHarvestPolicy,
+)
+
+
+def _make_state(fruit_row: dict[str, object]) -> HarvestState:
+    return HarvestState(
+        datetime=pd.Timestamp("2024-08-10"),
+        dt_days=1.0,
+        floor_area_basis=True,
+        plants_per_m2=1.836091,
+        lai=2.0,
+        cbuf_g_m2=0.0,
+        fruit_entities=pd.DataFrame([fruit_row]),
+        leaf_entities=pd.DataFrame(),
+        stem_root_state={"stem_dry_weight_g_m2": 1.0, "root_dry_weight_g_m2": 1.0},
+        harvested_fruit_cumulative_g_m2=0.0,
+        harvested_leaf_cumulative_g_m2=0.0,
+        diagnostics={},
+    )
+
+
+def test_tomsim_positive_delay_uses_post_maturity_residence_clock() -> None:
+    policy = TomsimTrussHarvestPolicy(tdvs_harvest_threshold=1.0, harvest_delay_days=1.0)
+    waiting_state = _make_state(
+        {
+            "entity_id": "truss_waiting",
+            "tdvs": 1.0,
+            "days_since_maturity": 0.5,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 4.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+    ready_state = _make_state(
+        {
+            "entity_id": "truss_ready",
+            "tdvs": 1.0,
+            "days_since_maturity": 1.1,
+            "fruit_dm_g_m2": 6.0,
+            "fruit_count": 4.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+
+    waiting_update = policy.step(waiting_state, env={}, dt_days=1.0)
+    ready_update = policy.step(ready_state, env={}, dt_days=1.0)
+
+    assert waiting_update.fruit_harvest_event_count == 0
+    assert ready_update.fruit_harvest_event_count == 1
+    assert math.isclose(ready_update.fruit_harvest_flux_g_m2_d, 6.0)
+    assert ready_update.diagnostics["delay_mode"] == "residence_clock"
+
+
+def test_dekoning_positive_delay_uses_post_maturity_residence_clock() -> None:
+    policy = DeKoningFdsHarvestPolicy(fds_harvest_threshold=1.0, harvest_delay_days=2.0)
+    waiting_state = _make_state(
+        {
+            "entity_id": "fruit_waiting",
+            "fds": 1.02,
+            "days_since_maturity": 1.5,
+            "fruit_dm_g_m2": 3.5,
+            "fruit_count": 1.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+    ready_state = _make_state(
+        {
+            "entity_id": "fruit_ready",
+            "fds": 1.02,
+            "days_since_maturity": 2.1,
+            "fruit_dm_g_m2": 3.5,
+            "fruit_count": 1.0,
+            "onplant_flag": True,
+            "harvested_flag": False,
+        }
+    )
+
+    waiting_update = policy.step(waiting_state, env={"T_air_C": 24.0}, dt_days=1.0)
+    ready_update = policy.step(ready_state, env={"T_air_C": 24.0}, dt_days=1.0)
+
+    assert waiting_update.fruit_harvest_event_count == 0
+    assert ready_update.fruit_harvest_event_count == 1
+    assert math.isclose(ready_update.fruit_harvest_flux_g_m2_d, 3.5)
+    assert ready_update.diagnostics["delay_mode"] == "residence_clock"


### PR DESCRIPTION
﻿## Background
- Follow up on zero-yield replay repair by completing the missing harvest-runtime state instead of rerunning the same proxy families again.
- This PR adds post-maturity runtime clocks, residence-gated delay semantics, partial fruit outflow support, and explicit harvested-cumulative scoring semantics.

## Changes
- Extend harvest fruit contracts and legacy tomato cohort state with post-maturity/runtime fields such as `matured_at`, `days_since_maturity`, `mature_pool_residence_days`, and `final_stage_residence_days`.
- Replace TOMSIM / De Koning threshold-shift delay with post-maturity residence-clock gating.
- Add mature-pool / final-stage residence semantics plus partial-outflow handling for TOMGRO / Vanthoor harvest policies.
- Preserve residual on-plant fruit mass through adapters, mass-balance diagnostics, model writeback, and harvest-family evaluation.
- Align common-structure harvest terms to step fluxes and make validation prefer explicit harvested cumulative columns while keeping legacy aliases compatible.
- Add runtime completion tests for positive delay, partial outflow, family-state separability, operator semantics, and common-structure harvest flux semantics.

## Validation
- `poetry run pytest tests/test_tomics_harvest_positive_delay.py tests/test_tomics_harvest_partial_outflow.py tests/test_tomics_harvest_family_state_axes.py tests/test_tomics_common_structure_harvest_flux_semantics.py tests/test_tomics_harvest_operator_semantics.py tests/test_tomics_harvest_policies.py tests/test_tomics_harvest_mass_balance.py tests/test_tomics_alloc_tomato_model.py tests/test_tomics_knu_observation_operator.py -q`
- `poetry run pytest`
- `poetry run ruff check .`

## Impact
- Harvest families now carry family-specific post-maturity runtime state instead of collapsing onto the same shared `tdvs` proxy surface.
- Partial fruit outflow no longer forces entities off-plant while positive residual mass remains.
- Harvest-aware reruns can now be gated on a runtime-complete state/writeback contract.

## Linked issue
Closes #253