### PR TITLE
[Data Prep] Harden TOMICS multidataset gate strictness and reviewed traitenv candidate wiring

### DIFF
--- a/configs/exp/tomics_multidataset_harvest_factorial.yaml
+++ b/configs/exp/tomics_multidataset_harvest_factorial.yaml
@@ -3,6 +3,8 @@ exp:
 
 validation:
   datasets:
+    registry_snapshot_path: configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json
+    allow_missing_registry_snapshot: true
     default_dataset_ids:
       - knu_actual
     items:
@@ -36,6 +38,6 @@ validation:
           - needs_residence_signal_dataset
           - prefer_rootzone_metadata
   multidataset_factorial:
-    output_root: out/tomics_multidataset_harvest_factorial
+    output_root: out/tomics/validation/multidataset
     dataset_factorial_roots:
       knu_actual: out/tomics_knu_harvest_family_factorial

--- a/configs/exp/tomics_multidataset_harvest_promotion_gate.yaml
+++ b/configs/exp/tomics_multidataset_harvest_promotion_gate.yaml
@@ -3,8 +3,8 @@ exp:
 
 validation:
   multidataset_promotion_gate:
-    scorecard_root: out/tomics_multidataset_harvest_factorial
-    output_root: out/tomics_multidataset_harvest_promotion_gate
+    scorecard_root: out/tomics/validation/multidataset
+    output_root: out/tomics/validation/multidataset
     winner_native_state_coverage_min: 0.5
     winner_shared_tdvs_proxy_fraction_max: 0.5
     cross_dataset_stability_score_min: 0.5

--- a/scripts/import_traitenv_dataset_candidates.py
+++ b/scripts/import_traitenv_dataset_candidates.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, write_json
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import DatasetCapability
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.metadata import (
+    build_dataset_blocker_report,
+    build_dataset_inventory_summary,
+    build_dataset_review_template,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.traitenv_loader import (
+    build_traitenv_candidate_registry,
+    load_traitenv_inventory,
+)
+
+
+def run_import_traitenv_dataset_candidates(
+    *,
+    traitenv_path: str | Path,
+    output_root: str | Path,
+    reviewed_manifest_dir: str | Path | None = None,
+) -> dict[str, object]:
+    inventory = load_traitenv_inventory(traitenv_path)
+    registry = build_traitenv_candidate_registry(traitenv_path)
+    output_dir = ensure_dir(Path(output_root).resolve())
+
+    capability_df = registry.to_frame()
+    blocker_df = registry.blocker_frame()
+    snapshot_payload = registry.to_payload()
+    inventory_summary = {
+        **build_dataset_inventory_summary(list(registry.datasets)),
+        "traitenv_bundle_path": str(inventory.bundle_path),
+        "traitenv_bundle_kind": inventory.bundle_kind,
+        "design_workbook_present": inventory.design_workbook_present,
+        "run_manifest": inventory.run_manifest,
+    }
+
+    capability_df.to_csv(output_dir / "dataset_capability_table.csv", index=False)
+    blocker_df.to_csv(output_dir / "dataset_blockers.csv", index=False)
+    write_json(output_dir / "dataset_registry_snapshot.json", snapshot_payload)
+    write_json(output_dir / "traitenv_inventory_summary.json", inventory_summary)
+    (output_dir / "dataset_blocker_report.md").write_text(
+        build_dataset_blocker_report(list(registry.datasets)),
+        encoding="utf-8",
+    )
+
+    if reviewed_manifest_dir is not None:
+        reviewed_dir = ensure_dir(Path(reviewed_manifest_dir).resolve())
+        write_json(reviewed_dir / "traitenv_candidate_registry.json", snapshot_payload)
+        review_template_dir = ensure_dir(reviewed_dir / "review_templates")
+        review_template_index: list[dict[str, str]] = []
+        for dataset in registry.datasets:
+            if dataset.capability is DatasetCapability.CONTEXT_ONLY or dataset.is_runnable_measured_harvest:
+                continue
+            template_filename = f"{dataset.dataset_id}.review.json"
+            write_json(
+                review_template_dir / template_filename,
+                build_dataset_review_template(dataset),
+            )
+            review_template_index.append(
+                {
+                    "dataset_id": dataset.dataset_id,
+                    "capability": dataset.capability.value,
+                    "ingestion_status": dataset.ingestion_status.value,
+                    "path": f"review_templates/{template_filename}",
+                }
+            )
+        write_json(reviewed_dir / "review_template_index.json", {"templates": review_template_index})
+
+    preview_columns = [
+        "dataset_id",
+        "dataset_family",
+        "observation_family",
+        "capability",
+        "ingestion_status",
+        "is_runnable_measured_harvest",
+        "blocker_codes",
+    ]
+    preview_df = capability_df.loc[:, [column for column in preview_columns if column in capability_df.columns]]
+    if not preview_df.empty:
+        print(preview_df.to_string(index=False))
+    else:
+        print("No traitenv dataset candidates were derived.")
+
+    return {
+        "output_root": str(output_dir),
+        "candidate_dataset_count": len(registry.datasets),
+        "runnable_measured_dataset_count": len(registry.runnable_measured_harvest_datasets()),
+        "review_template_count": (
+            0
+            if reviewed_manifest_dir is None
+            else sum(
+                1
+                for dataset in registry.datasets
+                if dataset.capability is not DatasetCapability.CONTEXT_ONLY and not dataset.is_runnable_measured_harvest
+            )
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import conservative TOMICS multi-dataset candidates from a traitenv inventory bundle."
+    )
+    parser.add_argument(
+        "--traitenv-path",
+        "--traitenv-root",
+        dest="traitenv_path",
+        required=True,
+        help="Path to the traitenv inventory directory or traitenv.zip bundle.",
+    )
+    parser.add_argument(
+        "--output-root",
+        default="out/tomics/validation/multidataset",
+        help="Directory for candidate capability/blocker artifacts.",
+    )
+    parser.add_argument(
+        "--reviewed-manifest-dir",
+        default=None,
+        help="Optional directory where a reviewable candidate registry snapshot JSON will be written.",
+    )
+    args = parser.parse_args()
+
+    result = run_import_traitenv_dataset_candidates(
+        traitenv_path=args.traitenv_path,
+        output_root=args.output_root,
+        reviewed_manifest_dir=args.reviewed_manifest_dir,
+    )
+    print(result["output_root"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tomics_multidataset_harvest_factorial.py
+++ b/scripts/run_tomics_multidataset_harvest_factorial.py
@@ -4,13 +4,17 @@ import argparse
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
+
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, load_config, write_json
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_repo_root
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.cross_dataset_scorecard import (
+    build_cross_dataset_inventory_scorecard,
     build_cross_dataset_scorecard,
     load_dataset_factorial_outputs,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.metadata import (
+    build_dataset_blocker_report,
     intake_priority_rows,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
@@ -24,24 +28,24 @@ def _as_dict(raw: object) -> dict[str, Any]:
     return {}
 
 
-def _resolve_config_path(raw: str | Path, *, repo_root: Path, config_path: Path) -> Path:
-    candidate = Path(raw)
-    if candidate.is_absolute():
-        return candidate
-    config_probe = (config_path.parent / candidate).resolve()
-    repo_probe = (repo_root / candidate).resolve()
-    probes = [config_probe, repo_probe]
-    for probe in probes:
-        if probe.exists():
-            return probe
-    return repo_probe
-
-
 def _resolve_artifact_path(raw: str | Path, *, repo_root: Path) -> Path:
     candidate = Path(raw)
     if candidate.is_absolute():
         return candidate
     return (repo_root / candidate).resolve()
+
+
+def _factorial_root_for_dataset(
+    *,
+    dataset_id: str,
+    dataset_roots: dict[str, Any],
+    repo_root: Path,
+) -> Path | None:
+    if dataset_id in dataset_roots:
+        return _resolve_artifact_path(str(dataset_roots[dataset_id]), repo_root=repo_root)
+    if dataset_id == "knu_actual":
+        return _resolve_artifact_path("out/tomics_knu_harvest_family_factorial", repo_root=repo_root)
+    return None
 
 
 def run_multidataset_harvest_factorial(
@@ -54,28 +58,88 @@ def run_multidataset_harvest_factorial(
     factorial_cfg = _as_dict(_as_dict(config.get("validation")).get("multidataset_factorial"))
     output_root = ensure_dir(
         _resolve_artifact_path(
-            factorial_cfg.get("output_root", "out/tomics_multidataset_harvest_factorial"),
+            factorial_cfg.get("output_root", "out/tomics/validation/multidataset"),
             repo_root=repo_root,
         )
     )
     dataset_roots = _as_dict(factorial_cfg.get("dataset_factorial_roots"))
-    rankings = []
-    selected_payloads = []
+    rankings: list[pd.DataFrame] = []
+    selected_payloads: list[dict[str, Any]] = []
+    skipped_rows: list[dict[str, Any]] = []
+
     for dataset in registry.datasets:
-        factorial_root_raw = dataset_roots.get(dataset.dataset_id, "out/tomics_knu_harvest_family_factorial")
+        if not dataset.is_runnable_measured_harvest:
+            skipped_rows.append(
+                {
+                    "dataset_id": dataset.dataset_id,
+                    "capability": dataset.capability.value,
+                    "ingestion_status": dataset.ingestion_status.value,
+                    "skip_reason": "not_runnable_measured_harvest",
+                    "blocker_codes": ",".join(dataset.blocker_codes),
+                }
+            )
+            continue
+        factorial_root = _factorial_root_for_dataset(
+            dataset_id=dataset.dataset_id,
+            dataset_roots=dataset_roots,
+            repo_root=repo_root,
+        )
+        if factorial_root is None:
+            skipped_rows.append(
+                {
+                    "dataset_id": dataset.dataset_id,
+                    "capability": dataset.capability.value,
+                    "ingestion_status": dataset.ingestion_status.value,
+                    "skip_reason": "missing_dataset_factorial_root",
+                    "blocker_codes": ",".join(dataset.blocker_codes),
+                }
+            )
+            continue
+        ranking_path = factorial_root / "candidate_ranking.csv"
+        selected_path = factorial_root / "selected_harvest_family.json"
+        if not ranking_path.exists() or not selected_path.exists():
+            skipped_rows.append(
+                {
+                    "dataset_id": dataset.dataset_id,
+                    "capability": dataset.capability.value,
+                    "ingestion_status": dataset.ingestion_status.value,
+                    "skip_reason": "missing_factorial_artifacts",
+                    "blocker_codes": ",".join(dataset.blocker_codes),
+                }
+            )
+            continue
         ranking_df, selected_payload = load_dataset_factorial_outputs(
             dataset_id=dataset.dataset_id,
-            factorial_root=_resolve_artifact_path(str(factorial_root_raw), repo_root=repo_root),
+            factorial_root=factorial_root,
         )
         rankings.append(ranking_df)
         selected_payloads.append(selected_payload)
-    scorecard_df = build_cross_dataset_scorecard(rankings, selected_payloads)
+
+    scorecard_df = build_cross_dataset_scorecard(rankings, selected_payloads, registry=registry)
+    inventory_scorecard = build_cross_dataset_inventory_scorecard(
+        registry,
+        scorecard_df=scorecard_df,
+        skipped_datasets=skipped_rows,
+    )
     registry_df = registry.to_frame()
-    registry_df.to_csv(output_root / "dataset_registry.csv", index=False)
+    blocker_df = registry.blocker_frame()
+    skipped_df = pd.DataFrame.from_records(
+        skipped_rows,
+        columns=["dataset_id", "capability", "ingestion_status", "skip_reason", "blocker_codes"],
+    )
+
+    registry_df.to_csv(output_root / "dataset_capability_table.csv", index=False)
+    blocker_df.to_csv(output_root / "dataset_blockers.csv", index=False)
+    skipped_df.to_csv(output_root / "dataset_skip_report.csv", index=False)
     scorecard_df.to_csv(output_root / "cross_dataset_scorecard.csv", index=False)
-    write_json(output_root / "dataset_registry.json", registry.to_payload())
+    write_json(output_root / "dataset_registry_snapshot.json", registry.to_payload())
+    write_json(output_root / "cross_dataset_scorecard.json", inventory_scorecard)
     write_json(output_root / "per_dataset_selected_families.json", {"datasets": selected_payloads})
     write_json(output_root / "intake_priority.json", {"datasets": intake_priority_rows(list(registry.datasets))})
+    (output_root / "dataset_blocker_report.md").write_text(
+        build_dataset_blocker_report(list(registry.datasets)),
+        encoding="utf-8",
+    )
     write_json(
         output_root / "dataset_metadata_summary.json",
         {
@@ -83,6 +147,8 @@ def run_multidataset_harvest_factorial(
                 {
                     "dataset_id": dataset.dataset_id,
                     "display_name": dataset.display_name,
+                    "capability": dataset.capability.value,
+                    "ingestion_status": dataset.ingestion_status.value,
                     "priority_tags": list(dataset.priority_tags),
                     "notes": dataset.notes,
                 }
@@ -92,7 +158,8 @@ def run_multidataset_harvest_factorial(
     )
     return {
         "output_root": str(output_root),
-        "dataset_count": len(registry.datasets),
+        "total_registry_datasets": len(registry.datasets),
+        "runnable_measured_dataset_count": len(registry.runnable_measured_harvest_datasets()),
         "scorecard_rows": int(scorecard_df.shape[0]),
     }
 

--- a/scripts/run_tomics_multidataset_harvest_promotion_gate.py
+++ b/scripts/run_tomics_multidataset_harvest_promotion_gate.py
@@ -19,24 +19,23 @@ def _as_dict(raw: object) -> dict[str, Any]:
     return {}
 
 
-def _resolve_config_path(raw: str | Path, *, repo_root: Path, config_path: Path) -> Path:
-    candidate = Path(raw)
-    if candidate.is_absolute():
-        return candidate
-    config_probe = (config_path.parent / candidate).resolve()
-    repo_probe = (repo_root / candidate).resolve()
-    probes = [config_probe, repo_probe]
-    for probe in probes:
-        if probe.exists():
-            return probe
-    return repo_probe
-
-
 def _resolve_artifact_path(raw: str | Path, *, repo_root: Path) -> Path:
     candidate = Path(raw)
     if candidate.is_absolute():
         return candidate
     return (repo_root / candidate).resolve()
+
+
+def _read_required_csv(path: Path, *, artifact_label: str) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Required multidataset artifact is missing: {artifact_label} at {path}")
+    try:
+        frame = pd.read_csv(path)
+    except pd.errors.EmptyDataError:
+        raise ValueError(f"Required multidataset artifact is empty: {artifact_label} at {path}") from None
+    if frame.empty:
+        raise ValueError(f"Required multidataset artifact has no rows: {artifact_label} at {path}")
+    return frame
 
 
 def run_multidataset_harvest_promotion_gate(
@@ -45,27 +44,37 @@ def run_multidataset_harvest_promotion_gate(
     repo_root: Path,
     config_path: Path,
 ) -> dict[str, object]:
+    del config_path
     validation_cfg = _as_dict(config.get("validation"))
     gate_cfg = _as_dict(validation_cfg.get("multidataset_promotion_gate"))
     output_root = ensure_dir(
         _resolve_artifact_path(
-            gate_cfg.get("output_root", "out/tomics_multidataset_harvest_promotion_gate"),
+            gate_cfg.get("output_root", "out/tomics/validation/multidataset"),
             repo_root=repo_root,
         )
     )
     scorecard_root = _resolve_artifact_path(
-        gate_cfg.get("scorecard_root", "out/tomics_multidataset_harvest_factorial"),
+        gate_cfg.get("scorecard_root", "out/tomics/validation/multidataset"),
         repo_root=repo_root,
     )
-    scorecard_df = pd.read_csv(scorecard_root / "cross_dataset_scorecard.csv")
+    scorecard_df = _read_required_csv(
+        scorecard_root / "cross_dataset_scorecard.csv",
+        artifact_label="cross_dataset_scorecard.csv",
+    )
+    registry_df = _read_required_csv(
+        scorecard_root / "dataset_capability_table.csv",
+        artifact_label="dataset_capability_table.csv",
+    )
     summary = build_cross_dataset_guardrail_summary(
         scorecard_df,
+        registry_df=registry_df,
         native_state_coverage_min=float(gate_cfg.get("winner_native_state_coverage_min", 0.5)),
         shared_tdvs_proxy_fraction_max=float(gate_cfg.get("winner_shared_tdvs_proxy_fraction_max", 0.5)),
         cross_dataset_stability_score_min=float(gate_cfg.get("cross_dataset_stability_score_min", 0.5)),
         min_dataset_count=int(gate_cfg.get("min_dataset_count", 2)),
     )
     scorecard_df.to_csv(output_root / "cross_dataset_promotion_scorecard.csv", index=False)
+    write_json(output_root / "cross_dataset_gate.json", summary)
     write_json(output_root / "cross_dataset_guardrails.json", summary)
     selected = summary.get("selected_candidate", {})
     decision_lines = [
@@ -73,13 +82,16 @@ def run_multidataset_harvest_promotion_gate(
         "",
         f"Recommendation: `{summary['recommendation']}`",
         "",
+        f"Runnable measured-harvest dataset count: {summary.get('measured_dataset_count', 0)}",
+        "",
     ]
     if selected:
         decision_lines.extend(
             [
                 "Summary:",
                 f"- selected family: {selected.get('fruit_harvest_family')} + {selected.get('leaf_harvest_family')} + {selected.get('fdmc_mode')}",
-                f"- dataset count: {selected.get('dataset_count')}",
+                f"- selected candidate dataset count: {selected.get('selected_candidate_dataset_count')}",
+                f"- runnable measured dataset count: {selected.get('measured_dataset_count')}",
                 f"- cross-dataset stability score: {float(selected.get('cross_dataset_stability_score', 0.0)):.2f}",
                 f"- native-state coverage: {float(selected.get('winner_native_state_coverage', 0.0)):.2f}",
                 f"- shared-TDVS proxy fraction: {float(selected.get('winner_shared_tdvs_proxy_fraction', 0.0)):.2f}",

--- a/src/stomatal_optimiaztion/__init__.py
+++ b/src/stomatal_optimiaztion/__init__.py
@@ -1,1 +1,31 @@
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _disable_windows_platform_wmi() -> None:
+    if sys.platform != "win32":
+        return
+    if os.environ.get("PHYTORITAS_ALLOW_PLATFORM_WMI", "").strip().lower() in {"1", "true", "yes"}:
+        return
+
+    import platform
+
+    original = getattr(platform, "_wmi_query", None)
+    if original is None or getattr(platform, "_phytoritas_wmi_guard", False):
+        return
+
+    def _wmi_query_disabled(*_args: object, **_kwargs: object) -> object:
+        raise OSError("platform WMI disabled by stomatal_optimiaztion package init")
+
+    platform._phytoritas_wmi_guard = True  # type: ignore[attr-defined]
+    platform._phytoritas_original_wmi_query = original  # type: ignore[attr-defined]
+    platform._wmi_query = _wmi_query_disabled  # type: ignore[assignment]
+    if hasattr(platform, "_uname_cache"):
+        platform._uname_cache = None  # type: ignore[attr-defined]
+
+
+_disable_windows_platform_wmi()
+
 __all__ = ["domains"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py
@@ -1,8 +1,52 @@
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import DatasetRegistry
+
+
+def _bool_series(frame: pd.DataFrame, column: str) -> pd.Series:
+    if column not in frame.columns:
+        return pd.Series(False, index=frame.index, dtype=bool)
+    normalized = frame[column].fillna(False).astype(str).str.strip().str.lower()
+    return normalized.isin({"true", "1", "yes"})
+
+
+def _nonempty_series(frame: pd.DataFrame, column: str) -> pd.Series:
+    if column not in frame.columns:
+        return pd.Series(False, index=frame.index, dtype=bool)
+    return frame[column].fillna("").astype(str).str.strip().ne("")
+
+
+def _existing_path_series(frame: pd.DataFrame, column: str) -> pd.Series:
+    if column not in frame.columns:
+        return pd.Series(False, index=frame.index, dtype=bool)
+    values = frame[column].fillna("").astype(str).str.strip()
+    return values.apply(lambda value: bool(value) and Path(value).exists())
+
+
+def _registry_measured_dataset_support(registry_df: pd.DataFrame | None) -> tuple[int, list[str]]:
+    if registry_df is None or registry_df.empty:
+        return 0, []
+    capability = registry_df.get("capability", pd.Series(dtype=object)).astype(str).str.strip().str.lower()
+    mask = (
+        capability.eq("measured_harvest")
+        & _bool_series(registry_df, "is_runnable_measured_harvest")
+        & _bool_series(registry_df, "basis_normalization_resolved")
+        & _nonempty_series(registry_df, "validation_start")
+        & _nonempty_series(registry_df, "validation_end")
+        & _nonempty_series(registry_df, "date_column")
+        & _nonempty_series(registry_df, "measured_cumulative_column")
+        & _existing_path_series(registry_df, "forcing_path")
+        & _existing_path_series(registry_df, "observed_harvest_path")
+        & _existing_path_series(registry_df, "sanitized_fixture_path")
+    )
+    dataset_ids = sorted({str(value) for value in registry_df.loc[mask, "dataset_id"].dropna()})
+    return len(dataset_ids), dataset_ids
 
 
 def cross_dataset_proxy_guardrail(
@@ -12,7 +56,8 @@ def cross_dataset_proxy_guardrail(
     shared_tdvs_proxy_fraction_max: float,
     cross_dataset_stability_score_min: float,
     min_dataset_count: int,
-) -> dict[str, float | bool]:
+    measured_dataset_count: int | None = None,
+) -> dict[str, float | bool | int]:
     native_state_coverage = float(
         pd.to_numeric(pd.Series([candidate.get("mean_native_family_state_fraction", 0.0)]), errors="coerce")
         .fillna(0.0)
@@ -33,43 +78,103 @@ def cross_dataset_proxy_guardrail(
         .fillna(0.0)
         .iloc[0]
     )
-    dataset_count = int(pd.to_numeric(pd.Series([candidate.get("dataset_count", 0)]), errors="coerce").fillna(0).iloc[0])
+    selected_candidate_dataset_count = int(
+        pd.to_numeric(pd.Series([candidate.get("dataset_count", 0)]), errors="coerce").fillna(0).iloc[0]
+    )
+    measured_dataset_evidence_available = measured_dataset_count is not None
+    registry_measured_dataset_count = int(measured_dataset_count or 0)
     proxy_heavy_flag = bool(
         native_state_coverage < native_state_coverage_min
         or shared_tdvs_proxy_fraction > shared_tdvs_proxy_fraction_max
     )
-    single_dataset_only_flag = dataset_count < int(min_dataset_count)
+    single_dataset_only_flag = (
+        selected_candidate_dataset_count < int(min_dataset_count)
+        or registry_measured_dataset_count < int(min_dataset_count)
+    )
     stability_fail_flag = stability_score < cross_dataset_stability_score_min
+    missing_dataset_registry_flag = not measured_dataset_evidence_available
     return {
         "winner_native_state_coverage": native_state_coverage,
         "winner_proxy_state_fraction": proxy_state_fraction,
         "winner_shared_tdvs_proxy_fraction": shared_tdvs_proxy_fraction,
         "winner_proxy_heavy_flag": proxy_heavy_flag,
         "cross_dataset_stability_score": stability_score,
+        "measured_dataset_count": registry_measured_dataset_count,
+        "measured_dataset_evidence_available": measured_dataset_evidence_available,
+        "selected_candidate_dataset_count": selected_candidate_dataset_count,
         "single_dataset_only_flag": single_dataset_only_flag,
+        "missing_dataset_registry_flag": missing_dataset_registry_flag,
         "winner_not_promotion_grade_due_to_proxy_dependence": proxy_heavy_flag,
-        "winner_not_promotion_grade_due_to_cross_dataset_instability": single_dataset_only_flag or stability_fail_flag,
-        "passes": not (proxy_heavy_flag or single_dataset_only_flag or stability_fail_flag),
+        "winner_not_promotion_grade_due_to_cross_dataset_instability": (
+            single_dataset_only_flag or stability_fail_flag or missing_dataset_registry_flag
+        ),
+        "passes": not (proxy_heavy_flag or single_dataset_only_flag or stability_fail_flag or missing_dataset_registry_flag),
     }
 
 
 def build_cross_dataset_guardrail_summary(
     scorecard_df: pd.DataFrame,
     *,
+    registry: "DatasetRegistry | None" = None,
+    registry_df: pd.DataFrame | None = None,
     native_state_coverage_min: float = 0.5,
     shared_tdvs_proxy_fraction_max: float = 0.5,
     cross_dataset_stability_score_min: float = 0.5,
     min_dataset_count: int = 2,
 ) -> dict[str, Any]:
+    if registry_df is None and registry is not None:
+        registry_df = registry.to_frame()
+    measured_dataset_count, measured_dataset_ids = _registry_measured_dataset_support(registry_df)
+    registry_evidence_available = registry_df is not None and not registry_df.empty
+    registry_summary = {}
+    if registry_evidence_available:
+        registry_summary = {
+            "total_registry_datasets": int(registry_df.shape[0]),
+            "proxy_dataset_count": int(
+                registry_df.get("capability", pd.Series(dtype=object))
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .eq("harvest_proxy")
+                .sum()
+            ),
+            "context_only_dataset_count": int(
+                registry_df.get("capability", pd.Series(dtype=object))
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .eq("context_only")
+                .sum()
+            ),
+            "draft_dataset_count": int(
+                registry_df.get("ingestion_status", pd.Series(dtype=object))
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .ne("runnable")
+                .sum()
+            ),
+            "measured_dataset_evidence_available": True,
+        }
+    else:
+        registry_summary = {"measured_dataset_evidence_available": False}
+    guardrails = {
+        "winner_native_state_coverage_min": native_state_coverage_min,
+        "winner_shared_tdvs_proxy_fraction_max": shared_tdvs_proxy_fraction_max,
+        "cross_dataset_stability_score_min": cross_dataset_stability_score_min,
+        "min_dataset_count": min_dataset_count,
+    }
     if scorecard_df.empty:
         return {
-            "recommendation": "No registered datasets were available for cross-dataset promotion.",
-            "guardrails": {
-                "winner_native_state_coverage_min": native_state_coverage_min,
-                "winner_shared_tdvs_proxy_fraction_max": shared_tdvs_proxy_fraction_max,
-                "cross_dataset_stability_score_min": cross_dataset_stability_score_min,
-                "min_dataset_count": min_dataset_count,
-            },
+            "recommendation": (
+                "Promotion remains blocked by design until at least two runnable measured-harvest datasets are registered."
+                if measured_dataset_count < int(min_dataset_count)
+                else "Promotion remains blocked because no cross-dataset factorial winner is available yet."
+            ),
+            "guardrails": guardrails,
+            "dataset_inventory_summary": registry_summary,
+            "measured_dataset_count": measured_dataset_count,
+            "measured_dataset_ids": measured_dataset_ids,
             "selected_candidate": {},
         }
     selected = scorecard_df.iloc[0]
@@ -79,20 +184,22 @@ def build_cross_dataset_guardrail_summary(
         shared_tdvs_proxy_fraction_max=shared_tdvs_proxy_fraction_max,
         cross_dataset_stability_score_min=cross_dataset_stability_score_min,
         min_dataset_count=min_dataset_count,
+        measured_dataset_count=measured_dataset_count if registry_evidence_available else None,
     )
-    recommendation = (
-        "Promotion remains blocked until a winner holds across multiple measured datasets."
-        if not guardrail["passes"]
-        else "Promotion-grade cross-dataset winner available."
-    )
+    if not registry_evidence_available:
+        recommendation = (
+            "Promotion remains blocked until runnable measured-harvest dataset support is resolved from the dataset registry."
+        )
+    elif not guardrail["passes"]:
+        recommendation = "Promotion remains blocked until a winner holds across multiple runnable measured-harvest datasets."
+    else:
+        recommendation = "Promotion-grade cross-dataset winner available."
     return {
         "recommendation": recommendation,
-        "guardrails": {
-            "winner_native_state_coverage_min": native_state_coverage_min,
-            "winner_shared_tdvs_proxy_fraction_max": shared_tdvs_proxy_fraction_max,
-            "cross_dataset_stability_score_min": cross_dataset_stability_score_min,
-            "min_dataset_count": min_dataset_count,
-        },
+        "guardrails": guardrails,
+        "dataset_inventory_summary": registry_summary,
+        "measured_dataset_count": measured_dataset_count,
+        "measured_dataset_ids": measured_dataset_ids,
         "selected_candidate": {**selected.to_dict(), **guardrail},
     }
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_scorecard.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_scorecard.py
@@ -6,8 +6,32 @@ from typing import Any
 
 import pandas as pd
 
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.metadata import (
+    build_dataset_inventory_summary,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    DatasetRegistry,
+)
+
 
 KEY_COLUMNS = ["fruit_harvest_family", "leaf_harvest_family", "fdmc_mode"]
+EMPTY_SCORECARD_COLUMNS = [
+    *KEY_COLUMNS,
+    "mean_score",
+    "mean_rmse_cumulative_offset",
+    "mean_rmse_daily_increment",
+    "max_harvest_mass_balance_error",
+    "max_canopy_collapse_days",
+    "mean_native_family_state_fraction",
+    "mean_proxy_family_state_fraction",
+    "mean_shared_tdvs_proxy_fraction",
+    "family_state_mode_distribution",
+    "proxy_mode_used_distribution",
+    "dataset_count",
+    "dataset_ids",
+    "dataset_win_count",
+    "cross_dataset_stability_score",
+]
 
 
 def _aggregate_distribution_json(series: pd.Series) -> str:
@@ -51,9 +75,11 @@ def load_dataset_factorial_outputs(
 def build_cross_dataset_scorecard(
     dataset_rankings: list[pd.DataFrame],
     dataset_selected_payloads: list[dict[str, Any]],
+    *,
+    registry: DatasetRegistry | None = None,
 ) -> pd.DataFrame:
     if not dataset_rankings:
-        return pd.DataFrame()
+        return pd.DataFrame(columns=EMPTY_SCORECARD_COLUMNS)
     combined = pd.concat(dataset_rankings, ignore_index=True)
     dataset_count = max(len({str(value) for value in combined["dataset_id"].dropna()}), 1)
     scorecard = (
@@ -91,7 +117,51 @@ def build_cross_dataset_scorecard(
         axis=1,
     )
     scorecard["cross_dataset_stability_score"] = scorecard["dataset_win_count"].astype(float) / float(dataset_count)
+    if registry is not None:
+        summary = build_dataset_inventory_summary(list(registry.datasets))
+        scorecard["total_registry_datasets"] = int(summary["total_registry_datasets"])
+        scorecard["runnable_measured_harvest_datasets"] = int(summary["runnable_measured_harvest_datasets"])
+        scorecard["proxy_datasets"] = int(summary["proxy_datasets"])
+        scorecard["context_only_datasets"] = int(summary["context_only_datasets"])
+        scorecard["blocked_by_missing_raw_fixture"] = int(summary["blocked_by_missing_raw_fixture"])
+        scorecard["blocked_by_missing_basis_or_density"] = int(summary["blocked_by_missing_basis_or_density"])
+        scorecard["blocked_by_missing_cumulative_mapping"] = int(summary["blocked_by_missing_cumulative_mapping"])
     return scorecard
 
 
-__all__ = ["KEY_COLUMNS", "build_cross_dataset_scorecard", "load_dataset_factorial_outputs"]
+def build_cross_dataset_scorecard_report(
+    scorecard_df: pd.DataFrame,
+    *,
+    registry: DatasetRegistry,
+    skipped_datasets: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "dataset_inventory_summary": build_dataset_inventory_summary(list(registry.datasets)),
+        "runnable_measured_dataset_ids": [dataset.dataset_id for dataset in registry.runnable_measured_harvest_datasets()],
+        "draft_dataset_ids": [dataset.dataset_id for dataset in registry.draft_datasets()],
+        "skipped_datasets": skipped_datasets or [],
+        "scorecard_rows": scorecard_df.to_dict(orient="records"),
+    }
+
+
+def build_cross_dataset_inventory_scorecard(
+    registry: DatasetRegistry,
+    *,
+    scorecard_df: pd.DataFrame | None = None,
+    skipped_datasets: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return build_cross_dataset_scorecard_report(
+        scorecard_df if scorecard_df is not None else pd.DataFrame(columns=EMPTY_SCORECARD_COLUMNS),
+        registry=registry,
+        skipped_datasets=skipped_datasets,
+    )
+
+
+__all__ = [
+    "EMPTY_SCORECARD_COLUMNS",
+    "KEY_COLUMNS",
+    "build_cross_dataset_inventory_scorecard",
+    "build_cross_dataset_scorecard",
+    "build_cross_dataset_scorecard_report",
+    "load_dataset_factorial_outputs",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/current_vs_promoted.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/current_vs_promoted.py
@@ -242,17 +242,23 @@ def prepare_knu_bundle(
     data = load_knu_validation_data(
         forcing_path=data_contract.forcing_path,
         yield_path=data_contract.yield_path,
+        date_column=data_contract.date_column,
+        measured_column=data_contract.measured_cumulative_column,
+        estimated_column=data_contract.estimated_cumulative_column,
     )
     manifest_summary = write_knu_manifest(
         output_root=prepared_root,
         forcing_df=data.forcing_df,
         yield_df=data.yield_df,
+        date_column=data.date_column,
         measured_column=data.measured_column,
         estimated_column=data.estimated_column,
         observation_unit_label=data.observation_unit_label,
         forcing_source_path=data_contract.forcing_path,
         yield_source_path=data_contract.yield_path,
         resample_rule=resample_rule,
+        reporting_basis=data_contract.reporting_basis,
+        plants_per_m2=data_contract.plants_per_m2,
     )
     data_contract_manifest = write_data_contract_manifest(
         output_root=prepared_root,
@@ -261,8 +267,11 @@ def prepare_knu_bundle(
     )
     observed_df = observed_floor_area_yield(
         data.yield_df,
+        date_column=data.date_column,
         measured_column=data.measured_column,
         estimated_column=data.estimated_column,
+        reporting_basis=data_contract.reporting_basis,
+        plants_per_m2=data_contract.plants_per_m2,
     )
     validation_start = pd.Timestamp(observed_df["date"].min()).normalize()
     validation_end = pd.Timestamp(observed_df["date"].max()).normalize()

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/data_contract.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/data_contract.py
@@ -23,6 +23,10 @@ class KnuDataContractPaths:
     reporting_basis: str
     plants_per_m2: float
     parser_assumptions: dict[str, Any]
+    date_column: str | None = None
+    measured_cumulative_column: str | None = None
+    estimated_cumulative_column: str | None = None
+    measured_semantics: str = "cumulative_harvested_fruit_dry_weight_floor_area"
     private_data_root: str | None = None
     contract_path: Path | None = None
 
@@ -140,14 +144,28 @@ def resolve_knu_data_contract(
             + (f" and private root {private_root!r}" if private_root else f"; env {env_name!r} was not configured")
         )
 
+    observation_cfg = _as_dict(contract.get("observation"))
+    contract_parser_assumptions = _as_dict(contract.get("parser_assumptions"))
+    measured_semantics = str(
+        observation_cfg.get(
+            "measured_semantics",
+            contract.get(
+                "measured_semantics",
+                contract_parser_assumptions.get(
+                    "observation_semantics",
+                    "cumulative_harvested_fruit_dry_weight_floor_area",
+                ),
+            ),
+        )
+    )
     parser_assumptions = {
         "forcing_parser": "csv_datetime_first_class",
         "yield_parser": yield_path.suffix.lower(),
         "units_policy": "preserve_source_declared_units",
         "datetime_policy": "naive_local_greenhouse_timestamps",
-        "observation_semantics": "cumulative_harvested_fruit_dry_weight_floor_area",
-        **_as_dict(contract.get("parser_assumptions")),
+        **contract_parser_assumptions,
     }
+    parser_assumptions["observation_semantics"] = measured_semantics
     return KnuDataContractPaths(
         forcing_path=forcing_path,
         yield_path=yield_path,
@@ -155,6 +173,30 @@ def resolve_knu_data_contract(
         yield_source_kind=yield_source_kind,
         reporting_basis=str(contract.get("reporting_basis", "floor_area_g_m2")),
         plants_per_m2=float(contract.get("plants_per_m2", PLANTS_PER_M2)),
+        date_column=(
+            str(observation_cfg["date_column"])
+            if observation_cfg.get("date_column") is not None
+            else (str(contract["date_column"]) if contract.get("date_column") is not None else None)
+        ),
+        measured_cumulative_column=(
+            str(observation_cfg["measured_cumulative_column"])
+            if observation_cfg.get("measured_cumulative_column") is not None
+            else (
+                str(contract["measured_cumulative_column"])
+                if contract.get("measured_cumulative_column") is not None
+                else None
+            )
+        ),
+        estimated_cumulative_column=(
+            str(observation_cfg["estimated_cumulative_column"])
+            if observation_cfg.get("estimated_cumulative_column") is not None
+            else (
+                str(contract["estimated_cumulative_column"])
+                if contract.get("estimated_cumulative_column") is not None
+                else None
+            )
+        ),
+        measured_semantics=measured_semantics,
         parser_assumptions=parser_assumptions,
         private_data_root=private_root,
         contract_path=contract_path,
@@ -179,6 +221,7 @@ def write_data_contract_manifest(
         "reporting_basis": contract.reporting_basis,
         "plants_per_m2": contract.plants_per_m2,
         "observation_columns": {
+            "date": data.date_column,
             "measured": data.measured_column,
             "estimated": data.estimated_column,
         },

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/__init__.py
@@ -1,11 +1,19 @@
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
     DatasetManagementMetadata,
     DatasetMetadataContract,
     DatasetObservationContract,
     DatasetSanitizedFixtureContract,
+    classify_blockers,
+    derive_ingestion_status,
+    is_measured_harvest_runnable,
+    missing_required_fields,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.metadata import (
+    build_dataset_inventory_summary,
+    dataset_blocker_frame,
     dataset_metadata_payload,
     dataset_registry_frame,
     intake_priority_rows,
@@ -14,16 +22,44 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.regis
     DatasetRegistry,
     load_dataset_registry,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.runtime import (
+    CANONICAL_REPORTING_BASIS,
+    PreparedDatasetThetaScenario,
+    PreparedMeasuredHarvestBundle,
+    prepare_measured_harvest_bundle,
+    read_dataset_observation_table,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.traitenv_loader import (
+    TraitenvInventoryBundle,
+    build_traitenv_candidate_registry,
+    load_traitenv_inventory,
+)
 
 __all__ = [
+    "CANONICAL_REPORTING_BASIS",
     "DatasetBasisContract",
+    "DatasetCapability",
+    "DatasetIngestionStatus",
     "DatasetManagementMetadata",
     "DatasetMetadataContract",
     "DatasetObservationContract",
     "DatasetRegistry",
     "DatasetSanitizedFixtureContract",
+    "PreparedDatasetThetaScenario",
+    "PreparedMeasuredHarvestBundle",
+    "TraitenvInventoryBundle",
+    "build_dataset_inventory_summary",
+    "build_traitenv_candidate_registry",
+    "classify_blockers",
+    "dataset_blocker_frame",
     "dataset_metadata_payload",
     "dataset_registry_frame",
+    "derive_ingestion_status",
     "intake_priority_rows",
+    "is_measured_harvest_runnable",
     "load_dataset_registry",
+    "load_traitenv_inventory",
+    "missing_required_fields",
+    "prepare_measured_harvest_bundle",
+    "read_dataset_observation_table",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/contracts.py
@@ -1,12 +1,55 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
 
-def _normalize_reporting_basis(value: str) -> str:
-    key = str(value).strip().lower()
+class DatasetCapability(str, Enum):
+    MEASURED_HARVEST = "measured_harvest"
+    HARVEST_PROXY = "harvest_proxy"
+    CONTEXT_ONLY = "context_only"
+
+
+class DatasetIngestionStatus(str, Enum):
+    RUNNABLE = "runnable"
+    DRAFT_NEEDS_RAW_FIXTURE = "draft_needs_raw_fixture"
+    DRAFT_NEEDS_BASIS_METADATA = "draft_needs_basis_metadata"
+    DRAFT_NEEDS_HARVEST_MAPPING = "draft_needs_harvest_mapping"
+    DRAFT_BLOCKED = "draft_blocked"
+
+
+RAW_FIXTURE_BLOCKER_CODES = frozenset(
+    {
+        "missing_raw_fixture",
+        "missing_forcing_path",
+        "missing_observed_harvest_path",
+        "missing_sanitized_fixture",
+    }
+)
+BASIS_BLOCKER_CODES = frozenset({"missing_reporting_basis", "missing_plants_per_m2"})
+HARVEST_MAPPING_BLOCKER_CODES = frozenset(
+    {
+        "missing_validation_window",
+        "missing_date_column",
+        "missing_measured_cumulative_column",
+        "ambiguous_harvest_semantics",
+    }
+)
+
+
+def _normalize_optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _normalize_reporting_basis(value: str | None) -> str:
+    key = str(value or "").strip().lower()
+    if key in {"", "unknown", "na", "n/a"}:
+        return "unknown"
     if key in {"floor_area", "floor_area_g_m2", "g/m^2", "g m^-2", "g/m2"}:
         return "floor_area_g_m2"
     if key in {"per_plant", "g/plant"}:
@@ -14,21 +57,52 @@ def _normalize_reporting_basis(value: str) -> str:
     raise ValueError(f"Unsupported reporting basis {value!r}.")
 
 
+def _normalize_capability(value: DatasetCapability | str | None) -> DatasetCapability:
+    if isinstance(value, DatasetCapability):
+        return value
+    key = str(value or DatasetCapability.MEASURED_HARVEST.value).strip().lower()
+    return DatasetCapability(key)
+
+
+def _normalize_ingestion_status(value: DatasetIngestionStatus | str | None) -> DatasetIngestionStatus | None:
+    if value is None:
+        return None
+    if isinstance(value, DatasetIngestionStatus):
+        return value
+    return DatasetIngestionStatus(str(value).strip().lower())
+
+
 @dataclass(frozen=True, slots=True)
 class DatasetBasisContract:
-    reporting_basis: str
-    plants_per_m2: float
-    basis_unit_label: str = "g/m^2"
+    reporting_basis: str = "unknown"
+    plants_per_m2: float | None = None
+    basis_unit_label: str = "unknown"
 
     def __post_init__(self) -> None:
         normalized = _normalize_reporting_basis(self.reporting_basis)
         object.__setattr__(self, "reporting_basis", normalized)
-        if float(self.plants_per_m2) <= 0.0:
-            raise ValueError("plants_per_m2 must be positive.")
+        plants_per_m2 = None if self.plants_per_m2 in (None, "") else float(self.plants_per_m2)
+        if plants_per_m2 is not None and plants_per_m2 <= 0.0:
+            raise ValueError("plants_per_m2 must be positive when provided.")
+        if normalized == "g_per_plant" and plants_per_m2 is None:
+            raise ValueError("plants_per_m2 is required for per-plant reporting.")
+        object.__setattr__(self, "plants_per_m2", plants_per_m2)
         if normalized == "floor_area_g_m2":
             object.__setattr__(self, "basis_unit_label", "g/m^2")
         elif normalized == "g_per_plant":
             object.__setattr__(self, "basis_unit_label", "g/plant")
+        else:
+            object.__setattr__(self, "basis_unit_label", "unknown")
+
+    @property
+    def requires_plant_density(self) -> bool:
+        return self.reporting_basis == "g_per_plant"
+
+    @property
+    def normalization_resolved(self) -> bool:
+        return self.reporting_basis == "floor_area_g_m2" or (
+            self.reporting_basis == "g_per_plant" and self.plants_per_m2 is not None
+        )
 
     def to_payload(self) -> dict[str, Any]:
         return asdict(self)
@@ -36,17 +110,30 @@ class DatasetBasisContract:
 
 @dataclass(frozen=True, slots=True)
 class DatasetObservationContract:
-    date_column: str
-    measured_cumulative_column: str
+    date_column: str | None = None
+    measured_cumulative_column: str | None = None
     estimated_cumulative_column: str | None = None
     measured_semantics: str = "cumulative_harvested_fruit_dry_weight_floor_area"
     daily_increment_column: str | None = None
 
     def __post_init__(self) -> None:
-        if not str(self.date_column).strip():
-            raise ValueError("date_column is required.")
-        if not str(self.measured_cumulative_column).strip():
-            raise ValueError("measured_cumulative_column is required.")
+        object.__setattr__(self, "date_column", _normalize_optional_text(self.date_column))
+        object.__setattr__(
+            self,
+            "measured_cumulative_column",
+            _normalize_optional_text(self.measured_cumulative_column),
+        )
+        object.__setattr__(
+            self,
+            "estimated_cumulative_column",
+            _normalize_optional_text(self.estimated_cumulative_column),
+        )
+        object.__setattr__(self, "daily_increment_column", _normalize_optional_text(self.daily_increment_column))
+        object.__setattr__(self, "measured_semantics", str(self.measured_semantics or "").strip())
+
+    @property
+    def has_explicit_cumulative_mapping(self) -> bool:
+        return self.date_column is not None and self.measured_cumulative_column is not None
 
     def to_payload(self) -> dict[str, Any]:
         return asdict(self)
@@ -61,6 +148,18 @@ class DatasetManagementMetadata:
     ec_path: Path | None = None
     rootzone_path: Path | None = None
 
+    def __post_init__(self) -> None:
+        for field_name in (
+            "pruning_records_path",
+            "defoliation_records_path",
+            "harvest_timing_records_path",
+            "irrigation_path",
+            "ec_path",
+            "rootzone_path",
+        ):
+            raw = getattr(self, field_name)
+            object.__setattr__(self, field_name, Path(raw) if raw not in (None, "") else None)
+
     def to_payload(self) -> dict[str, Any]:
         payload = asdict(self)
         for key, value in list(payload.items()):
@@ -74,6 +173,22 @@ class DatasetSanitizedFixtureContract:
     forcing_fixture_path: Path | None = None
     observed_harvest_fixture_path: Path | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "forcing_fixture_path",
+            Path(self.forcing_fixture_path) if self.forcing_fixture_path not in (None, "") else None,
+        )
+        object.__setattr__(
+            self,
+            "observed_harvest_fixture_path",
+            Path(self.observed_harvest_fixture_path) if self.observed_harvest_fixture_path not in (None, "") else None,
+        )
+
+    @property
+    def is_complete(self) -> bool:
+        return self.forcing_fixture_path is not None and self.observed_harvest_fixture_path is not None
+
     def to_payload(self) -> dict[str, Any]:
         payload = asdict(self)
         for key, value in list(payload.items()):
@@ -86,18 +201,25 @@ class DatasetMetadataContract:
     dataset_id: str
     dataset_kind: str
     display_name: str
-    forcing_path: Path
-    observed_harvest_path: Path
-    validation_start: str
-    validation_end: str
-    cultivar: str
-    greenhouse: str
-    season: str
-    basis: DatasetBasisContract
-    observation: DatasetObservationContract
+    forcing_path: Path | None = None
+    observed_harvest_path: Path | None = None
+    validation_start: str | None = None
+    validation_end: str | None = None
+    cultivar: str = "unknown"
+    greenhouse: str = "unknown"
+    season: str = "unknown"
+    dataset_family: str = ""
+    observation_family: str = ""
+    capability: DatasetCapability | str | None = None
+    ingestion_status: DatasetIngestionStatus | str | None = None
+    source_refs: tuple[str, ...] = ()
+    basis: DatasetBasisContract = field(default_factory=DatasetBasisContract)
+    observation: DatasetObservationContract = field(default_factory=DatasetObservationContract)
     management: DatasetManagementMetadata = field(default_factory=DatasetManagementMetadata)
     sanitized_fixture: DatasetSanitizedFixtureContract = field(default_factory=DatasetSanitizedFixtureContract)
     priority_tags: tuple[str, ...] = ()
+    blocker_codes: tuple[str, ...] = ()
+    provenance_tags: tuple[str, ...] = ()
     notes: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -107,11 +229,41 @@ class DatasetMetadataContract:
             raise ValueError("dataset_kind is required.")
         if not str(self.display_name).strip():
             raise ValueError("display_name is required.")
-        if not str(self.validation_start).strip() or not str(self.validation_end).strip():
-            raise ValueError("validation_start and validation_end are required.")
-        object.__setattr__(self, "forcing_path", Path(self.forcing_path))
-        object.__setattr__(self, "observed_harvest_path", Path(self.observed_harvest_path))
-        object.__setattr__(self, "priority_tags", tuple(str(tag) for tag in self.priority_tags if str(tag).strip()))
+
+        forcing_path = Path(self.forcing_path) if self.forcing_path not in (None, "") else None
+        observed_harvest_path = (
+            Path(self.observed_harvest_path) if self.observed_harvest_path not in (None, "") else None
+        )
+        object.__setattr__(self, "forcing_path", forcing_path)
+        object.__setattr__(self, "observed_harvest_path", observed_harvest_path)
+        object.__setattr__(self, "validation_start", _normalize_optional_text(self.validation_start))
+        object.__setattr__(self, "validation_end", _normalize_optional_text(self.validation_end))
+        object.__setattr__(self, "dataset_family", str(self.dataset_family or "").strip())
+        object.__setattr__(self, "observation_family", str(self.observation_family or "").strip())
+        object.__setattr__(self, "capability", _normalize_capability(self.capability))
+        object.__setattr__(
+            self,
+            "priority_tags",
+            tuple(str(tag) for tag in self.priority_tags if str(tag).strip()),
+        )
+        object.__setattr__(
+            self,
+            "source_refs",
+            tuple(str(ref) for ref in self.source_refs if str(ref).strip()),
+        )
+        object.__setattr__(
+            self,
+            "provenance_tags",
+            tuple(str(tag) for tag in self.provenance_tags if str(tag).strip()),
+        )
+        explicit_blockers = tuple(str(code) for code in self.blocker_codes if str(code).strip())
+        derived_blockers = tuple(classify_blockers(self))
+        merged_blockers = tuple(sorted(set(explicit_blockers) | set(derived_blockers)))
+        object.__setattr__(self, "blocker_codes", merged_blockers)
+        normalized_status = _normalize_ingestion_status(self.ingestion_status)
+        if normalized_status is None:
+            normalized_status = derive_ingestion_status(self.capability, merged_blockers)
+        object.__setattr__(self, "ingestion_status", normalized_status)
 
     @property
     def has_management_records(self) -> bool:
@@ -124,13 +276,30 @@ class DatasetMetadataContract:
             )
         )
 
+    @property
+    def sanitized_fixture_path(self) -> Path | None:
+        if self.sanitized_fixture.is_complete:
+            return self.sanitized_fixture.forcing_fixture_path.parent
+        return None
+
+    @property
+    def is_runnable_measured_harvest(self) -> bool:
+        return is_measured_harvest_runnable(self)
+
     def to_payload(self) -> dict[str, Any]:
         return {
             "dataset_id": self.dataset_id,
             "dataset_kind": self.dataset_kind,
             "display_name": self.display_name,
-            "forcing_path": str(self.forcing_path),
-            "observed_harvest_path": str(self.observed_harvest_path),
+            "dataset_family": self.dataset_family,
+            "observation_family": self.observation_family,
+            "capability": self.capability.value,
+            "ingestion_status": self.ingestion_status.value,
+            "source_refs": list(self.source_refs),
+            "forcing_path": str(self.forcing_path) if self.forcing_path is not None else None,
+            "observed_harvest_path": (
+                str(self.observed_harvest_path) if self.observed_harvest_path is not None else None
+            ),
             "validation_start": self.validation_start,
             "validation_end": self.validation_end,
             "cultivar": self.cultivar,
@@ -140,15 +309,125 @@ class DatasetMetadataContract:
             "observation": self.observation.to_payload(),
             "management": self.management.to_payload(),
             "sanitized_fixture": self.sanitized_fixture.to_payload(),
+            "sanitized_fixture_path": (
+                str(self.sanitized_fixture_path) if self.sanitized_fixture_path is not None else None
+            ),
             "priority_tags": list(self.priority_tags),
+            "blocker_codes": list(self.blocker_codes),
+            "provenance_tags": list(self.provenance_tags),
             "notes": dict(self.notes),
         }
 
 
+def missing_required_fields(dataset: DatasetMetadataContract) -> list[str]:
+    missing: list[str] = []
+    if dataset.forcing_path is None:
+        missing.append("forcing_path")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and dataset.observed_harvest_path is None:
+        missing.append("observed_harvest_path")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and not dataset.validation_start:
+        missing.append("validation_start")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and not dataset.validation_end:
+        missing.append("validation_end")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and dataset.basis.reporting_basis == "unknown":
+        missing.append("reporting_basis")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and dataset.basis.requires_plant_density:
+        if dataset.basis.plants_per_m2 is None:
+            missing.append("plants_per_m2")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and dataset.observation.date_column is None:
+        missing.append("date_column")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and dataset.observation.measured_cumulative_column is None:
+        missing.append("measured_cumulative_column")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST and not dataset.sanitized_fixture.is_complete:
+        missing.append("sanitized_fixture")
+    return missing
+
+
+def classify_blockers(dataset: DatasetMetadataContract) -> list[str]:
+    blockers: list[str] = []
+    if dataset.forcing_path is None and dataset.observed_harvest_path is None and not dataset.sanitized_fixture.is_complete:
+        blockers.append("missing_raw_fixture")
+    elif dataset.forcing_path is None:
+        blockers.append("missing_forcing_path")
+    if dataset.capability is DatasetCapability.MEASURED_HARVEST:
+        if dataset.observed_harvest_path is None:
+            blockers.append("missing_observed_harvest_path")
+        if dataset.basis.reporting_basis == "unknown":
+            blockers.append("missing_reporting_basis")
+        if dataset.basis.requires_plant_density and dataset.basis.plants_per_m2 is None:
+            blockers.append("missing_plants_per_m2")
+        if not dataset.validation_start or not dataset.validation_end:
+            blockers.append("missing_validation_window")
+        if dataset.observation.date_column is None:
+            blockers.append("missing_date_column")
+        if dataset.observation.measured_cumulative_column is None:
+            blockers.append("missing_measured_cumulative_column")
+        semantics = dataset.observation.measured_semantics.strip().lower()
+        if "cumulative_harvested" not in semantics:
+            blockers.append("ambiguous_harvest_semantics")
+        if not dataset.sanitized_fixture.is_complete:
+            blockers.append("missing_sanitized_fixture")
+    return sorted(set(blockers))
+
+
+def derive_ingestion_status(
+    capability: DatasetCapability | str,
+    blocker_codes: list[str] | tuple[str, ...],
+) -> DatasetIngestionStatus:
+    del capability
+    blocker_set = {str(code) for code in blocker_codes if str(code).strip()}
+    if not blocker_set:
+        return DatasetIngestionStatus.RUNNABLE
+    if blocker_set & RAW_FIXTURE_BLOCKER_CODES:
+        return DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE
+    if blocker_set & BASIS_BLOCKER_CODES:
+        return DatasetIngestionStatus.DRAFT_NEEDS_BASIS_METADATA
+    if blocker_set & HARVEST_MAPPING_BLOCKER_CODES:
+        return DatasetIngestionStatus.DRAFT_NEEDS_HARVEST_MAPPING
+    return DatasetIngestionStatus.DRAFT_BLOCKED
+
+
+def infer_ingestion_status(
+    *,
+    capability: DatasetCapability | str,
+    blocker_codes: list[str] | tuple[str, ...],
+    has_source_refs: bool | None = None,
+) -> DatasetIngestionStatus:
+    del has_source_refs
+    return derive_ingestion_status(capability, blocker_codes)
+
+
+def is_measured_harvest_runnable(dataset: DatasetMetadataContract) -> bool:
+    if dataset.capability is not DatasetCapability.MEASURED_HARVEST:
+        return False
+    if dataset.ingestion_status is not DatasetIngestionStatus.RUNNABLE:
+        return False
+    if classify_blockers(dataset):
+        return False
+    semantics = dataset.observation.measured_semantics.strip().lower()
+    return (
+        dataset.forcing_path is not None
+        and dataset.observed_harvest_path is not None
+        and dataset.validation_start is not None
+        and dataset.validation_end is not None
+        and dataset.observation.has_explicit_cumulative_mapping
+        and dataset.basis.normalization_resolved
+        and "cumulative_harvested" in semantics
+        and dataset.sanitized_fixture.is_complete
+    )
+
+
 __all__ = [
     "DatasetBasisContract",
+    "DatasetCapability",
+    "DatasetIngestionStatus",
     "DatasetManagementMetadata",
     "DatasetMetadataContract",
     "DatasetObservationContract",
     "DatasetSanitizedFixtureContract",
+    "classify_blockers",
+    "derive_ingestion_status",
+    "infer_ingestion_status",
+    "is_measured_harvest_runnable",
+    "missing_required_fields",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py
@@ -1,13 +1,72 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
+    DatasetManagementMetadata,
     DatasetMetadataContract,
+    DatasetObservationContract,
+    is_measured_harvest_runnable,
 )
+
+
+def normalize_basis_metadata(
+    *,
+    reporting_basis: str | None = None,
+    plants_per_m2: float | None = None,
+) -> DatasetBasisContract:
+    return DatasetBasisContract(reporting_basis=reporting_basis or "unknown", plants_per_m2=plants_per_m2)
+
+
+def normalize_observation_metadata(
+    *,
+    date_column: str | None = None,
+    measured_cumulative_column: str | None = None,
+    estimated_cumulative_column: str | None = None,
+    measured_semantics: str = "cumulative_harvested_fruit_dry_weight_floor_area",
+    daily_increment_column: str | None = None,
+) -> DatasetObservationContract:
+    return DatasetObservationContract(
+        date_column=date_column,
+        measured_cumulative_column=measured_cumulative_column,
+        estimated_cumulative_column=estimated_cumulative_column,
+        measured_semantics=measured_semantics,
+        daily_increment_column=daily_increment_column,
+    )
+
+
+def normalize_label(value: object, *, default: str = "unknown") -> str:
+    text = str(value).strip() if value is not None else ""
+    return text or default
+
+
+def normalize_management_metadata(
+    *,
+    pruning_records_path: str | Path | None = None,
+    defoliation_records_path: str | Path | None = None,
+    harvest_timing_records_path: str | Path | None = None,
+    irrigation_path: str | Path | None = None,
+    ec_path: str | Path | None = None,
+    rootzone_path: str | Path | None = None,
+) -> DatasetManagementMetadata:
+    def _maybe_path(raw: str | Path | None) -> Path | None:
+        return Path(raw) if raw not in (None, "") else None
+
+    return DatasetManagementMetadata(
+        pruning_records_path=_maybe_path(pruning_records_path),
+        defoliation_records_path=_maybe_path(defoliation_records_path),
+        harvest_timing_records_path=_maybe_path(harvest_timing_records_path),
+        irrigation_path=_maybe_path(irrigation_path),
+        ec_path=_maybe_path(ec_path),
+        rootzone_path=_maybe_path(rootzone_path),
+    )
 
 
 def dataset_metadata_payload(dataset: DatasetMetadataContract) -> dict[str, Any]:
@@ -26,6 +85,8 @@ def dataset_metadata_payload(dataset: DatasetMetadataContract) -> dict[str, Any]
         )
     )
     payload["has_management_records"] = dataset.has_management_records
+    payload["is_runnable_measured_harvest"] = is_measured_harvest_runnable(dataset)
+    payload["basis_normalization_resolved"] = dataset.basis.normalization_resolved
     return payload
 
 
@@ -38,22 +99,215 @@ def dataset_registry_frame(datasets: list[DatasetMetadataContract]) -> pd.DataFr
                 "dataset_id": payload["dataset_id"],
                 "dataset_kind": payload["dataset_kind"],
                 "display_name": payload["display_name"],
+                "dataset_family": payload["dataset_family"],
+                "observation_family": payload["observation_family"],
+                "capability": payload["capability"],
+                "ingestion_status": payload["ingestion_status"],
+                "is_runnable_measured_harvest": payload["is_runnable_measured_harvest"],
                 "reporting_basis": payload["basis"]["reporting_basis"],
                 "plants_per_m2": payload["basis"]["plants_per_m2"],
                 "basis_unit_label": payload["basis"]["basis_unit_label"],
+                "basis_normalization_resolved": payload["basis_normalization_resolved"],
                 "validation_start": payload["validation_start"],
                 "validation_end": payload["validation_end"],
+                "date_column": payload["observation"]["date_column"],
+                "measured_cumulative_column": payload["observation"]["measured_cumulative_column"],
                 "cultivar": payload["cultivar"],
                 "greenhouse": payload["greenhouse"],
                 "season": payload["season"],
+                "source_refs": json.dumps(payload["source_refs"], sort_keys=True),
                 "priority_tags": json.dumps(payload["priority_tags"], sort_keys=True),
+                "blocker_codes": json.dumps(payload["blocker_codes"], sort_keys=True),
+                "provenance_tags": json.dumps(payload["provenance_tags"], sort_keys=True),
                 "has_management_records": payload["has_management_records"],
                 "management_record_count": payload["management_record_count"],
                 "forcing_path": payload["forcing_path"],
                 "observed_harvest_path": payload["observed_harvest_path"],
+                "sanitized_fixture_path": payload["sanitized_fixture_path"],
             }
         )
     return pd.DataFrame(rows)
+
+
+def dataset_blocker_frame(datasets: list[DatasetMetadataContract]) -> pd.DataFrame:
+    columns = [
+        "dataset_id",
+        "dataset_kind",
+        "dataset_family",
+        "observation_family",
+        "capability",
+        "ingestion_status",
+        "blocker_code",
+    ]
+    rows: list[dict[str, Any]] = []
+    for dataset in datasets:
+        for blocker_code in dataset.blocker_codes:
+            rows.append(
+                {
+                    "dataset_id": dataset.dataset_id,
+                    "dataset_kind": dataset.dataset_kind,
+                    "dataset_family": dataset.dataset_family,
+                    "observation_family": dataset.observation_family,
+                    "capability": dataset.capability.value,
+                    "ingestion_status": dataset.ingestion_status.value,
+                    "blocker_code": blocker_code,
+                }
+            )
+    return pd.DataFrame(rows, columns=columns)
+
+
+def dataset_blocker_rows(datasets: list[DatasetMetadataContract]) -> list[dict[str, Any]]:
+    return dataset_blocker_frame(datasets).to_dict(orient="records")
+
+
+BLOCKER_ACTIONS = {
+    "missing_raw_fixture": "Add a reproducible raw-to-sanitized fixture path or sanitized fixture pair before promotion use.",
+    "missing_forcing_path": "Declare a forcing source that covers the validation window.",
+    "missing_observed_harvest_path": "Declare the observed harvest source for this dataset candidate.",
+    "missing_sanitized_fixture": "Create or point to a sanitized forcing/harvest fixture pair.",
+    "missing_reporting_basis": "Set reporting_basis explicitly and keep floor-area vs per-plant provenance explicit.",
+    "missing_plants_per_m2": "Provide plants_per_m2 before any per-plant dataset can become runnable.",
+    "missing_validation_window": "Set validation_start and validation_end for the measured-harvest window.",
+    "missing_date_column": "Map the standardized observation date column explicitly.",
+    "missing_measured_cumulative_column": (
+        "Map or losslessly construct a cumulative harvested-fruit column from the standardized harvest signal."
+    ),
+    "ambiguous_harvest_semantics": (
+        "Clarify that the measured target is cumulative harvested fruit dry weight, not latent or on-plant fruit mass."
+    ),
+}
+
+
+def blocker_action_items(blocker_codes: list[str] | tuple[str, ...]) -> list[str]:
+    actions: list[str] = []
+    for blocker_code in blocker_codes:
+        action = BLOCKER_ACTIONS.get(str(blocker_code))
+        if action is not None and action not in actions:
+            actions.append(action)
+    return actions
+
+
+def build_dataset_review_template(dataset: DatasetMetadataContract) -> dict[str, Any]:
+    payload = dataset.to_payload()
+    candidate_schema_hints = {
+        key: payload["notes"][key]
+        for key in (
+            "candidate_date_key",
+            "candidate_harvest_column",
+            "candidate_harvest_requires_cumulative_construction",
+            "candidate_harvest_includes_fallen_fruit",
+            "comparison_daily_standard_names",
+            "traitenv_bundle_ref",
+        )
+        if key in payload["notes"]
+    }
+    return {
+        "dataset_id": dataset.dataset_id,
+        "dataset_family": dataset.dataset_family,
+        "observation_family": dataset.observation_family,
+        "capability": dataset.capability.value,
+        "ingestion_status": dataset.ingestion_status.value,
+        "source_refs": list(dataset.source_refs),
+        "blocker_codes": list(dataset.blocker_codes),
+        "next_actions": blocker_action_items(dataset.blocker_codes),
+        "candidate_schema_hints": candidate_schema_hints,
+        "promotion_ready_checklist": {
+            "forcing_path": dataset.forcing_path is not None,
+            "observed_harvest_path": dataset.observed_harvest_path is not None,
+            "validation_window": bool(dataset.validation_start and dataset.validation_end),
+            "reporting_basis": dataset.basis.reporting_basis != "unknown",
+            "plants_per_m2": (
+                True if not dataset.basis.requires_plant_density else dataset.basis.plants_per_m2 is not None
+            ),
+            "date_column": dataset.observation.date_column is not None,
+            "measured_cumulative_column": dataset.observation.measured_cumulative_column is not None,
+            "sanitized_fixture_pair": dataset.sanitized_fixture.is_complete,
+        },
+        "review_updates": {
+            "forcing_path": payload["forcing_path"],
+            "observed_harvest_path": payload["observed_harvest_path"],
+            "validation_start": payload["validation_start"],
+            "validation_end": payload["validation_end"],
+            "basis": {
+                "reporting_basis": payload["basis"]["reporting_basis"],
+                "plants_per_m2": payload["basis"]["plants_per_m2"],
+            },
+            "observation": {
+                "date_column": payload["observation"]["date_column"],
+                "measured_cumulative_column": payload["observation"]["measured_cumulative_column"],
+                "estimated_cumulative_column": payload["observation"]["estimated_cumulative_column"],
+                "daily_increment_column": payload["observation"]["daily_increment_column"],
+                "measured_semantics": payload["observation"]["measured_semantics"],
+            },
+            "sanitized_fixture": {
+                "forcing_fixture_path": payload["sanitized_fixture"]["forcing_fixture_path"],
+                "observed_harvest_fixture_path": payload["sanitized_fixture"]["observed_harvest_fixture_path"],
+            },
+            "notes": {
+                "review_status": "todo",
+                "basis_provenance_note": None,
+                "cumulative_mapping_note": None,
+                "fixture_provenance_note": None,
+            },
+        },
+    }
+
+
+def build_dataset_blocker_report(datasets: list[DatasetMetadataContract]) -> str:
+    summary = build_dataset_inventory_summary(datasets)
+    measured_candidates = [
+        dataset
+        for dataset in datasets
+        if dataset.capability is DatasetCapability.MEASURED_HARVEST and not dataset.is_runnable_measured_harvest
+    ]
+    proxy_candidates = [
+        dataset for dataset in datasets if dataset.capability is DatasetCapability.HARVEST_PROXY
+    ]
+    lines = [
+        "# Dataset Intake Blocker Report",
+        "",
+        f"Total registry datasets: {summary['total_registry_datasets']}",
+        f"Runnable measured-harvest datasets: {summary['runnable_measured_harvest_datasets']}",
+        f"Measured-harvest candidates still blocked: {len(measured_candidates)}",
+        f"Harvest-proxy candidates: {len(proxy_candidates)}",
+        "",
+    ]
+    if not measured_candidates and not proxy_candidates:
+        lines.extend(
+            [
+                "No blocked measured-harvest or harvest-proxy candidates are present in the registry.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+    for dataset in measured_candidates:
+        lines.extend(
+            [
+                f"## {dataset.dataset_id}",
+                f"- capability: `{dataset.capability.value}`",
+                f"- ingestion_status: `{dataset.ingestion_status.value}`",
+                f"- blocker_codes: `{', '.join(dataset.blocker_codes)}`",
+            ]
+        )
+        for action in blocker_action_items(dataset.blocker_codes):
+            lines.append(f"- next_action: {action}")
+        candidate_harvest_column = dataset.observation.daily_increment_column or dataset.notes.get("candidate_harvest_column")
+        if candidate_harvest_column is not None:
+            lines.append(
+                f"- schema_hint: standardized daily harvest signal `{candidate_harvest_column}` is available but cumulative mapping is not yet resolved."
+            )
+        lines.append("")
+    for dataset in proxy_candidates:
+        lines.extend(
+            [
+                f"## {dataset.dataset_id}",
+                f"- capability: `{dataset.capability.value}`",
+                f"- ingestion_status: `{dataset.ingestion_status.value}`",
+                "- next_action: keep this dataset out of the measured-harvest promotion denominator until an explicit cumulative harvest contract exists.",
+                "",
+            ]
+        )
+    return "\n".join(lines)
 
 
 def intake_priority_rows(datasets: list[DatasetMetadataContract]) -> list[dict[str, Any]]:
@@ -63,7 +317,11 @@ def intake_priority_rows(datasets: list[DatasetMetadataContract]) -> list[dict[s
             {
                 "dataset_id": dataset.dataset_id,
                 "display_name": dataset.display_name,
-                "priority_tags": list(dataset.priority_tags),
+                "dataset_family": dataset.dataset_family,
+                "observation_family": dataset.observation_family,
+                "capability": dataset.capability.value,
+                "ingestion_status": dataset.ingestion_status.value,
+                "is_runnable_measured_harvest": is_measured_harvest_runnable(dataset),
                 "has_management_records": dataset.has_management_records,
                 "has_irrigation_or_rootzone": any(
                     value is not None
@@ -73,9 +331,69 @@ def intake_priority_rows(datasets: list[DatasetMetadataContract]) -> list[dict[s
                         dataset.management.rootzone_path,
                     )
                 ),
+                "priority_tags": list(dataset.priority_tags),
+                "blocker_codes": list(dataset.blocker_codes),
             }
         )
     return rows
 
 
-__all__ = ["dataset_metadata_payload", "dataset_registry_frame", "intake_priority_rows"]
+def build_dataset_inventory_summary(datasets: list[DatasetMetadataContract]) -> dict[str, Any]:
+    total_registry_datasets = len(datasets)
+    capability_counts = {
+        capability.value: sum(dataset.capability is capability for dataset in datasets)
+        for capability in DatasetCapability
+    }
+    ingestion_status_counts = {
+        status.value: sum(dataset.ingestion_status is status for dataset in datasets)
+        for status in DatasetIngestionStatus
+    }
+    return {
+        "total_registry_datasets": total_registry_datasets,
+        "runnable_measured_harvest_datasets": sum(is_measured_harvest_runnable(dataset) for dataset in datasets),
+        "proxy_datasets": capability_counts[DatasetCapability.HARVEST_PROXY.value],
+        "context_only_datasets": capability_counts[DatasetCapability.CONTEXT_ONLY.value],
+        "blocked_by_missing_raw_fixture": sum(
+            "missing_raw_fixture" in dataset.blocker_codes
+            or "missing_forcing_path" in dataset.blocker_codes
+            or "missing_observed_harvest_path" in dataset.blocker_codes
+            or "missing_sanitized_fixture" in dataset.blocker_codes
+            for dataset in datasets
+        ),
+        "blocked_by_missing_basis_or_density": sum(
+            "missing_reporting_basis" in dataset.blocker_codes or "missing_plants_per_m2" in dataset.blocker_codes
+            for dataset in datasets
+        ),
+        "blocked_by_missing_cumulative_mapping": sum(
+            "missing_validation_window" in dataset.blocker_codes
+            or "missing_date_column" in dataset.blocker_codes
+            or "missing_measured_cumulative_column" in dataset.blocker_codes
+            or "ambiguous_harvest_semantics" in dataset.blocker_codes
+            for dataset in datasets
+        ),
+        "capability_counts": capability_counts,
+        "ingestion_status_counts": ingestion_status_counts,
+    }
+
+
+def registry_capability_summary(datasets: list[DatasetMetadataContract]) -> dict[str, Any]:
+    return build_dataset_inventory_summary(datasets)
+
+
+__all__ = [
+    "BLOCKER_ACTIONS",
+    "blocker_action_items",
+    "build_dataset_review_template",
+    "build_dataset_inventory_summary",
+    "build_dataset_blocker_report",
+    "dataset_blocker_frame",
+    "dataset_blocker_rows",
+    "dataset_metadata_payload",
+    "dataset_registry_frame",
+    "intake_priority_rows",
+    "normalize_basis_metadata",
+    "normalize_label",
+    "normalize_management_metadata",
+    "normalize_observation_metadata",
+    "registry_capability_summary",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from pathlib import Path
 from typing import Any
 
@@ -11,12 +12,17 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.data_contract 
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
     DatasetManagementMetadata,
     DatasetMetadataContract,
     DatasetObservationContract,
     DatasetSanitizedFixtureContract,
+    is_measured_harvest_runnable,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.metadata import (
+    dataset_blocker_frame,
+    build_dataset_inventory_summary,
     dataset_registry_frame,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.knu_data import (
@@ -36,9 +42,19 @@ def _as_list(raw: object) -> list[Any]:
     return []
 
 
-def _resolve_config_path(raw: str | Path, *, repo_root: Path, config_path: Path) -> Path:
+def _resolve_config_path(
+    raw: str | Path | None,
+    *,
+    repo_root: Path,
+    config_path: Path,
+    require_exists: bool = False,
+) -> Path | None:
+    if raw in (None, ""):
+        return None
     candidate = Path(raw)
     if candidate.is_absolute():
+        if require_exists and not candidate.exists():
+            return None
         return candidate
     probes = [
         (config_path.parent / candidate).resolve(),
@@ -47,13 +63,23 @@ def _resolve_config_path(raw: str | Path, *, repo_root: Path, config_path: Path)
     for probe in probes:
         if probe.exists():
             return probe
+    if require_exists:
+        return None
     return probes[1]
 
 
-def _optional_path(raw: object, *, repo_root: Path, config_path: Path) -> Path | None:
-    if raw in (None, ""):
-        return None
-    return _resolve_config_path(str(raw), repo_root=repo_root, config_path=config_path)
+def _default_capability(raw: dict[str, Any]) -> str:
+    notes = _as_dict(raw.get("notes"))
+    capability = str(raw.get("capability") or notes.get("capability") or "").strip().lower()
+    if capability:
+        return capability
+    dataset_kind = str(raw.get("dataset_kind", "")).strip().lower()
+    observation_family = str(raw.get("observation_family") or notes.get("observation_family") or "").strip().lower()
+    if "proxy" in dataset_kind or "yield_environment" in observation_family:
+        return DatasetCapability.HARVEST_PROXY.value
+    if "environment" in dataset_kind or "context" in dataset_kind or "metadata" in dataset_kind:
+        return DatasetCapability.CONTEXT_ONLY.value
+    return DatasetCapability.MEASURED_HARVEST.value
 
 
 def _build_dataset_from_config(
@@ -66,74 +92,109 @@ def _build_dataset_from_config(
     observation_cfg = _as_dict(raw.get("observation"))
     management_cfg = _as_dict(raw.get("management"))
     fixture_cfg = _as_dict(raw.get("sanitized_fixture"))
+    notes = _as_dict(raw.get("notes"))
+    dataset_id = str(raw["dataset_id"])
+    dataset_kind = str(raw.get("dataset_kind", dataset_id))
+    display_name = str(raw.get("display_name", dataset_id))
     return DatasetMetadataContract(
-        dataset_id=str(raw["dataset_id"]),
-        dataset_kind=str(raw.get("dataset_kind", raw["dataset_id"])),
-        display_name=str(raw.get("display_name", raw["dataset_id"])),
-        forcing_path=_resolve_config_path(str(raw["forcing_path"]), repo_root=repo_root, config_path=config_path),
-        observed_harvest_path=_resolve_config_path(
-            str(raw["observed_harvest_path"]),
+        dataset_id=dataset_id,
+        dataset_kind=dataset_kind,
+        display_name=display_name,
+        dataset_family=str(raw.get("dataset_family") or notes.get("dataset_family") or dataset_kind),
+        observation_family=str(raw.get("observation_family") or notes.get("observation_family") or ""),
+        capability=str(raw.get("capability") or _default_capability(raw)),
+        ingestion_status=raw.get("ingestion_status"),
+        source_refs=tuple(str(value) for value in _as_list(raw.get("source_refs"))),
+        forcing_path=_resolve_config_path(
+            raw.get("forcing_path"),
             repo_root=repo_root,
             config_path=config_path,
+            require_exists=True,
         ),
-        validation_start=str(raw["validation_start"]),
-        validation_end=str(raw["validation_end"]),
+        observed_harvest_path=_resolve_config_path(
+            raw.get("observed_harvest_path"),
+            repo_root=repo_root,
+            config_path=config_path,
+            require_exists=True,
+        ),
+        validation_start=raw.get("validation_start"),
+        validation_end=raw.get("validation_end"),
         cultivar=str(raw.get("cultivar", "unknown")),
         greenhouse=str(raw.get("greenhouse", "unknown")),
         season=str(raw.get("season", "unknown")),
         basis=DatasetBasisContract(
-            reporting_basis=str(basis_cfg.get("reporting_basis", "floor_area_g_m2")),
-            plants_per_m2=float(basis_cfg.get("plants_per_m2", 1.0)),
+            reporting_basis=str(basis_cfg.get("reporting_basis", "unknown")),
+            plants_per_m2=basis_cfg.get("plants_per_m2"),
         ),
         observation=DatasetObservationContract(
-            date_column=str(observation_cfg.get("date_column", "date")),
-            measured_cumulative_column=str(
-                observation_cfg.get("measured_cumulative_column", "measured_cumulative_total_fruit_dry_weight_floor_area")
-            ),
-            estimated_cumulative_column=(
-                str(observation_cfg["estimated_cumulative_column"])
-                if observation_cfg.get("estimated_cumulative_column") is not None
-                else None
-            ),
+            date_column=observation_cfg.get("date_column"),
+            measured_cumulative_column=observation_cfg.get("measured_cumulative_column"),
+            estimated_cumulative_column=observation_cfg.get("estimated_cumulative_column"),
             measured_semantics=str(
                 observation_cfg.get(
                     "measured_semantics",
                     "cumulative_harvested_fruit_dry_weight_floor_area",
                 )
             ),
-            daily_increment_column=(
-                str(observation_cfg["daily_increment_column"])
-                if observation_cfg.get("daily_increment_column") is not None
-                else None
-            ),
+            daily_increment_column=observation_cfg.get("daily_increment_column"),
         ),
         management=DatasetManagementMetadata(
-            pruning_records_path=_optional_path(management_cfg.get("pruning_records_path"), repo_root=repo_root, config_path=config_path),
-            defoliation_records_path=_optional_path(
+            pruning_records_path=_resolve_config_path(
+                management_cfg.get("pruning_records_path"),
+                repo_root=repo_root,
+                config_path=config_path,
+                require_exists=True,
+            ),
+            defoliation_records_path=_resolve_config_path(
                 management_cfg.get("defoliation_records_path"),
                 repo_root=repo_root,
                 config_path=config_path,
+                require_exists=True,
             ),
-            harvest_timing_records_path=_optional_path(
+            harvest_timing_records_path=_resolve_config_path(
                 management_cfg.get("harvest_timing_records_path"),
                 repo_root=repo_root,
                 config_path=config_path,
+                require_exists=True,
             ),
-            irrigation_path=_optional_path(management_cfg.get("irrigation_path"), repo_root=repo_root, config_path=config_path),
-            ec_path=_optional_path(management_cfg.get("ec_path"), repo_root=repo_root, config_path=config_path),
-            rootzone_path=_optional_path(management_cfg.get("rootzone_path"), repo_root=repo_root, config_path=config_path),
+            irrigation_path=_resolve_config_path(
+                management_cfg.get("irrigation_path"),
+                repo_root=repo_root,
+                config_path=config_path,
+                require_exists=True,
+            ),
+            ec_path=_resolve_config_path(
+                management_cfg.get("ec_path"),
+                repo_root=repo_root,
+                config_path=config_path,
+                require_exists=True,
+            ),
+            rootzone_path=_resolve_config_path(
+                management_cfg.get("rootzone_path"),
+                repo_root=repo_root,
+                config_path=config_path,
+                require_exists=True,
+            ),
         ),
         sanitized_fixture=DatasetSanitizedFixtureContract(
             fixture_kind=str(fixture_cfg.get("fixture_kind", "sanitized_csv_fixture")),
-            forcing_fixture_path=_optional_path(fixture_cfg.get("forcing_fixture_path"), repo_root=repo_root, config_path=config_path),
-            observed_harvest_fixture_path=_optional_path(
+            forcing_fixture_path=_resolve_config_path(
+                fixture_cfg.get("forcing_fixture_path"),
+                repo_root=repo_root,
+                config_path=config_path,
+                require_exists=True,
+            ),
+            observed_harvest_fixture_path=_resolve_config_path(
                 fixture_cfg.get("observed_harvest_fixture_path"),
                 repo_root=repo_root,
                 config_path=config_path,
+                require_exists=True,
             ),
         ),
         priority_tags=tuple(str(tag) for tag in _as_list(raw.get("priority_tags"))),
-        notes=_as_dict(raw.get("notes")),
+        blocker_codes=tuple(str(code) for code in _as_list(raw.get("blocker_codes"))),
+        provenance_tags=tuple(str(tag) for tag in _as_list(raw.get("provenance_tags"))),
+        notes=notes,
     )
 
 
@@ -155,6 +216,11 @@ def _default_knu_dataset(
         dataset_id="knu_actual",
         dataset_kind="knu_measured_harvest",
         display_name="KNU measured harvest longrun",
+        dataset_family="knu_actual",
+        observation_family="yield",
+        capability=DatasetCapability.MEASURED_HARVEST,
+        ingestion_status=DatasetIngestionStatus.RUNNABLE,
+        source_refs=(str(contract.contract_path) if contract.contract_path is not None else "knu_data_contract",),
         forcing_path=contract.forcing_path,
         observed_harvest_path=contract.yield_path,
         validation_start=str(yield_dates.min().date()),
@@ -187,6 +253,7 @@ def _default_knu_dataset(
             "needs_residence_signal_dataset",
             "prefer_rootzone_metadata",
         ),
+        provenance_tags=("actual_data_contract", "knu", "measured_harvest"),
         notes={
             "dataset_source_kind": "actual_data_contract",
             "reporting_basis": contract.reporting_basis,
@@ -203,8 +270,6 @@ class DatasetRegistry:
         ids = [dataset.dataset_id for dataset in self.datasets]
         if len(ids) != len(set(ids)):
             raise ValueError("Dataset IDs must be unique.")
-        if not self.default_dataset_ids:
-            raise ValueError("At least one default dataset_id is required.")
         missing = [dataset_id for dataset_id in self.default_dataset_ids if dataset_id not in ids]
         if missing:
             raise ValueError(f"default_dataset_ids reference unknown datasets: {missing}")
@@ -215,14 +280,80 @@ class DatasetRegistry:
                 return dataset
         raise KeyError(f"Unknown dataset_id {dataset_id!r}")
 
+    def list_by_capability(self, capability: DatasetCapability | str) -> tuple[DatasetMetadataContract, ...]:
+        expected = DatasetCapability(str(capability))
+        return tuple(dataset for dataset in self.datasets if dataset.capability is expected)
+
+    def runnable_measured_harvest_datasets(self) -> tuple[DatasetMetadataContract, ...]:
+        return tuple(dataset for dataset in self.datasets if is_measured_harvest_runnable(dataset))
+
+    def draft_datasets(self) -> tuple[DatasetMetadataContract, ...]:
+        return tuple(dataset for dataset in self.datasets if dataset.ingestion_status is not DatasetIngestionStatus.RUNNABLE)
+
     def to_frame(self) -> pd.DataFrame:
         return dataset_registry_frame(list(self.datasets))
+
+    def blocker_frame(self) -> pd.DataFrame:
+        return dataset_blocker_frame(list(self.datasets))
 
     def to_payload(self) -> dict[str, Any]:
         return {
             "default_dataset_ids": list(self.default_dataset_ids),
+            "summary": build_dataset_inventory_summary(list(self.datasets)),
             "datasets": [dataset.to_payload() for dataset in self.datasets],
         }
+
+
+def _default_dataset_ids(datasets: tuple[DatasetMetadataContract, ...]) -> tuple[str, ...]:
+    runnable_ids = tuple(dataset.dataset_id for dataset in datasets if is_measured_harvest_runnable(dataset))
+    if runnable_ids:
+        return runnable_ids
+    return ()
+
+
+def _merge_dataset_rows(
+    imported_rows: list[dict[str, Any]],
+    explicit_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for row in imported_rows:
+        merged[str(row["dataset_id"])] = dict(row)
+    for row in explicit_rows:
+        dataset_id = str(row["dataset_id"])
+        if dataset_id not in merged:
+            merged[dataset_id] = dict(row)
+            continue
+        merged[dataset_id] = _overlay_dataset_row(merged[dataset_id], row)
+    return list(merged.values())
+
+
+def _overlay_dataset_row(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _overlay_dataset_row(_as_dict(merged[key]), value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_dataset_registry_snapshot(
+    snapshot_path: str | Path,
+    *,
+    repo_root: Path,
+    config_path: Path,
+) -> DatasetRegistry:
+    resolved_path = _resolve_config_path(snapshot_path, repo_root=repo_root, config_path=config_path)
+    if resolved_path is None:
+        raise ValueError("registry snapshot path is required.")
+    payload = json.loads(resolved_path.read_text(encoding="utf-8"))
+    dataset_rows = [_as_dict(item) for item in _as_list(payload.get("datasets")) if _as_dict(item)]
+    datasets = tuple(
+        _build_dataset_from_config(row, repo_root=repo_root, config_path=resolved_path)
+        for row in dataset_rows
+    )
+    default_ids = tuple(str(value) for value in _as_list(payload.get("default_dataset_ids")))
+    return DatasetRegistry(datasets=datasets, default_dataset_ids=default_ids)
 
 
 def load_dataset_registry(
@@ -233,17 +364,34 @@ def load_dataset_registry(
 ) -> DatasetRegistry:
     validation_cfg = _as_dict(config.get("validation"))
     datasets_cfg = _as_dict(validation_cfg.get("datasets"))
-    dataset_rows = [_as_dict(item) for item in _as_list(datasets_cfg.get("items")) if _as_dict(item)]
+    imported_rows: list[dict[str, Any]] = []
+    snapshot_path = datasets_cfg.get("registry_snapshot_path")
+    allow_missing_snapshot = bool(datasets_cfg.get("allow_missing_registry_snapshot", False))
+    if snapshot_path not in (None, ""):
+        try:
+            snapshot_registry = load_dataset_registry_snapshot(
+                snapshot_path,
+                repo_root=repo_root,
+                config_path=config_path,
+            )
+        except FileNotFoundError:
+            if not allow_missing_snapshot:
+                raise
+        else:
+            imported_rows = [dataset.to_payload() for dataset in snapshot_registry.datasets]
+    explicit_rows = [_as_dict(item) for item in _as_list(datasets_cfg.get("items")) if _as_dict(item)]
+    dataset_rows = _merge_dataset_rows(imported_rows, explicit_rows)
     if dataset_rows:
         datasets = tuple(
             _build_dataset_from_config(row, repo_root=repo_root, config_path=config_path)
             for row in dataset_rows
         )
-        default_ids = tuple(str(value) for value in _as_list(datasets_cfg.get("default_dataset_ids")))
+        explicit_defaults = tuple(str(value) for value in _as_list(datasets_cfg.get("default_dataset_ids")))
+        default_ids = explicit_defaults or _default_dataset_ids(datasets)
     else:
         datasets = (_default_knu_dataset(config=config, repo_root=repo_root, config_path=config_path),)
         default_ids = ("knu_actual",)
     return DatasetRegistry(datasets=datasets, default_dataset_ids=default_ids)
 
 
-__all__ = ["DatasetRegistry", "load_dataset_registry"]
+__all__ = ["DatasetRegistry", "load_dataset_registry", "load_dataset_registry_snapshot"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/traitenv_loader.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/traitenv_loader.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import io
+import json
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetBasisContract,
+    DatasetCapability,
+    DatasetMetadataContract,
+    DatasetObservationContract,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    DatasetRegistry,
+)
+
+REQUIRED_TRAITENV_FILES = (
+    "source_inventory.csv",
+    "source_summary.csv",
+    "variable_dictionary.csv",
+    "comparison_rules.csv",
+    "integration_contract.json",
+    "run_manifest.json",
+    "workbook_index.csv",
+    "comparison_daily.csv",
+    "traitenv_design_workbook.xlsx",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TraitenvInventoryBundle:
+    bundle_path: Path
+    bundle_kind: str
+    source_inventory: pd.DataFrame
+    source_summary: pd.DataFrame
+    variable_dictionary: pd.DataFrame
+    comparison_rules: pd.DataFrame
+    integration_contract: dict[str, Any]
+    run_manifest: dict[str, Any]
+    workbook_index: pd.DataFrame
+    comparison_daily: pd.DataFrame
+    design_workbook_present: bool
+
+
+def _read_csv_from_archive(archive: zipfile.ZipFile, member_name: str) -> pd.DataFrame:
+    with archive.open(member_name) as handle:
+        return pd.read_csv(handle)
+
+
+def _read_json_from_archive(archive: zipfile.ZipFile, member_name: str) -> dict[str, Any]:
+    with archive.open(member_name) as handle:
+        return json.load(io.TextIOWrapper(handle, encoding="utf-8"))
+
+
+def _resolve_archive_members(archive: zipfile.ZipFile) -> dict[str, str]:
+    members: dict[str, str] = {}
+    for member_name in archive.namelist():
+        if member_name.endswith("/"):
+            continue
+        base_name = Path(member_name).name
+        if base_name in REQUIRED_TRAITENV_FILES:
+            members[base_name] = member_name
+    return members
+
+
+def _slugify(*parts: str) -> str:
+    raw = "__".join(str(part).strip().lower() for part in parts if str(part).strip())
+    return re.sub(r"[^a-z0-9]+", "_", raw).strip("_")
+
+
+def _capability_for_candidate(dataset_family: str, observation_family: str) -> DatasetCapability:
+    family = str(dataset_family).strip().lower()
+    observation = str(observation_family).strip().lower()
+    if observation == "yield" and family in {"school_trait_bundle", "public_rda", "public_ai_competition"}:
+        return DatasetCapability.MEASURED_HARVEST
+    if observation == "yield_environment" or ("yield" in observation and observation != "yield"):
+        return DatasetCapability.HARVEST_PROXY
+    return DatasetCapability.CONTEXT_ONLY
+
+
+def _candidate_date_key(
+    *,
+    dataset_daily_rows: pd.DataFrame,
+    observation_family: str,
+    available_standard_names: set[str],
+) -> str | None:
+    if dataset_daily_rows.empty:
+        return None
+    if "environment" in observation_family and "observation_datetime" in available_standard_names:
+        return "observation_datetime"
+    if "observation_date" in available_standard_names:
+        return "observation_date"
+    return None
+
+
+def load_traitenv_inventory(bundle_path: str | Path) -> TraitenvInventoryBundle:
+    path = Path(bundle_path).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Could not find traitenv bundle at {path}.")
+    if path.is_dir():
+        missing = [name for name in REQUIRED_TRAITENV_FILES if not (path / name).exists()]
+        if missing:
+            raise FileNotFoundError(f"traitenv directory is missing required files: {missing}")
+        return TraitenvInventoryBundle(
+            bundle_path=path,
+            bundle_kind="directory",
+            source_inventory=pd.read_csv(path / "source_inventory.csv"),
+            source_summary=pd.read_csv(path / "source_summary.csv"),
+            variable_dictionary=pd.read_csv(path / "variable_dictionary.csv"),
+            comparison_rules=pd.read_csv(path / "comparison_rules.csv"),
+            integration_contract=json.loads((path / "integration_contract.json").read_text(encoding="utf-8")),
+            run_manifest=json.loads((path / "run_manifest.json").read_text(encoding="utf-8")),
+            workbook_index=pd.read_csv(path / "workbook_index.csv"),
+            comparison_daily=pd.read_csv(path / "comparison_daily.csv"),
+            design_workbook_present=True,
+        )
+    if path.suffix.lower() != ".zip":
+        raise ValueError(f"traitenv bundle must be a directory or .zip, got {path}.")
+    with zipfile.ZipFile(path) as archive:
+        members = _resolve_archive_members(archive)
+        missing = [name for name in REQUIRED_TRAITENV_FILES if name not in members]
+        if missing:
+            raise FileNotFoundError(f"traitenv archive is missing required files: {missing}")
+        return TraitenvInventoryBundle(
+            bundle_path=path,
+            bundle_kind="zip",
+            source_inventory=_read_csv_from_archive(archive, members["source_inventory.csv"]),
+            source_summary=_read_csv_from_archive(archive, members["source_summary.csv"]),
+            variable_dictionary=_read_csv_from_archive(archive, members["variable_dictionary.csv"]),
+            comparison_rules=_read_csv_from_archive(archive, members["comparison_rules.csv"]),
+            integration_contract=_read_json_from_archive(archive, members["integration_contract.json"]),
+            run_manifest=_read_json_from_archive(archive, members["run_manifest.json"]),
+            workbook_index=_read_csv_from_archive(archive, members["workbook_index.csv"]),
+            comparison_daily=_read_csv_from_archive(archive, members["comparison_daily.csv"]),
+            design_workbook_present=True,
+        )
+
+
+def build_traitenv_candidate_registry(bundle_path: TraitenvInventoryBundle | str | Path) -> DatasetRegistry:
+    bundle = bundle_path if isinstance(bundle_path, TraitenvInventoryBundle) else load_traitenv_inventory(bundle_path)
+    source_summary = bundle.source_summary.copy()
+    source_inventory = bundle.source_inventory.copy()
+    available_standard_names = {
+        str(value).strip()
+        for value in bundle.variable_dictionary.get("standard_name", pd.Series(dtype=object)).dropna().astype(str)
+        if str(value).strip()
+    }
+    if source_summary.empty:
+        raise ValueError("traitenv source_summary.csv did not contain any dataset rows.")
+    datasets: list[DatasetMetadataContract] = []
+    for row in source_summary.to_dict(orient="records"):
+        dataset_family = str(row.get("dataset_family", "")).strip()
+        observation_family = str(row.get("observation_family", "")).strip()
+        if not dataset_family or not observation_family:
+            continue
+        subset = source_inventory.loc[
+            source_inventory["dataset_family"].astype(str).eq(dataset_family)
+            & source_inventory["observation_family"].astype(str).eq(observation_family)
+        ].copy()
+        capability = _capability_for_candidate(dataset_family, observation_family)
+        source_refs = tuple(
+            str(value)
+            for value in subset.get("relative_path", pd.Series(dtype=object)).dropna().astype(str).head(25).tolist()
+        )
+        source_groups = sorted({str(value) for value in subset.get("source_group", pd.Series(dtype=object)).dropna()})
+        grain_hints = sorted({str(value) for value in subset.get("grain_hint", pd.Series(dtype=object)).dropna()})
+        rollup_hints = sorted(
+            {str(value) for value in subset.get("comparison_rollup_hint", pd.Series(dtype=object)).dropna()}
+        )
+        metadata_join_hints = sorted(
+            {str(value) for value in subset.get("metadata_join_hint", pd.Series(dtype=object)).dropna()}
+        )
+        preview_statuses = sorted({str(value) for value in subset.get("preview_status", pd.Series(dtype=object)).dropna()})
+        comparison_daily_subset = bundle.comparison_daily.loc[
+            bundle.comparison_daily.get("dataset_family", pd.Series(dtype=object)).astype(str).eq(dataset_family)
+            & bundle.comparison_daily.get("observation_family", pd.Series(dtype=object)).astype(str).eq(observation_family)
+        ].copy()
+        daily_standard_names = sorted(
+            {
+                str(value)
+                for value in comparison_daily_subset.get("standard_name", pd.Series(dtype=object)).dropna().astype(str)
+                if str(value).strip()
+            }
+        )
+        candidate_date_key = _candidate_date_key(
+            dataset_daily_rows=comparison_daily_subset,
+            observation_family=observation_family,
+            available_standard_names=available_standard_names,
+        )
+        candidate_harvest_column = (
+            "total_yield_weight_g"
+            if observation_family == "yield" and "total_yield_weight_g" in daily_standard_names
+            else None
+        )
+        relevant_rule_mask = (
+            bundle.comparison_rules.get("scope", pd.Series(dtype=object))
+            .astype(str)
+            .str.contains(dataset_family, case=False, na=False)
+            | bundle.comparison_rules.get("scope", pd.Series(dtype=object))
+            .astype(str)
+            .str.contains(observation_family, case=False, na=False)
+            | bundle.comparison_rules.get("scope", pd.Series(dtype=object)).astype(str).str.contains("all", case=False, na=False)
+        )
+        relevant_rules = bundle.comparison_rules.loc[relevant_rule_mask].copy()
+        candidate_id = f"{dataset_family}__{observation_family}".lower()
+        datasets.append(
+            DatasetMetadataContract(
+                dataset_id=candidate_id,
+                dataset_kind="traitenv_candidate",
+                display_name=f"{dataset_family} / {observation_family}",
+                dataset_family=dataset_family,
+                observation_family=observation_family,
+                capability=capability,
+                source_refs=source_refs,
+                cultivar="unknown",
+                greenhouse="unknown",
+                season="unknown",
+                basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+                observation=DatasetObservationContract(
+                    date_column=None,
+                    measured_cumulative_column=None,
+                    measured_semantics="cumulative_harvested_fruit_dry_weight_floor_area",
+                    daily_increment_column=None,
+                ),
+                provenance_tags=tuple(source_groups + [dataset_family, observation_family]),
+                notes={
+                    "source_group_candidates": source_groups,
+                    "grain_hints": grain_hints,
+                    "comparison_rollup_hints": rollup_hints,
+                    "metadata_join_hints": metadata_join_hints,
+                    "preview_statuses": preview_statuses,
+                    "traitenv_bundle_kind": bundle.bundle_kind,
+                    "traitenv_bundle_ref": bundle.bundle_path.name,
+                    "design_workbook_present": bundle.design_workbook_present,
+                    "n_files": int(row.get("n_files", 0) or 0),
+                    "candidate_date_key": candidate_date_key,
+                    "candidate_harvest_column": candidate_harvest_column,
+                    "candidate_harvest_requires_cumulative_construction": candidate_harvest_column is not None,
+                    "candidate_harvest_includes_fallen_fruit": observation_family == "yield",
+                    "comparison_daily_standard_names": daily_standard_names,
+                    "comparison_rule_ids": [
+                        str(value)
+                        for value in relevant_rules.get("rule_id", pd.Series(dtype=object)).dropna().astype(str).tolist()
+                    ],
+                    "integration_fact_tables": [
+                        str(fact.get("name"))
+                        for fact in bundle.integration_contract.get("fact_tables", [])
+                        if isinstance(fact, dict) and str(fact.get("name", "")).strip()
+                    ],
+                    "special_rules": [
+                        str(value)
+                        for value in bundle.integration_contract.get("special_rules", [])
+                        if str(value).strip()
+                    ],
+                },
+            )
+        )
+    datasets_tuple = tuple(sorted(datasets, key=lambda dataset: (dataset.dataset_family, dataset.observation_family)))
+    return DatasetRegistry(datasets=datasets_tuple, default_dataset_ids=())
+
+
+__all__ = ["TraitenvInventoryBundle", "build_traitenv_candidate_registry", "load_traitenv_inventory"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py
@@ -42,22 +42,36 @@ def model_floor_area_cumulative_total_fruit(model_df: pd.DataFrame) -> pd.DataFr
 def observed_floor_area_yield(
     yield_df: pd.DataFrame,
     *,
+    date_column: str | None = None,
     measured_column: str,
-    estimated_column: str,
+    estimated_column: str | None,
+    reporting_basis: str = "floor_area_g_m2",
+    plants_per_m2: float = 1.0,
 ) -> pd.DataFrame:
+    date_key = str(date_column or yield_df.columns[0])
+    estimated_key = str(estimated_column or measured_column)
     observed = pd.DataFrame(
         {
-            "date": pd.to_datetime(yield_df.iloc[:, 0], errors="coerce").dt.normalize(),
+            "date": pd.to_datetime(yield_df[date_key], errors="coerce").dt.normalize(),
             "measured_cumulative_harvested_fruit_dry_weight_floor_area": pd.to_numeric(
                 yield_df[measured_column],
                 errors="coerce",
             ),
             "estimated_cumulative_harvested_fruit_dry_weight_floor_area": pd.to_numeric(
-                yield_df[estimated_column],
+                yield_df[estimated_key],
                 errors="coerce",
             ),
         }
     ).dropna(subset=["date"])
+    if str(reporting_basis) == "g_per_plant":
+        observed["measured_cumulative_harvested_fruit_dry_weight_floor_area"] = (
+            observed["measured_cumulative_harvested_fruit_dry_weight_floor_area"] * float(plants_per_m2)
+        )
+        observed["estimated_cumulative_harvested_fruit_dry_weight_floor_area"] = (
+            observed["estimated_cumulative_harvested_fruit_dry_weight_floor_area"] * float(plants_per_m2)
+        )
+    elif str(reporting_basis) != "floor_area_g_m2":
+        raise ValueError(f"Unsupported reporting basis {reporting_basis!r}.")
     observed["measured_cumulative_total_fruit_dry_weight_floor_area"] = observed[
         "measured_cumulative_harvested_fruit_dry_weight_floor_area"
     ]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/knu_data.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/knu_data.py
@@ -33,6 +33,7 @@ class KnuValidationData:
     observation_unit_label: str
     measured_column: str
     estimated_column: str
+    date_column: str = "Date"
 
 
 def _finite_float_series(series: pd.Series) -> pd.Series:
@@ -149,26 +150,69 @@ def _first_sheet_rows_from_xlsx(path: Path) -> list[dict[int, Any]]:
     return rows
 
 
-def _read_knu_yield_csv(path: Path) -> tuple[pd.DataFrame, str, str, str]:
+def _require_column(df: pd.DataFrame, column: str, *, label: str) -> str:
+    if column not in df.columns:
+        raise ValueError(f"KNU yield table is missing requested {label} column {column!r}.")
+    return column
+
+
+def _read_knu_yield_csv(
+    path: Path,
+    *,
+    date_column: str | None = None,
+    measured_column: str | None = None,
+    estimated_column: str | None = None,
+) -> tuple[pd.DataFrame, str, str, str, str]:
     df = pd.read_csv(path)
-    if df.shape[1] < 3:
+    if df.shape[1] < 2:
         raise ValueError(f"KNU yield CSV has too few columns: {list(df.columns)!r}")
-    date_col = str(df.columns[0])
-    measured_col = str(df.columns[1])
-    estimated_col = str(df.columns[2])
+    date_col = _require_column(df, str(date_column or df.columns[0]), label="date")
+    measured_col = _require_column(
+        df,
+        str(measured_column or df.columns[min(1, len(df.columns) - 1)]),
+        label="measured",
+    )
+    estimated_col = str(estimated_column or (df.columns[2] if df.shape[1] >= 3 else measured_col))
+    estimated_col = _require_column(df, estimated_col, label="estimated")
     out = df.copy()
     out[date_col] = pd.to_datetime(out[date_col], errors="coerce").dt.normalize()
     out = out.dropna(subset=[date_col]).reset_index(drop=True)
     out[measured_col] = _finite_float_series(out[measured_col])
-    out[estimated_col] = _finite_float_series(out[estimated_col])
+    if estimated_col == measured_col:
+        out[estimated_col] = out[measured_col].copy()
+    else:
+        out[estimated_col] = _finite_float_series(out[estimated_col])
     unit_label = measured_col[measured_col.find("(") + 1 : measured_col.rfind(")")] if "(" in measured_col and ")" in measured_col else measured_col
-    return out, unit_label, measured_col, estimated_col
+    return out, unit_label, date_col, measured_col, estimated_col
 
 
-def read_knu_yield_workbook(path: str | Path) -> tuple[pd.DataFrame, str, str, str]:
+def _resolve_header_index(headers: list[Any], requested: str | None, *, default_index: int, label: str) -> int:
+    if requested:
+        normalized = str(requested)
+        for idx, header in enumerate(headers):
+            if str(header) == normalized:
+                return idx
+        raise ValueError(f"KNU yield workbook is missing requested {label} column {requested!r}.")
+    if default_index >= len(headers):
+        raise ValueError(f"KNU yield workbook has no default {label} column at index {default_index}.")
+    return default_index
+
+
+def read_knu_yield_workbook(
+    path: str | Path,
+    *,
+    date_column: str | None = None,
+    measured_column: str | None = None,
+    estimated_column: str | None = None,
+) -> tuple[pd.DataFrame, str, str, str, str]:
     workbook_path = Path(path)
     if workbook_path.suffix.lower() == ".csv":
-        return _read_knu_yield_csv(workbook_path)
+        return _read_knu_yield_csv(
+            workbook_path,
+            date_column=date_column,
+            measured_column=measured_column,
+            estimated_column=estimated_column,
+        )
 
     rows = _first_sheet_rows_from_xlsx(workbook_path)
     if not rows:
@@ -177,23 +221,30 @@ def read_knu_yield_workbook(path: str | Path) -> tuple[pd.DataFrame, str, str, s
     header_map = rows[0]
     max_header_idx = max(header_map) if header_map else -1
     headers = [header_map.get(idx) for idx in range(max_header_idx + 1)]
-    if len(headers) < 3:
+    minimum_columns = 2 if estimated_column is None else 3
+    if len(headers) < minimum_columns:
         raise ValueError(f"KNU yield workbook has too few header columns: {headers!r}")
 
-    date_col = str(headers[0])
-    measured_col = str(headers[1])
-    estimated_col = str(headers[2])
+    date_idx = _resolve_header_index(headers, date_column, default_index=0, label="date")
+    measured_idx = _resolve_header_index(headers, measured_column, default_index=1, label="measured")
+    if estimated_column is None and len(headers) < 3:
+        estimated_idx = measured_idx
+    else:
+        estimated_idx = _resolve_header_index(headers, estimated_column, default_index=2, label="estimated")
+    date_col = str(headers[date_idx])
+    measured_col = str(headers[measured_idx])
+    estimated_col = str(headers[estimated_idx])
 
     records: list[dict[str, Any]] = []
     for raw_row in rows[1:]:
-        date_value = raw_row.get(0)
+        date_value = raw_row.get(date_idx)
         if not isinstance(date_value, datetime):
             continue
         records.append(
             {
                 date_col: pd.Timestamp(date_value).normalize(),
-                measured_col: raw_row.get(1),
-                estimated_col: raw_row.get(2),
+                measured_col: raw_row.get(measured_idx),
+                estimated_col: raw_row.get(estimated_idx),
             }
         )
 
@@ -202,9 +253,12 @@ def read_knu_yield_workbook(path: str | Path) -> tuple[pd.DataFrame, str, str, s
 
     df = pd.DataFrame.from_records(records)
     df[measured_col] = _finite_float_series(df[measured_col])
-    df[estimated_col] = _finite_float_series(df[estimated_col])
+    if estimated_col == measured_col:
+        df[estimated_col] = df[measured_col].copy()
+    else:
+        df[estimated_col] = _finite_float_series(df[estimated_col])
     unit_label = measured_col[measured_col.find("(") + 1 : measured_col.rfind(")")] if "(" in measured_col and ")" in measured_col else measured_col
-    return df, unit_label, measured_col, estimated_col
+    return df, unit_label, date_col, measured_col, estimated_col
 
 
 def forcing_summary(forcing_df: pd.DataFrame) -> dict[str, Any]:
@@ -219,11 +273,17 @@ def forcing_summary(forcing_df: pd.DataFrame) -> dict[str, Any]:
     }
 
 
-def yield_summary(yield_df: pd.DataFrame, *, measured_column: str, estimated_column: str) -> dict[str, Any]:
+def yield_summary(
+    yield_df: pd.DataFrame,
+    *,
+    date_column: str,
+    measured_column: str,
+    estimated_column: str,
+) -> dict[str, Any]:
     return {
         "rows": int(yield_df.shape[0]),
-        "start": pd.Timestamp(yield_df.iloc[0, 0]).isoformat(),
-        "end": pd.Timestamp(yield_df.iloc[-1, 0]).isoformat(),
+        "start": pd.Timestamp(yield_df[date_column].iloc[0]).isoformat(),
+        "end": pd.Timestamp(yield_df[date_column].iloc[-1]).isoformat(),
         "measured_start": float(yield_df[measured_column].iloc[0]),
         "measured_end": float(yield_df[measured_column].iloc[-1]),
         "estimated_start": float(yield_df[estimated_column].iloc[0]),
@@ -265,12 +325,15 @@ def write_knu_manifest(
     output_root: Path,
     forcing_df: pd.DataFrame,
     yield_df: pd.DataFrame,
+    date_column: str,
     measured_column: str,
     estimated_column: str,
     observation_unit_label: str,
     forcing_source_path: Path,
     yield_source_path: Path,
     resample_rule: str,
+    reporting_basis: str = "floor_area_g_m2",
+    plants_per_m2: float = PLANTS_PER_M2,
 ) -> dict[str, str]:
     output_root.mkdir(parents=True, exist_ok=True)
     forcing_summary_path = output_root / "forcing_summary.csv"
@@ -296,12 +359,13 @@ def write_knu_manifest(
         "forcing_source_path": str(forcing_source_path.resolve()),
         "yield_source_path": str(yield_source_path.resolve()),
         "resample_rule": resample_rule,
-        "reporting_basis": "floor_area",
-        "plants_per_m2": PLANTS_PER_M2,
+        "reporting_basis": reporting_basis,
+        "plants_per_m2": float(plants_per_m2),
         "observation_unit_label": observation_unit_label,
         "forcing_summary": forcing_summary(forcing_df),
         "yield_summary": yield_summary(
             yield_df,
+            date_column=date_column,
             measured_column=measured_column,
             estimated_column=estimated_column,
         ),
@@ -318,21 +382,31 @@ def load_knu_validation_data(
     *,
     forcing_path: str | Path,
     yield_path: str | Path,
+    date_column: str | None = None,
+    measured_column: str | None = None,
+    estimated_column: str | None = None,
 ) -> KnuValidationData:
     forcing_df = read_knu_forcing_csv(forcing_path)
-    yield_df, observation_unit_label, measured_column, estimated_column = read_knu_yield_workbook(yield_path)
+    yield_df, observation_unit_label, resolved_date_column, measured_column, estimated_column = read_knu_yield_workbook(
+        yield_path,
+        date_column=date_column,
+        measured_column=measured_column,
+        estimated_column=estimated_column,
+    )
     return KnuValidationData(
         forcing_df=forcing_df,
         yield_df=yield_df,
         forcing_summary=forcing_summary(forcing_df),
         yield_summary=yield_summary(
             yield_df,
+            date_column=resolved_date_column,
             measured_column=measured_column,
             estimated_column=estimated_column,
         ),
         observation_unit_label=observation_unit_label,
         measured_column=measured_column,
         estimated_column=estimated_column,
+        date_column=resolved_date_column,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,32 @@
 from __future__ import annotations
 
+import os
+import platform
 import sys
 from pathlib import Path
+
+
+def _disable_windows_platform_wmi_for_pytest() -> None:
+    if sys.platform != "win32":
+        return
+    if os.environ.get("PHYTORITAS_ALLOW_PLATFORM_WMI", "").strip().lower() in {"1", "true", "yes"}:
+        return
+
+    original = getattr(platform, "_wmi_query", None)
+    if original is None or getattr(platform, "_phytoritas_wmi_guard", False):
+        return
+
+    def _wmi_query_disabled(*_args: object, **_kwargs: object) -> object:
+        raise OSError("platform WMI disabled by pytest conftest")
+
+    platform._phytoritas_wmi_guard = True  # type: ignore[attr-defined]
+    platform._phytoritas_original_wmi_query = original  # type: ignore[attr-defined]
+    platform._wmi_query = _wmi_query_disabled  # type: ignore[assignment]
+    if hasattr(platform, "_uname_cache"):
+        platform._uname_cache = None  # type: ignore[attr-defined]
+
+
+_disable_windows_platform_wmi_for_pytest()
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 

--- a/tests/test_cross_dataset_gate.py
+++ b/tests/test_cross_dataset_gate.py
@@ -1,11 +1,50 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.cross_dataset_gate import (
     build_cross_dataset_guardrail_summary,
     cross_dataset_proxy_guardrail,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
+    DatasetMetadataContract,
+    DatasetObservationContract,
+    DatasetSanitizedFixtureContract,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    DatasetRegistry,
+)
+
+
+def _runnable_measured_dataset(tmp_path: Path, dataset_id: str, *, dataset_family: str) -> DatasetMetadataContract:
+    forcing_path = tmp_path / f"{dataset_id}_forcing.csv"
+    harvest_path = tmp_path / f"{dataset_id}_harvest.csv"
+    forcing_path.write_text("datetime,T_air_C\n2025-01-01,24\n", encoding="utf-8")
+    harvest_path.write_text("date,measured\n2025-01-01,1.0\n", encoding="utf-8")
+    return DatasetMetadataContract(
+        dataset_id=dataset_id,
+        dataset_kind="fixture",
+        display_name=dataset_id,
+        dataset_family=dataset_family,
+        observation_family="yield",
+        capability=DatasetCapability.MEASURED_HARVEST,
+        ingestion_status=DatasetIngestionStatus.RUNNABLE,
+        forcing_path=forcing_path,
+        observed_harvest_path=harvest_path,
+        validation_start="2025-01-01",
+        validation_end="2025-01-31",
+        basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=1.7),
+        observation=DatasetObservationContract(date_column="date", measured_cumulative_column="measured"),
+        sanitized_fixture=DatasetSanitizedFixtureContract(
+            forcing_fixture_path=forcing_path,
+            observed_harvest_fixture_path=harvest_path,
+        ),
+    )
 
 
 def test_cross_dataset_proxy_guardrail_blocks_single_dataset_proxy_heavy_winner() -> None:
@@ -30,7 +69,7 @@ def test_cross_dataset_proxy_guardrail_blocks_single_dataset_proxy_heavy_winner(
     assert guardrail["passes"] is False
 
 
-def test_cross_dataset_guardrail_summary_selects_top_candidate() -> None:
+def test_cross_dataset_guardrail_summary_blocks_without_registry_evidence() -> None:
     scorecard = pd.DataFrame(
         [
             {
@@ -46,5 +85,211 @@ def test_cross_dataset_guardrail_summary_selects_top_candidate() -> None:
         ]
     )
     summary = build_cross_dataset_guardrail_summary(scorecard)
+    assert summary["selected_candidate"]["passes"] is False
+    assert summary["selected_candidate"]["missing_dataset_registry_flag"] is True
+    assert "dataset registry" in summary["recommendation"]
+
+
+def test_cross_dataset_guardrail_summary_selects_top_candidate_with_registry_evidence(tmp_path: Path) -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _runnable_measured_dataset(tmp_path, "measured_a", dataset_family="public_rda"),
+            _runnable_measured_dataset(tmp_path, "measured_b", dataset_family="school_trait_bundle"),
+        ),
+        default_dataset_ids=("measured_a", "measured_b"),
+    )
+    scorecard = pd.DataFrame(
+        [
+            {
+                "fruit_harvest_family": "dekoning_fds",
+                "leaf_harvest_family": "vegetative_unit_pruning",
+                "fdmc_mode": "dekoning_fds",
+                "dataset_count": 2,
+                "mean_native_family_state_fraction": 1.0,
+                "mean_proxy_family_state_fraction": 0.0,
+                "mean_shared_tdvs_proxy_fraction": 0.0,
+                "cross_dataset_stability_score": 1.0,
+            }
+        ]
+    )
+
+    summary = build_cross_dataset_guardrail_summary(scorecard, registry=registry)
+
     assert summary["selected_candidate"]["passes"] is True
-    assert "multiple measured datasets" in summary["recommendation"] or "Promotion-grade" in summary["recommendation"]
+    assert summary["selected_candidate"]["missing_dataset_registry_flag"] is False
+    assert "Promotion-grade" in summary["recommendation"]
+
+
+def test_cross_dataset_guardrail_blocks_when_only_one_measured_dataset_is_runnable(tmp_path: Path) -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _runnable_measured_dataset(tmp_path, "measured_a", dataset_family="public_rda"),
+            DatasetMetadataContract(
+                dataset_id="proxy_b",
+                dataset_kind="traitenv_candidate",
+                display_name="Proxy B",
+                dataset_family="public_bigdata_platform",
+                observation_family="yield_environment",
+                capability=DatasetCapability.HARVEST_PROXY,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+                blocker_codes=("missing_raw_fixture",),
+            ),
+        ),
+        default_dataset_ids=("measured_a",),
+    )
+    summary = build_cross_dataset_guardrail_summary(pd.DataFrame(), registry=registry, min_dataset_count=2)
+    assert summary["measured_dataset_count"] == 1
+    assert summary["selected_candidate"] == {}
+    assert "at least two runnable measured-harvest datasets" in summary["recommendation"]
+
+
+def test_cross_dataset_guardrail_ignores_malformed_runnable_registry_rows(tmp_path: Path) -> None:
+    malformed_forcing_path = tmp_path / "measured_b_forcing.csv"
+    malformed_harvest_path = tmp_path / "measured_b_harvest.csv"
+    malformed_forcing_path.write_text("datetime,T_air_C\n2025-02-01,24\n", encoding="utf-8")
+    malformed_harvest_path.write_text("date,measured\n2025-02-01,1.0\n", encoding="utf-8")
+    registry = DatasetRegistry(
+        datasets=(
+            _runnable_measured_dataset(tmp_path, "measured_a", dataset_family="public_rda"),
+            DatasetMetadataContract(
+                dataset_id="measured_b_malformed",
+                dataset_kind="fixture",
+                display_name="Measured B malformed",
+                dataset_family="school_trait_bundle",
+                observation_family="yield",
+                capability=DatasetCapability.MEASURED_HARVEST,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                forcing_path=malformed_forcing_path,
+                observed_harvest_path=malformed_harvest_path,
+                validation_start="2025-02-01",
+                validation_end="2025-02-28",
+                basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=2.0),
+                observation=DatasetObservationContract(date_column="date", measured_cumulative_column=None),
+                sanitized_fixture=DatasetSanitizedFixtureContract(
+                    forcing_fixture_path=malformed_forcing_path,
+                    observed_harvest_fixture_path=malformed_harvest_path,
+                ),
+            ),
+        ),
+        default_dataset_ids=("measured_a",),
+    )
+
+    summary = build_cross_dataset_guardrail_summary(pd.DataFrame(), registry=registry, min_dataset_count=2)
+
+    assert summary["measured_dataset_count"] == 1
+    assert summary["measured_dataset_ids"] == ["measured_a"]
+    assert summary["selected_candidate"] == {}
+    assert "at least two runnable measured-harvest datasets" in summary["recommendation"]
+
+
+def test_cross_dataset_guardrail_blocks_when_zero_measured_datasets_are_runnable() -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            DatasetMetadataContract(
+                dataset_id="proxy_b",
+                dataset_kind="traitenv_candidate",
+                display_name="Proxy B",
+                dataset_family="public_bigdata_platform",
+                observation_family="yield_environment",
+                capability=DatasetCapability.HARVEST_PROXY,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+                blocker_codes=("missing_raw_fixture",),
+            ),
+            DatasetMetadataContract(
+                dataset_id="context_c",
+                dataset_kind="traitenv_candidate",
+                display_name="Context C",
+                dataset_family="school_greenhouse_environment",
+                observation_family="environment",
+                capability=DatasetCapability.CONTEXT_ONLY,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+                observation=DatasetObservationContract(),
+            ),
+        ),
+        default_dataset_ids=(),
+    )
+
+    summary = build_cross_dataset_guardrail_summary(pd.DataFrame(), registry=registry, min_dataset_count=2)
+
+    assert summary["measured_dataset_count"] == 0
+    assert summary["measured_dataset_ids"] == []
+    assert summary["selected_candidate"] == {}
+    assert "at least two runnable measured-harvest datasets" in summary["recommendation"]
+
+
+def test_cross_dataset_guardrail_passes_with_two_runnable_measured_datasets_only(tmp_path: Path) -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _runnable_measured_dataset(tmp_path, "measured_a", dataset_family="public_rda"),
+            _runnable_measured_dataset(tmp_path, "measured_b", dataset_family="school_trait_bundle"),
+            DatasetMetadataContract(
+                dataset_id="proxy_c",
+                dataset_kind="traitenv_candidate",
+                display_name="Proxy C",
+                dataset_family="public_bigdata_platform",
+                observation_family="yield_environment",
+                capability=DatasetCapability.HARVEST_PROXY,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+                blocker_codes=("missing_raw_fixture",),
+            ),
+            DatasetMetadataContract(
+                dataset_id="context_d",
+                dataset_kind="traitenv_candidate",
+                display_name="Context D",
+                dataset_family="school_greenhouse_environment",
+                observation_family="environment",
+                capability=DatasetCapability.CONTEXT_ONLY,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+                observation=DatasetObservationContract(),
+            ),
+        ),
+        default_dataset_ids=("measured_a", "measured_b"),
+    )
+    scorecard = pd.DataFrame(
+        [
+            {
+                "fruit_harvest_family": "dekoning_fds",
+                "leaf_harvest_family": "vegetative_unit_pruning",
+                "fdmc_mode": "dekoning_fds",
+                "dataset_count": 2,
+                "mean_native_family_state_fraction": 0.9,
+                "mean_proxy_family_state_fraction": 0.1,
+                "mean_shared_tdvs_proxy_fraction": 0.0,
+                "cross_dataset_stability_score": 1.0,
+            }
+        ]
+    )
+
+    summary = build_cross_dataset_guardrail_summary(scorecard, registry=registry, min_dataset_count=2)
+
+    assert summary["measured_dataset_count"] == 2
+    assert summary["measured_dataset_ids"] == ["measured_a", "measured_b"]
+    assert summary["selected_candidate"]["selected_candidate_dataset_count"] == 2
+    assert summary["selected_candidate"]["passes"] is True
+    assert summary["selected_candidate"]["single_dataset_only_flag"] is False
+
+
+def test_cross_dataset_guardrail_ignores_registry_rows_marked_runnable_without_real_evidence() -> None:
+    registry_df = pd.DataFrame(
+        [
+            {
+                "dataset_id": "paper_only",
+                "capability": "measured_harvest",
+                "ingestion_status": "runnable",
+                "is_runnable_measured_harvest": True,
+                "basis_normalization_resolved": True,
+                "validation_start": "2025-01-01",
+                "validation_end": "2025-01-31",
+                "date_column": "date",
+                "measured_cumulative_column": "measured",
+                "forcing_path": "missing_forcing.csv",
+                "observed_harvest_path": "missing_harvest.csv",
+                "sanitized_fixture_path": "missing_fixture_dir",
+            }
+        ]
+    )
+    summary = build_cross_dataset_guardrail_summary(pd.DataFrame(), registry_df=registry_df, min_dataset_count=2)
+    assert summary["measured_dataset_count"] == 0
+    assert summary["measured_dataset_ids"] == []

--- a/tests/test_cross_dataset_scorecard.py
+++ b/tests/test_cross_dataset_scorecard.py
@@ -6,6 +6,18 @@ import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.cross_dataset_scorecard import (
     build_cross_dataset_scorecard,
+    build_cross_dataset_scorecard_report,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
+    DatasetMetadataContract,
+    DatasetObservationContract,
+    DatasetSanitizedFixtureContract,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    DatasetRegistry,
 )
 
 
@@ -72,3 +84,189 @@ def test_cross_dataset_scorecard_aggregates_dataset_rows() -> None:
     assert row["dataset_win_count"] == 2
     assert row["cross_dataset_stability_score"] == 1.0
     assert row["mean_native_family_state_fraction"] == 0.75
+
+
+def test_cross_dataset_scorecard_report_keeps_registry_breadth_separate_from_denominator() -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            DatasetMetadataContract(
+                dataset_id="measured_a",
+                dataset_kind="fixture",
+                display_name="Measured A",
+                dataset_family="public_rda",
+                observation_family="yield",
+                capability=DatasetCapability.MEASURED_HARVEST,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                forcing_path="forcing.csv",
+                observed_harvest_path="harvest.csv",
+                validation_start="2025-01-01",
+                validation_end="2025-01-31",
+                basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=1.7),
+                observation=DatasetObservationContract(date_column="date", measured_cumulative_column="measured"),
+                sanitized_fixture=DatasetSanitizedFixtureContract(
+                    forcing_fixture_path="forcing.csv",
+                    observed_harvest_fixture_path="harvest.csv",
+                ),
+            ),
+            DatasetMetadataContract(
+                dataset_id="proxy_b",
+                dataset_kind="traitenv_candidate",
+                display_name="Proxy B",
+                dataset_family="public_bigdata_platform",
+                observation_family="yield_environment",
+                capability=DatasetCapability.HARVEST_PROXY,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+                blocker_codes=("missing_raw_fixture",),
+            ),
+        ),
+        default_dataset_ids=("measured_a",),
+    )
+    dataset_rankings = [
+        pd.DataFrame(
+            [
+                {
+                    "dataset_id": "measured_a",
+                    "fruit_harvest_family": "dekoning_fds",
+                    "leaf_harvest_family": "vegetative_unit_pruning",
+                    "fdmc_mode": "dekoning_fds",
+                    "mean_score": -8.0,
+                    "mean_rmse_cumulative_offset": 4.0,
+                    "mean_rmse_daily_increment": 1.5,
+                    "max_harvest_mass_balance_error": 0.0,
+                    "max_canopy_collapse_days": 2,
+                    "mean_native_family_state_fraction": 0.7,
+                    "mean_proxy_family_state_fraction": 0.3,
+                    "mean_shared_tdvs_proxy_fraction": 0.2,
+                    "family_state_mode_distribution": json.dumps({"native_payload": 0.7}),
+                    "proxy_mode_used_distribution": json.dumps({"false": 0.7, "true": 0.3}),
+                }
+            ]
+        )
+    ]
+    selected_payloads = [
+        {
+            "dataset_id": "measured_a",
+            "selected_fruit_harvest_family": "dekoning_fds",
+            "selected_leaf_harvest_family": "vegetative_unit_pruning",
+            "selected_fdmc_mode": "dekoning_fds",
+        }
+    ]
+
+    scorecard = build_cross_dataset_scorecard(dataset_rankings, selected_payloads, registry=registry)
+    report = build_cross_dataset_scorecard_report(scorecard, registry=registry)
+
+    assert int(scorecard.iloc[0]["runnable_measured_harvest_datasets"]) == 1
+    assert int(scorecard.iloc[0]["proxy_datasets"]) == 1
+    assert report["dataset_inventory_summary"]["total_registry_datasets"] == 2
+    assert report["runnable_measured_dataset_ids"] == ["measured_a"]
+
+
+def test_cross_dataset_scorecard_report_counts_context_and_blocked_datasets_separately() -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            DatasetMetadataContract(
+                dataset_id="measured_a",
+                dataset_kind="fixture",
+                display_name="Measured A",
+                dataset_family="public_rda",
+                observation_family="yield",
+                capability=DatasetCapability.MEASURED_HARVEST,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                forcing_path="forcing.csv",
+                observed_harvest_path="harvest.csv",
+                validation_start="2025-01-01",
+                validation_end="2025-01-31",
+                basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=1.7),
+                observation=DatasetObservationContract(date_column="date", measured_cumulative_column="measured"),
+                sanitized_fixture=DatasetSanitizedFixtureContract(
+                    forcing_fixture_path="forcing.csv",
+                    observed_harvest_fixture_path="harvest.csv",
+                ),
+            ),
+            DatasetMetadataContract(
+                dataset_id="measured_basis_blocked",
+                dataset_kind="traitenv_candidate",
+                display_name="Measured Basis Blocked",
+                dataset_family="public_ai_competition",
+                observation_family="yield",
+                capability=DatasetCapability.MEASURED_HARVEST,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_BASIS_METADATA,
+                forcing_path="forcing.csv",
+                observed_harvest_path="harvest.csv",
+                validation_start="2025-01-01",
+                validation_end="2025-01-31",
+                basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+                observation=DatasetObservationContract(date_column="date", measured_cumulative_column="measured"),
+                sanitized_fixture=DatasetSanitizedFixtureContract(
+                    forcing_fixture_path="forcing.csv",
+                    observed_harvest_fixture_path="harvest.csv",
+                ),
+                blocker_codes=("missing_reporting_basis",),
+            ),
+            DatasetMetadataContract(
+                dataset_id="proxy_b",
+                dataset_kind="traitenv_candidate",
+                display_name="Proxy B",
+                dataset_family="public_bigdata_platform",
+                observation_family="yield_environment",
+                capability=DatasetCapability.HARVEST_PROXY,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+                blocker_codes=("missing_raw_fixture",),
+            ),
+            DatasetMetadataContract(
+                dataset_id="context_c",
+                dataset_kind="traitenv_candidate",
+                display_name="Context C",
+                dataset_family="school_greenhouse_environment",
+                observation_family="environment",
+                capability=DatasetCapability.CONTEXT_ONLY,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+                observation=DatasetObservationContract(),
+            ),
+        ),
+        default_dataset_ids=("measured_a",),
+    )
+    dataset_rankings = [
+        pd.DataFrame(
+            [
+                {
+                    "dataset_id": "measured_a",
+                    "fruit_harvest_family": "dekoning_fds",
+                    "leaf_harvest_family": "vegetative_unit_pruning",
+                    "fdmc_mode": "dekoning_fds",
+                    "mean_score": -7.0,
+                    "mean_rmse_cumulative_offset": 3.0,
+                    "mean_rmse_daily_increment": 1.0,
+                    "max_harvest_mass_balance_error": 0.0,
+                    "max_canopy_collapse_days": 1,
+                    "mean_native_family_state_fraction": 0.9,
+                    "mean_proxy_family_state_fraction": 0.1,
+                    "mean_shared_tdvs_proxy_fraction": 0.0,
+                    "family_state_mode_distribution": json.dumps({"native_payload": 0.9}),
+                    "proxy_mode_used_distribution": json.dumps({"false": 0.9, "true": 0.1}),
+                }
+            ]
+        )
+    ]
+    selected_payloads = [
+        {
+            "dataset_id": "measured_a",
+            "selected_fruit_harvest_family": "dekoning_fds",
+            "selected_leaf_harvest_family": "vegetative_unit_pruning",
+            "selected_fdmc_mode": "dekoning_fds",
+        }
+    ]
+
+    scorecard = build_cross_dataset_scorecard(dataset_rankings, selected_payloads, registry=registry)
+    report = build_cross_dataset_scorecard_report(scorecard, registry=registry)
+    row = scorecard.iloc[0]
+
+    assert int(row["total_registry_datasets"]) == 4
+    assert int(row["runnable_measured_harvest_datasets"]) == 1
+    assert int(row["proxy_datasets"]) == 1
+    assert int(row["context_only_datasets"]) == 1
+    assert int(row["blocked_by_missing_raw_fixture"]) == 2
+    assert int(row["blocked_by_missing_basis_or_density"]) == 1
+    assert report["runnable_measured_dataset_ids"] == ["measured_a"]
+    assert report["draft_dataset_ids"] == ["measured_basis_blocked", "proxy_b"]

--- a/tests/test_multidataset_contracts.py
+++ b/tests/test_multidataset_contracts.py
@@ -4,8 +4,14 @@ import pytest
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
     DatasetMetadataContract,
     DatasetObservationContract,
+    DatasetSanitizedFixtureContract,
+    classify_blockers,
+    derive_ingestion_status,
+    is_measured_harvest_runnable,
 )
 
 
@@ -18,6 +24,11 @@ def test_dataset_basis_contract_normalizes_floor_area_basis() -> None:
 def test_dataset_metadata_contract_requires_positive_plants_per_m2() -> None:
     with pytest.raises(ValueError):
         DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=0.0)
+
+
+def test_dataset_basis_contract_requires_plants_per_m2_for_per_plant() -> None:
+    with pytest.raises(ValueError):
+        DatasetBasisContract(reporting_basis="g/plant", plants_per_m2=None)
 
 
 def test_dataset_metadata_contract_serializes_required_fields() -> None:
@@ -43,3 +54,98 @@ def test_dataset_metadata_contract_serializes_required_fields() -> None:
     assert payload["basis"]["reporting_basis"] == "floor_area_g_m2"
     assert payload["observation"]["measured_cumulative_column"] == "measured"
     assert payload["priority_tags"] == ["long_harvest_wave"]
+
+
+def test_measured_harvest_contract_reports_missing_basis_and_mapping_blockers() -> None:
+    dataset = DatasetMetadataContract(
+        dataset_id="draft_candidate",
+        dataset_kind="traitenv_candidate",
+        display_name="Draft candidate",
+        capability=DatasetCapability.MEASURED_HARVEST,
+        ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+        forcing_path=None,
+        observed_harvest_path=None,
+        basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+        observation=DatasetObservationContract(),
+    )
+    blocker_codes = set(classify_blockers(dataset))
+    assert "missing_reporting_basis" in blocker_codes
+    assert "missing_date_column" in blocker_codes
+    assert "missing_measured_cumulative_column" in blocker_codes
+    assert "missing_sanitized_fixture" in blocker_codes
+    assert is_measured_harvest_runnable(dataset) is False
+
+
+def test_context_only_dataset_never_counts_as_runnable_measured_harvest() -> None:
+    dataset = DatasetMetadataContract(
+        dataset_id="context_env",
+        dataset_kind="environment_bundle",
+        display_name="Context env",
+        capability=DatasetCapability.CONTEXT_ONLY,
+        ingestion_status=DatasetIngestionStatus.RUNNABLE,
+        forcing_path="forcing.csv",
+        basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+        observation=DatasetObservationContract(),
+    )
+    assert is_measured_harvest_runnable(dataset) is False
+
+
+@pytest.mark.parametrize(
+    ("blocker_codes", "expected_status"),
+    [
+        (["missing_raw_fixture", "missing_reporting_basis"], DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE),
+        (["missing_reporting_basis"], DatasetIngestionStatus.DRAFT_NEEDS_BASIS_METADATA),
+        (["missing_measured_cumulative_column"], DatasetIngestionStatus.DRAFT_NEEDS_HARVEST_MAPPING),
+        (["custom_blocker"], DatasetIngestionStatus.DRAFT_BLOCKED),
+        ([], DatasetIngestionStatus.RUNNABLE),
+    ],
+)
+def test_derive_ingestion_status_prioritizes_blocker_classes(
+    blocker_codes: list[str],
+    expected_status: DatasetIngestionStatus,
+) -> None:
+    assert derive_ingestion_status(DatasetCapability.MEASURED_HARVEST, blocker_codes) is expected_status
+
+
+def test_dataset_metadata_contract_normalizes_capability_and_status_strings() -> None:
+    dataset = DatasetMetadataContract(
+        dataset_id="proxy_candidate",
+        dataset_kind="traitenv_candidate",
+        display_name="Proxy candidate",
+        capability="harvest_proxy",
+        ingestion_status="draft_needs_raw_fixture",
+        basis=DatasetBasisContract(reporting_basis="unknown", plants_per_m2=None),
+        observation=DatasetObservationContract(),
+    )
+
+    assert dataset.capability is DatasetCapability.HARVEST_PROXY
+    assert dataset.ingestion_status is DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE
+
+
+def test_measured_harvest_contract_flags_ambiguous_harvest_semantics() -> None:
+    dataset = DatasetMetadataContract(
+        dataset_id="ambiguous_semantics",
+        dataset_kind="fixture",
+        display_name="Ambiguous semantics",
+        capability=DatasetCapability.MEASURED_HARVEST,
+        ingestion_status=DatasetIngestionStatus.RUNNABLE,
+        forcing_path="forcing.csv",
+        observed_harvest_path="harvest.csv",
+        validation_start="2025-01-01",
+        validation_end="2025-01-31",
+        basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=1.8),
+        observation=DatasetObservationContract(
+            date_column="date",
+            measured_cumulative_column="measured",
+            measured_semantics="fruit_buffer_proxy",
+        ),
+        sanitized_fixture=DatasetSanitizedFixtureContract(
+            forcing_fixture_path="forcing.csv",
+            observed_harvest_fixture_path="harvest.csv",
+        ),
+    )
+
+    blocker_codes = set(classify_blockers(dataset))
+
+    assert "ambiguous_harvest_semantics" in blocker_codes
+    assert is_measured_harvest_runnable(dataset) is False

--- a/tests/test_multidataset_registry.py
+++ b/tests/test_multidataset_registry.py
@@ -1,12 +1,61 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import yaml
 
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetBasisContract,
+    DatasetCapability,
+    DatasetIngestionStatus,
+    DatasetMetadataContract,
+    DatasetObservationContract,
+    DatasetSanitizedFixtureContract,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    DatasetRegistry,
     load_dataset_registry,
 )
+
+
+def _dataset(
+    dataset_id: str,
+    *,
+    capability: DatasetCapability,
+    ingestion_status: DatasetIngestionStatus,
+    observation_family: str = "yield",
+    reporting_basis: str = "floor_area_g_m2",
+    plants_per_m2: float | None = 1.7,
+    blocker_codes: tuple[str, ...] = (),
+) -> DatasetMetadataContract:
+    kwargs: dict[str, object] = {
+        "dataset_id": dataset_id,
+        "dataset_kind": "fixture",
+        "display_name": dataset_id,
+        "dataset_family": "fixture_family",
+        "observation_family": observation_family,
+        "capability": capability,
+        "ingestion_status": ingestion_status,
+        "basis": DatasetBasisContract(reporting_basis=reporting_basis, plants_per_m2=plants_per_m2),
+        "observation": DatasetObservationContract(
+            date_column="date" if capability is DatasetCapability.MEASURED_HARVEST else None,
+            measured_cumulative_column="measured" if capability is DatasetCapability.MEASURED_HARVEST else None,
+        ),
+        "blocker_codes": blocker_codes,
+    }
+    if capability is DatasetCapability.MEASURED_HARVEST and ingestion_status is DatasetIngestionStatus.RUNNABLE:
+        kwargs.update(
+            forcing_path="forcing.csv",
+            observed_harvest_path="harvest.csv",
+            validation_start="2025-01-01",
+            validation_end="2025-01-31",
+            sanitized_fixture=DatasetSanitizedFixtureContract(
+                forcing_fixture_path="forcing.csv",
+                observed_harvest_fixture_path="harvest.csv",
+            ),
+        )
+    return DatasetMetadataContract(**kwargs)
 
 
 def test_dataset_registry_loads_explicit_items(tmp_path: Path) -> None:
@@ -43,3 +92,240 @@ def test_dataset_registry_loads_explicit_items(tmp_path: Path) -> None:
     assert registry.default_dataset_ids == ("demo",)
     assert registry.require("demo").dataset_kind == "fixture"
     assert registry.to_frame().shape[0] == 1
+
+
+def test_dataset_registry_loads_snapshot_and_filters_runnable_measured_harvest(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_payload = {
+        "default_dataset_ids": [],
+        "datasets": [
+            {
+                "dataset_id": "measured_demo",
+                "dataset_kind": "fixture",
+                "display_name": "Measured Demo",
+                "dataset_family": "public_rda",
+                "observation_family": "yield",
+                "capability": "measured_harvest",
+                "ingestion_status": "runnable",
+                "forcing_path": "forcing.csv",
+                "observed_harvest_path": "harvest.csv",
+                "validation_start": "2025-01-01",
+                "validation_end": "2025-01-31",
+                "basis": {"reporting_basis": "floor_area_g_m2", "plants_per_m2": 1.7},
+                "observation": {"date_column": "date", "measured_cumulative_column": "measured"},
+                "sanitized_fixture": {
+                    "forcing_fixture_path": "forcing.csv",
+                    "observed_harvest_fixture_path": "harvest.csv",
+                },
+            },
+            {
+                "dataset_id": "proxy_demo",
+                "dataset_kind": "traitenv_candidate",
+                "display_name": "Proxy Demo",
+                "dataset_family": "public_bigdata_platform",
+                "observation_family": "yield_environment",
+                "capability": "harvest_proxy",
+                "ingestion_status": "draft_needs_raw_fixture",
+                "blocker_codes": ["missing_raw_fixture"],
+            },
+        ],
+    }
+    (tmp_path / "forcing.csv").write_text("datetime,T_air_C\n2025-01-01,24\n", encoding="utf-8")
+    (tmp_path / "harvest.csv").write_text("date,measured\n2025-01-01,1.0\n", encoding="utf-8")
+    snapshot_path.write_text(json.dumps(snapshot_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    config = {"validation": {"datasets": {"registry_snapshot_path": str(snapshot_path)}}}
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    registry = load_dataset_registry(config, repo_root=tmp_path, config_path=config_path)
+
+    assert registry.default_dataset_ids == ("measured_demo",)
+    assert [dataset.dataset_id for dataset in registry.runnable_measured_harvest_datasets()] == ["measured_demo"]
+    assert [dataset.dataset_id for dataset in registry.draft_datasets()] == ["proxy_demo"]
+
+
+def test_dataset_registry_lists_capabilities_and_separates_drafts_from_runnable_denominator() -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _dataset(
+                "measured_live",
+                capability=DatasetCapability.MEASURED_HARVEST,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+            ),
+            _dataset(
+                "measured_basis_blocked",
+                capability=DatasetCapability.MEASURED_HARVEST,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_BASIS_METADATA,
+                reporting_basis="unknown",
+                plants_per_m2=None,
+                blocker_codes=("missing_reporting_basis",),
+            ),
+            _dataset(
+                "proxy_demo",
+                capability=DatasetCapability.HARVEST_PROXY,
+                ingestion_status=DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE,
+                observation_family="yield_environment",
+                reporting_basis="unknown",
+                plants_per_m2=None,
+                blocker_codes=("missing_raw_fixture",),
+            ),
+            _dataset(
+                "context_demo",
+                capability=DatasetCapability.CONTEXT_ONLY,
+                ingestion_status=DatasetIngestionStatus.RUNNABLE,
+                observation_family="environment",
+                reporting_basis="unknown",
+                plants_per_m2=None,
+            ),
+        ),
+        default_dataset_ids=("measured_live",),
+    )
+
+    assert [dataset.dataset_id for dataset in registry.list_by_capability(DatasetCapability.MEASURED_HARVEST.value)] == [
+        "measured_live",
+        "measured_basis_blocked",
+    ]
+    assert [dataset.dataset_id for dataset in registry.runnable_measured_harvest_datasets()] == ["measured_live"]
+    assert [dataset.dataset_id for dataset in registry.draft_datasets()] == [
+        "measured_basis_blocked",
+        "proxy_demo",
+    ]
+    blocker_frame = registry.blocker_frame()
+    assert set(blocker_frame["dataset_id"]) == {"measured_basis_blocked", "proxy_demo", "context_demo"}
+
+
+def test_dataset_registry_can_ignore_missing_optional_snapshot(tmp_path: Path) -> None:
+    config = {
+        "validation": {
+            "datasets": {
+                "registry_snapshot_path": "configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json",
+                "allow_missing_registry_snapshot": True,
+                "default_dataset_ids": ["demo"],
+                "items": [
+                    {
+                        "dataset_id": "demo",
+                        "dataset_kind": "fixture",
+                        "display_name": "Demo",
+                        "forcing_path": "forcing.csv",
+                        "observed_harvest_path": "harvest.csv",
+                        "validation_start": "2025-01-01",
+                        "validation_end": "2025-01-31",
+                        "basis": {"reporting_basis": "floor_area_g_m2", "plants_per_m2": 1.7},
+                        "observation": {
+                            "date_column": "date",
+                            "measured_cumulative_column": "measured",
+                        },
+                    }
+                ],
+            }
+        }
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    registry = load_dataset_registry(config, repo_root=tmp_path, config_path=config_path)
+
+    assert registry.default_dataset_ids == ("demo",)
+    assert [dataset.dataset_id for dataset in registry.datasets] == ["demo"]
+
+
+def test_dataset_registry_snapshot_nonexistent_paths_do_not_become_runnable(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_payload = {
+        "default_dataset_ids": [],
+        "datasets": [
+            {
+                "dataset_id": "paper_only",
+                "dataset_kind": "fixture",
+                "display_name": "Paper Only",
+                "dataset_family": "public_rda",
+                "observation_family": "yield",
+                "capability": "measured_harvest",
+                "ingestion_status": "runnable",
+                "forcing_path": "missing_forcing.csv",
+                "observed_harvest_path": "missing_harvest.csv",
+                "validation_start": "2025-01-01",
+                "validation_end": "2025-01-31",
+                "basis": {"reporting_basis": "floor_area_g_m2", "plants_per_m2": 1.7},
+                "observation": {"date_column": "date", "measured_cumulative_column": "measured"},
+                "sanitized_fixture": {
+                    "forcing_fixture_path": "missing_forcing.csv",
+                    "observed_harvest_fixture_path": "missing_harvest.csv",
+                },
+            }
+        ],
+    }
+    snapshot_path.write_text(json.dumps(snapshot_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    config = {"validation": {"datasets": {"registry_snapshot_path": str(snapshot_path)}}}
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    registry = load_dataset_registry(config, repo_root=tmp_path, config_path=config_path)
+    dataset = registry.require("paper_only")
+
+    assert dataset.forcing_path is None
+    assert dataset.observed_harvest_path is None
+    assert dataset.sanitized_fixture.is_complete is False
+    assert [item.dataset_id for item in registry.runnable_measured_harvest_datasets()] == []
+
+
+def test_dataset_registry_explicit_items_overlay_snapshot_rows_instead_of_replacing_them(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "snapshot.json"
+    forcing_path = tmp_path / "forcing.csv"
+    harvest_path = tmp_path / "harvest.csv"
+    forcing_path.write_text("datetime,T_air_C\n2025-01-01,24\n", encoding="utf-8")
+    harvest_path.write_text("date,measured\n2025-01-01,1.0\n", encoding="utf-8")
+    snapshot_payload = {
+        "default_dataset_ids": [],
+        "datasets": [
+            {
+                "dataset_id": "review_candidate",
+                "dataset_kind": "traitenv_candidate",
+                "display_name": "Review Candidate",
+                "dataset_family": "public_rda",
+                "observation_family": "yield",
+                "capability": "measured_harvest",
+                "ingestion_status": "draft_needs_harvest_mapping",
+                "source_refs": ["bundle/yield.csv"],
+                "forcing_path": "forcing.csv",
+                "observed_harvest_path": "harvest.csv",
+                "validation_start": "2025-01-01",
+                "validation_end": "2025-01-31",
+                "basis": {"reporting_basis": "floor_area_g_m2", "plants_per_m2": 1.7},
+                "observation": {"date_column": "date", "measured_cumulative_column": None},
+                "sanitized_fixture": {
+                    "forcing_fixture_path": "forcing.csv",
+                    "observed_harvest_fixture_path": "harvest.csv",
+                },
+                "notes": {"candidate_harvest_column": "total_yield_weight_g"},
+                "provenance_tags": ["traitenv"],
+            }
+        ],
+    }
+    snapshot_path.write_text(json.dumps(snapshot_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    config = {
+        "validation": {
+            "datasets": {
+                "registry_snapshot_path": str(snapshot_path),
+                "items": [
+                    {
+                        "dataset_id": "review_candidate",
+                        "greenhouse": "demo-house",
+                        "observation": {"measured_cumulative_column": "measured"},
+                    }
+                ],
+            }
+        }
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    registry = load_dataset_registry(config, repo_root=tmp_path, config_path=config_path)
+    dataset = registry.require("review_candidate")
+
+    assert dataset.dataset_family == "public_rda"
+    assert dataset.greenhouse == "demo-house"
+    assert dataset.source_refs == ("bundle/yield.csv",)
+    assert dataset.notes["candidate_harvest_column"] == "total_yield_weight_g"
+    assert dataset.observation.measured_cumulative_column == "measured"
+    assert dataset.sanitized_fixture.is_complete is True

--- a/tests/test_multidataset_runner_guards.py
+++ b/tests/test_multidataset_runner_guards.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def _load_script_module(module_name: str, relative_script_path: str):
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / relative_script_path
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load script module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_multidataset_factorial_runner_requires_explicit_root_for_non_knu_runnable_dataset(tmp_path: Path) -> None:
+    module = _load_script_module(
+        "run_tomics_multidataset_harvest_factorial_module",
+        "scripts/run_tomics_multidataset_harvest_factorial.py",
+    )
+    forcing_path = tmp_path / "forcing.csv"
+    harvest_path = tmp_path / "harvest.csv"
+    output_root = tmp_path / "out"
+    forcing_path.write_text("datetime,T_air_C\n2025-01-01,24\n", encoding="utf-8")
+    harvest_path.write_text("date,measured\n2025-01-01,1.0\n", encoding="utf-8")
+    config = {
+        "validation": {
+            "datasets": {
+                "items": [
+                    {
+                        "dataset_id": "public_demo",
+                        "dataset_kind": "fixture",
+                        "display_name": "Public Demo",
+                        "dataset_family": "public_rda",
+                        "observation_family": "yield",
+                        "capability": "measured_harvest",
+                        "ingestion_status": "runnable",
+                        "forcing_path": str(forcing_path),
+                        "observed_harvest_path": str(harvest_path),
+                        "validation_start": "2025-01-01",
+                        "validation_end": "2025-01-31",
+                        "basis": {"reporting_basis": "floor_area_g_m2", "plants_per_m2": 1.7},
+                        "observation": {"date_column": "date", "measured_cumulative_column": "measured"},
+                        "sanitized_fixture": {
+                            "forcing_fixture_path": str(forcing_path),
+                            "observed_harvest_fixture_path": str(harvest_path),
+                        },
+                    }
+                ]
+            },
+            "multidataset_factorial": {
+                "output_root": str(output_root),
+                "dataset_factorial_roots": {},
+            },
+        }
+    }
+    config_path = tmp_path / "factorial.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    result = module.run_multidataset_harvest_factorial(config, repo_root=tmp_path, config_path=config_path)
+
+    assert result["scorecard_rows"] == 0
+    skip_df = pd.read_csv(output_root / "dataset_skip_report.csv")
+    assert skip_df.loc[0, "dataset_id"] == "public_demo"
+    assert skip_df.loc[0, "skip_reason"] == "missing_dataset_factorial_root"
+
+
+def test_multidataset_promotion_gate_fails_when_required_upstream_artifacts_are_missing(tmp_path: Path) -> None:
+    module = _load_script_module(
+        "run_tomics_multidataset_harvest_promotion_gate_module",
+        "scripts/run_tomics_multidataset_harvest_promotion_gate.py",
+    )
+    config = {
+        "validation": {
+            "multidataset_promotion_gate": {
+                "scorecard_root": str(tmp_path / "missing"),
+                "output_root": str(tmp_path / "out"),
+            }
+        }
+    }
+
+    try:
+        module.run_multidataset_harvest_promotion_gate(
+            config,
+            repo_root=tmp_path,
+            config_path=tmp_path / "gate.yaml",
+        )
+    except FileNotFoundError as exc:
+        assert "cross_dataset_scorecard.csv" in str(exc)
+    else:
+        raise AssertionError("Expected promotion gate to fail when upstream scorecard artifacts are missing.")

--- a/tests/test_tomics_knu_data_contract.py
+++ b/tests/test_tomics_knu_data_contract.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pandas as pd
 import yaml
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.data_contract import (
     resolve_knu_data_contract,
     write_data_contract_manifest,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
+    observed_floor_area_yield,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.knu_data import load_knu_validation_data
 
@@ -32,6 +36,12 @@ def test_knu_data_contract_resolves_private_root_and_writes_manifest(tmp_path: P
                 "yield_relative_path": "data/forcing/tomato_validation_data_yield_260222.csv",
                 "reporting_basis": "floor_area_g_m2",
                 "plants_per_m2": 1.836091,
+                "observation": {
+                    "date_column": "Date",
+                    "measured_cumulative_column": "Measured_Cumulative_Total_Fruit_DW (g/m^2)",
+                    "estimated_cumulative_column": "Estimated_Cumulative_Total_Fruit_DW (g/m^2)",
+                    "measured_semantics": "cumulative_harvested_fruit_dry_weight_floor_area",
+                },
             },
             sort_keys=False,
             allow_unicode=False,
@@ -47,9 +57,72 @@ def test_knu_data_contract_resolves_private_root_and_writes_manifest(tmp_path: P
     contract = resolve_knu_data_contract(validation_cfg=validation_cfg, repo_root=repo_root, config_path=contract_path)
     assert contract.forcing_source_kind == "private_root"
     assert contract.yield_source_kind == "private_root"
+    assert contract.date_column == "Date"
+    assert contract.measured_cumulative_column == "Measured_Cumulative_Total_Fruit_DW (g/m^2)"
+    assert contract.estimated_cumulative_column == "Estimated_Cumulative_Total_Fruit_DW (g/m^2)"
     data = load_knu_validation_data(forcing_path=contract.forcing_path, yield_path=contract.yield_path)
     manifest_path = write_data_contract_manifest(output_root=tmp_path / "out", contract=contract, data=data)
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["reporting_basis"] == "floor_area_g_m2"
     assert manifest["plants_per_m2"] == 1.836091
+    assert manifest["observation_columns"]["date"] == "Date"
     assert manifest["parser_assumptions"]["observation_semantics"] == "cumulative_harvested_fruit_dry_weight_floor_area"
+
+
+def test_load_knu_validation_data_honors_explicit_observation_columns(tmp_path: Path) -> None:
+    forcing_path = tmp_path / "forcing.csv"
+    forcing_path.write_text(
+        "\n".join(
+            [
+                "datetime,T_air_C,PAR_umol,CO2_ppm,RH_percent,wind_speed_ms",
+                "2025-01-01 00:00:00,20,200,400,70,0.5",
+                "2025-01-01 01:00:00,20,220,400,69,0.5",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    yield_path = tmp_path / "yield.csv"
+    yield_path.write_text(
+        "\n".join(
+            [
+                "stamp,harvest_obs,harvest_est,notes",
+                "2025-01-01,1.0,1.2,a",
+                "2025-01-02,2.0,2.2,b",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    data = load_knu_validation_data(
+        forcing_path=forcing_path,
+        yield_path=yield_path,
+        date_column="stamp",
+        measured_column="harvest_obs",
+        estimated_column="harvest_est",
+    )
+
+    assert data.date_column == "stamp"
+    assert data.measured_column == "harvest_obs"
+    assert data.estimated_column == "harvest_est"
+    assert data.yield_summary["start"].startswith("2025-01-01")
+    assert data.yield_summary["end"].startswith("2025-01-02")
+
+
+def test_observed_floor_area_yield_normalizes_per_plant_input_to_floor_area() -> None:
+    yield_df = pd.DataFrame.from_records(
+        [
+            {"stamp": "2025-01-01", "harvest_obs": 1.0, "harvest_est": 1.5},
+            {"stamp": "2025-01-02", "harvest_obs": 2.0, "harvest_est": 2.5},
+        ]
+    )
+    observed = observed_floor_area_yield(
+        yield_df=yield_df,
+        date_column="stamp",
+        measured_column="harvest_obs",
+        estimated_column="harvest_est",
+        reporting_basis="g_per_plant",
+        plants_per_m2=2.0,
+    )
+
+    assert observed["measured_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [2.0, 4.0]
+    assert observed["estimated_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [3.0, 5.0]

--- a/tests/test_tomics_multidataset_harvest_factorial_runner.py
+++ b/tests/test_tomics_multidataset_harvest_factorial_runner.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "run_tomics_multidataset_harvest_factorial.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "tomics_multidataset_harvest_factorial_runner_script",
+        _script_path(),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_dataset_files(tmp_path: Path, dataset_id: str) -> dict[str, object]:
+    forcing_path = tmp_path / f"{dataset_id}_forcing.csv"
+    harvest_path = tmp_path / f"{dataset_id}_harvest.csv"
+    forcing_path.write_text("datetime,T_air_C\n2025-01-01,24\n", encoding="utf-8")
+    harvest_path.write_text("date,measured\n2025-01-01,1.0\n", encoding="utf-8")
+    return {
+        "dataset_id": dataset_id,
+        "dataset_kind": "fixture",
+        "display_name": dataset_id,
+        "dataset_family": "fixture_family",
+        "observation_family": "yield",
+        "capability": "measured_harvest",
+        "ingestion_status": "runnable",
+        "forcing_path": str(forcing_path),
+        "observed_harvest_path": str(harvest_path),
+        "validation_start": "2025-01-01",
+        "validation_end": "2025-01-31",
+        "basis": {"reporting_basis": "floor_area_g_m2", "plants_per_m2": 1.7},
+        "observation": {"date_column": "date", "measured_cumulative_column": "measured"},
+        "sanitized_fixture": {
+            "forcing_fixture_path": str(forcing_path),
+            "observed_harvest_fixture_path": str(harvest_path),
+        },
+    }
+
+
+def _write_factorial_outputs(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "fruit_harvest_family": "dekoning_fds",
+                "leaf_harvest_family": "vegetative_unit_pruning",
+                "fdmc_mode": "dekoning_fds",
+                "mean_score": -8.0,
+                "mean_rmse_cumulative_offset": 4.0,
+                "mean_rmse_daily_increment": 1.5,
+                "max_harvest_mass_balance_error": 0.0,
+                "max_canopy_collapse_days": 2.0,
+                "mean_native_family_state_fraction": 0.8,
+                "mean_proxy_family_state_fraction": 0.2,
+                "mean_shared_tdvs_proxy_fraction": 0.1,
+                "family_state_mode_distribution": json.dumps({"native_payload": 0.8}, sort_keys=True),
+                "proxy_mode_used_distribution": json.dumps({"false": 0.8, "true": 0.2}, sort_keys=True),
+            }
+        ]
+    ).to_csv(root / "candidate_ranking.csv", index=False)
+    (root / "selected_harvest_family.json").write_text(
+        json.dumps(
+            {
+                "selected_fruit_harvest_family": "dekoning_fds",
+                "selected_leaf_harvest_family": "vegetative_unit_pruning",
+                "selected_fdmc_mode": "dekoning_fds",
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_multidataset_factorial_runner_does_not_reuse_knu_root_for_unmapped_dataset(tmp_path: Path) -> None:
+    module = _load_script_module()
+    knu_factorial_root = tmp_path / "out" / "tomics_knu_harvest_family_factorial"
+    _write_factorial_outputs(knu_factorial_root)
+
+    config = {
+        "validation": {
+            "datasets": {
+                "default_dataset_ids": ["knu_actual"],
+                "items": [
+                    _write_dataset_files(tmp_path, "knu_actual"),
+                    _write_dataset_files(tmp_path, "school_demo"),
+                ],
+            },
+            "multidataset_factorial": {
+                "output_root": str(tmp_path / "multidataset-output"),
+                "dataset_factorial_roots": {
+                    "knu_actual": str(knu_factorial_root),
+                },
+            },
+        }
+    }
+    config_path = tmp_path / "tomics_multidataset.yaml"
+    config_path.write_text("validation: {}\n", encoding="utf-8")
+
+    result = module.run_multidataset_harvest_factorial(
+        config,
+        repo_root=tmp_path,
+        config_path=config_path,
+    )
+    output_root = Path(result["output_root"])
+    selected_payload = json.loads((output_root / "per_dataset_selected_families.json").read_text(encoding="utf-8"))
+    skipped_df = pd.read_csv(output_root / "dataset_skip_report.csv")
+    scorecard_df = pd.read_csv(output_root / "cross_dataset_scorecard.csv")
+
+    assert result["runnable_measured_dataset_count"] == 2
+    assert [row["dataset_id"] for row in selected_payload["datasets"]] == ["knu_actual"]
+    assert set(scorecard_df["dataset_ids"]) == {json.dumps(["knu_actual"])}
+    school_skip = skipped_df.loc[skipped_df["dataset_id"].eq("school_demo")]
+    assert not school_skip.empty
+    assert school_skip.iloc[0]["skip_reason"] == "missing_dataset_factorial_root"

--- a/tests/test_traitenv_importer_smoke.py
+++ b/tests/test_traitenv_importer_smoke.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+from tests.test_traitenv_loader import _write_traitenv_fixture
+
+
+def test_import_traitenv_dataset_candidates_script_accepts_zip_bundle(tmp_path: Path) -> None:
+    traitenv_root = tmp_path / "traitenv"
+    archive_path = tmp_path / "traitenv.zip"
+    output_root = tmp_path / "out"
+    reviewed_dir = tmp_path / "reviewed"
+    _write_traitenv_fixture(traitenv_root)
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for file_path in sorted(traitenv_root.iterdir()):
+            archive.write(file_path, arcname=file_path.name)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/import_traitenv_dataset_candidates.py",
+            "--traitenv-root",
+            str(archive_path),
+            "--output-root",
+            str(output_root),
+            "--reviewed-manifest-dir",
+            str(reviewed_dir),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (output_root / "dataset_capability_table.csv").exists()
+    assert (output_root / "dataset_blocker_report.md").exists()
+    assert (output_root / "dataset_registry_snapshot.json").exists()
+    assert (reviewed_dir / "traitenv_candidate_registry.json").exists()
+    assert (reviewed_dir / "review_template_index.json").exists()
+    assert (reviewed_dir / "review_templates" / "school_trait_bundle__yield.review.json").exists()
+
+    snapshot = json.loads((output_root / "dataset_registry_snapshot.json").read_text(encoding="utf-8"))
+    dataset_ids = {row["dataset_id"] for row in snapshot["datasets"]}
+    assert "school_trait_bundle__yield" in dataset_ids
+    assert "public_bigdata_platform__yield_environment" in dataset_ids

--- a/tests/test_traitenv_loader.py
+++ b/tests/test_traitenv_loader.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetCapability,
+    DatasetIngestionStatus,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.metadata import (
+    build_dataset_review_template,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.traitenv_loader import (
+    build_traitenv_candidate_registry,
+    load_traitenv_inventory,
+)
+
+
+def _write_traitenv_fixture(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        [
+            {
+                "source_group": "school_traits",
+                "source_kind": "school",
+                "dataset_family": "school_trait_bundle",
+                "observation_family": "yield",
+                "relative_path": "school/yield.xlsx",
+            },
+            {
+                "source_group": "public_data",
+                "source_kind": "public",
+                "dataset_family": "public_bigdata_platform",
+                "observation_family": "yield_environment",
+                "relative_path": "public/yield_env.csv",
+            },
+            {
+                "source_group": "school_environment",
+                "source_kind": "school",
+                "dataset_family": "school_greenhouse_environment",
+                "observation_family": "environment",
+                "relative_path": "school/env.csv",
+            },
+        ]
+    ).to_csv(root / "source_inventory.csv", index=False, encoding="utf-8-sig")
+    pd.DataFrame(
+        [
+            {"source_group": "school_traits", "dataset_family": "school_trait_bundle", "observation_family": "yield", "n_files": 1},
+            {"source_group": "public_data", "dataset_family": "public_bigdata_platform", "observation_family": "yield_environment", "n_files": 1},
+            {"source_group": "school_environment", "dataset_family": "school_greenhouse_environment", "observation_family": "environment", "n_files": 1},
+        ]
+    ).to_csv(root / "source_summary.csv", index=False, encoding="utf-8-sig")
+    pd.DataFrame(
+        [
+            {"standard_name": "observation_date", "domain": "identifier", "unit_std": "date", "grain_hint": "all", "raw_aliases": "DATE", "notes": ""},
+            {"standard_name": "total_yield_weight_g", "domain": "yield", "unit_std": "g", "grain_hint": "line_or_truss_day", "raw_aliases": "fruit_weight_g + fallen_fruit_weight_g", "notes": ""},
+        ]
+    ).to_csv(root / "variable_dictionary.csv", index=False, encoding="utf-8-sig")
+    pd.DataFrame(
+        [
+            {"rule_id": "school_total_yield_weight", "scope": "school_yield", "target_field": "total_yield_weight_g", "priority": 1, "expression": "fruit_weight_g + fallen_fruit_weight_g", "notes": ""},
+        ]
+    ).to_csv(root / "comparison_rules.csv", index=False, encoding="utf-8-sig")
+    (root / "integration_contract.json").write_text(
+        json.dumps({"fact_tables": [{"name": "comparison_daily"}]}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (root / "run_manifest.json").write_text(
+        json.dumps({"n_files": 3, "n_dataset_families": 3}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    pd.DataFrame(
+        [{"slice_type": "season_domain", "slice_key": "2025__yield", "season_key": "2025", "domain_key": "yield", "path": "workbooks/2025/yield.xlsx", "observation_rows": 10, "measurement_rows": 10, "comparison_rows": 10}]
+    ).to_csv(root / "workbook_index.csv", index=False, encoding="utf-8-sig")
+    (root / "traitenv_design_workbook.xlsx").write_bytes(b"placeholder-workbook")
+    pd.DataFrame(
+        [
+            {"comparison_date": "2025-01-01", "dataset_family": "school_trait_bundle", "observation_family": "yield", "season_label": "2025", "treatment": "Control", "comparison_entity": "A", "standard_name": "total_yield_weight_g", "aggregation_stat": "sum", "n_values": 1, "value_mean": 10.0, "value_min": 10.0, "value_max": 10.0, "value_sum": 10.0},
+            {"comparison_date": "2025-01-02", "dataset_family": "public_bigdata_platform", "observation_family": "yield_environment", "season_label": "2025", "treatment": "", "comparison_entity": "site-1", "standard_name": "fruit_weight_g", "aggregation_stat": "mean", "n_values": 1, "value_mean": 5.0, "value_min": 5.0, "value_max": 5.0, "value_sum": 5.0},
+        ]
+    ).to_csv(root / "comparison_daily.csv", index=False, encoding="utf-8-sig")
+
+
+def test_traitenv_loader_classifies_candidates_conservatively(tmp_path: Path) -> None:
+    traitenv_root = tmp_path / "traitenv"
+    _write_traitenv_fixture(traitenv_root)
+
+    inventory = load_traitenv_inventory(traitenv_root)
+    registry = build_traitenv_candidate_registry(inventory)
+
+    measured = registry.require("school_trait_bundle__yield")
+    proxy = registry.require("public_bigdata_platform__yield_environment")
+    context = registry.require("school_greenhouse_environment__environment")
+
+    assert measured.capability is DatasetCapability.MEASURED_HARVEST
+    assert measured.ingestion_status is DatasetIngestionStatus.DRAFT_NEEDS_RAW_FIXTURE
+    assert measured.observation.date_column is None
+    assert measured.observation.daily_increment_column is None
+    assert measured.notes["candidate_date_key"] == "observation_date"
+    assert measured.notes["candidate_harvest_column"] == "total_yield_weight_g"
+    assert "missing_date_column" in measured.blocker_codes
+    assert "missing_measured_cumulative_column" in measured.blocker_codes
+    assert measured.notes["candidate_harvest_includes_fallen_fruit"] is True
+    assert proxy.capability is DatasetCapability.HARVEST_PROXY
+    assert proxy.observation.measured_cumulative_column is None
+    assert proxy.observation.daily_increment_column is None
+    assert proxy.notes["candidate_harvest_column"] is None
+    assert proxy.notes["candidate_harvest_requires_cumulative_construction"] is False
+    assert context.capability is DatasetCapability.CONTEXT_ONLY
+    assert registry.default_dataset_ids == ()
+
+
+def test_traitenv_review_template_exposes_missing_measured_harvest_fields(tmp_path: Path) -> None:
+    traitenv_root = tmp_path / "traitenv"
+    _write_traitenv_fixture(traitenv_root)
+
+    registry = build_traitenv_candidate_registry(traitenv_root)
+    measured = registry.require("school_trait_bundle__yield")
+    template = build_dataset_review_template(measured)
+
+    assert template["dataset_id"] == "school_trait_bundle__yield"
+    assert "missing_measured_cumulative_column" in template["blocker_codes"]
+    assert template["candidate_schema_hints"]["candidate_harvest_column"] == "total_yield_weight_g"
+    assert template["candidate_schema_hints"]["candidate_date_key"] == "observation_date"
+    assert template["review_updates"]["observation"]["date_column"] is None
+    assert template["review_updates"]["observation"]["measured_cumulative_column"] is None
+    assert template["promotion_ready_checklist"]["sanitized_fixture_pair"] is False
+
+
+def test_import_traitenv_dataset_candidates_script_smoke(tmp_path: Path) -> None:
+    traitenv_root = tmp_path / "traitenv"
+    output_root = tmp_path / "out"
+    reviewed_dir = tmp_path / "reviewed"
+    _write_traitenv_fixture(traitenv_root)
+
+    result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/import_traitenv_dataset_candidates.py",
+                "--traitenv-root",
+                str(traitenv_root),
+                "--output-root",
+                str(output_root),
+                "--reviewed-manifest-dir",
+                str(reviewed_dir),
+            ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (output_root / "dataset_capability_table.csv").exists()
+    assert (output_root / "dataset_blockers.csv").exists()
+    assert (output_root / "dataset_blocker_report.md").exists()
+    assert (output_root / "dataset_registry_snapshot.json").exists()
+    assert (reviewed_dir / "traitenv_candidate_registry.json").exists()
+    assert (reviewed_dir / "review_template_index.json").exists()
+    assert (reviewed_dir / "review_templates" / "school_trait_bundle__yield.review.json").exists()

--- a/tests/test_windows_sitecustomize.py
+++ b/tests/test_windows_sitecustomize.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific startup guard")
+def test_windows_platform_wmi_guard_is_active_in_test_process() -> None:
+    if os.environ.get("PHYTORITAS_ALLOW_PLATFORM_WMI", "").strip().lower() in {"1", "true", "yes"}:
+        pytest.skip("Repo-local platform WMI guard explicitly disabled")
+
+    assert getattr(platform, "_phytoritas_wmi_guard", False) is True
+    with pytest.raises(OSError, match="disabled by"):
+        platform._wmi_query("CPU", "Architecture")  # type: ignore[attr-defined]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific startup guard")
+def test_windows_platform_wmi_guard_preserves_fast_platform_machine_fallback() -> None:
+    machine = platform.machine()
+    assert isinstance(machine, str)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific startup guard")
+def test_repo_package_import_guard_allows_pandas_backed_validation_import() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    probe_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            dir=repo_root,
+            delete=False,
+            encoding="utf-8",
+        ) as handle:
+            handle.write(
+                "from pathlib import Path\n"
+                "import sys\n"
+                "repo_root = Path(__file__).resolve().parent\n"
+                "sys.path.insert(0, str(repo_root / 'src'))\n"
+                "from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.cross_dataset_gate import (\n"
+                "    cross_dataset_proxy_guardrail,\n"
+                ")\n"
+                "print(cross_dataset_proxy_guardrail.__name__)\n"
+            )
+            probe_path = Path(handle.name)
+        completed = subprocess.run(
+            [sys.executable, str(probe_path)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    finally:
+        if probe_path is not None and probe_path.exists():
+            probe_path.unlink()
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip()


### PR DESCRIPTION
## Background
- PR `#260` merged the multidataset scaffold, but the current verified follow-up still needs a dedicated recording pass for stricter gate semantics, reviewed-candidate wiring, and Windows-safe validation imports.

## Changes
- require explicit runnable measured-harvest registry evidence before the public cross-dataset guardrail can pass
- keep proxy and context-only datasets visible in diagnostics while excluding them from the promotion denominator
- wire the reviewed `traitenv` candidate snapshot into the multidataset factorial config without fabricating runnable datasets
- emit clearer multidataset blocker and skip artifacts under `out/tomics/validation/multidataset/`
- harden Windows validation imports by guarding the repo-owned `pytest` and package-import seams that actually execute on this machine

## Validation
- `.\.venv\Scripts\ruff.exe check .`
- `.\.venv\Scripts\python.exe -m pytest`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_windows_sitecustomize.py tests\test_traitenv_importer_smoke.py`

## Impact
- promotion remains conservative and still requires at least two runnable measured-harvest datasets
- current denominator remains `1` runnable measured-harvest dataset (`knu_actual`)
- dataset `#2` is still blocked by missing sanitized fixture, basis metadata, and explicit cumulative-harvest mapping
- Windows pytest/import verification is green again without relying on inactive auxiliary startup files

## Linked issue
Closes #261
