### PR TITLE
[Data Prep] Formalize TOMICS private-reviewed traitenv workflow for school validation

### DIFF
--- a/docs/architecture/delivery/tomics-traitenv-private-reviewed-workflow-decision.md
+++ b/docs/architecture/delivery/tomics-traitenv-private-reviewed-workflow-decision.md
@@ -1,0 +1,93 @@
+# TOMICS traitenv private-reviewed workflow decision
+
+## Problem statement
+
+Issue `#265` now has a working private-reviewed derivative path for `school_trait_bundle__yield`, but the operational policy was still implicit.
+
+The repository needed an explicit answer to this question:
+
+- does `traitenv_school_validation` stay the official **manual-reviewed derivative workflow**
+- or does it become an official **repo-local helper with guarded source-sync support**
+
+This decision also had to stay separate from PR `#264`, which covers the lane-matrix architecture on another branch.
+
+## Options considered
+
+### Option A. Manual-reviewed derivative workflow
+
+Pros:
+
+- strongest provenance boundary
+- easiest to explain in docs and PR text
+- lowest risk of private-source leakage
+- easiest to keep separate from public promotion semantics
+
+Cons:
+
+- more operator friction
+- repeated sync/rebuild steps remain manual
+
+### Option B. Repo-local helper with guarded source-sync support
+
+Pros:
+
+- more reproducible local operator flow
+- less repeated setup friction
+- easier to rerun from cloned private bundles
+
+Cons:
+
+- larger policy surface
+- higher risk of blurring private derivative vs promotable public dataset
+- would require stricter path and promotion guardrails than the current helper provides
+
+## Decision
+
+Choose **Option A** as the official repository workflow for this step.
+
+The existing repo-local helper remains available, but only as a **bounded local preparation utility** for the manual-reviewed workflow.
+
+That means:
+
+- manual review remains the default provenance boundary
+- the helper does not become the policy source of truth for promotion
+- the committed public candidate registry remains conservative and review-only
+- local helper outputs remain private-output artifacts, not public promotion evidence
+
+## Why Option B is not chosen now
+
+Option B was rejected for now because the current helper does not yet satisfy the stricter reading required for official source-sync automation.
+
+Current gaps:
+
+1. path recovery is not limited to explicit local paths or `.source_origin.json`; the helper still supports adjacent `outputs/traitenv` inference
+2. `--approve-runnable-contract` can produce a locally runnable private overlay, which is acceptable for a bounded private workflow but is still too easy to misread as broader promotion widening
+3. the branch still has heavy semantic overlap with PR `#264`, so formal source-sync promotion would further blur issue boundaries right before PR closure work
+
+## Revisit criteria
+
+Option B can be reconsidered only after all of the following are true:
+
+1. raw workbook recovery is limited to explicit local path input or `.source_origin.json`
+2. helper approval semantics are split clearly enough that private runnable preparation cannot be mistaken for public promotion eligibility
+3. regression tests cover `.source_origin.json` recovery and the promotion-boundary contract
+4. the issue `#265` branch is disentangled from PR `#264` overlap enough to open a clean workflow/productization PR
+
+## Branch relation to PR #264
+
+PR `#264` is a neighboring lane-matrix effort on branch `feat/263-add-tomics-lane-matrix-comparison-architecture`.
+
+For this issue:
+
+- do not treat PR `#264` as this branch's PR
+- do not treat PR `#264` as this branch's merge signal
+- if this branch keeps stacked local overlap, the future PR text must say that explicitly
+
+## Immediate consequence
+
+For the current branch closure pass, the smallest correct step is:
+
+- document the manual-reviewed default
+- keep the existing helper bounded and explicit
+- strengthen provenance/test coverage around `.source_origin.json`
+- prepare commit/push/PR-ready notes without claiming promotion widening

--- a/docs/architecture/implementation/tomics-school-traitenv-private-validation.md
+++ b/docs/architecture/implementation/tomics-school-traitenv-private-validation.md
@@ -1,0 +1,146 @@
+# TOMICS school traitenv private validation path
+
+## Why this exists
+
+The committed public traitenv snapshot remains intentionally conservative.
+
+- `configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json` keeps `school_trait_bundle__yield` review-only.
+- the literature dry-matter seam stays visible on review and diagnostic surfaces.
+- public promotion logic must not silently turn the school dataset runnable.
+
+This implementation adds a separate **private reviewed derivative path** for the cloned traitenv bundle under `out/private-data/traitenv`.
+
+## Official workflow status
+
+For issue `#265`, the repository treats this path as **manual-reviewed derivative workflow by default**.
+
+- the repo-local helper is kept as a bounded preparation utility
+- it is not the source of truth for public promotion eligibility
+- it does not mutate the committed public registry snapshot
+- it does not replace the incumbent TOMICS gate policy
+
+This is intentionally more conservative than a full source-sync automation policy.
+
+## What the private helper does
+
+`scripts/prepare_traitenv_school_validation.py` reads three school-specific partition tables from the cloned bundle:
+
+- `school_crop_info__metadata`
+- `school_greenhouse_environment__environment`
+- `school_trait_bundle__yield` from `comparison_daily`
+
+It then derives:
+
+1. a KNU-compatible forcing CSV
+2. a KNU-compatible cumulative harvested DW CSV
+3. a dataset overlay payload for `validation.datasets.items`
+4. generated configs for:
+   - current-vs-promoted factorial
+   - harvest-family factorial
+   - multidataset harvest factorial
+   - multidataset promotion gate
+
+When the cloned `school_crop_info__metadata` surface only contains notes or mixed review rows, the helper falls back to the raw tomato common workbook:
+
+- `40_작업·재배정보/토마토_재배정보_공통.xlsx`
+
+That fallback supplies:
+
+- crop start / end
+- floor-area basis metadata
+- plant density
+
+## Contract semantics
+
+The helper does **not** edit the committed public registry snapshot.
+
+- without `--approve-runnable-contract`, the generated overlay still carries `dry_matter_conversion.review_only = true`
+- with `--approve-runnable-contract`, the overlay clears only that blocker because the helper also supplies the missing runtime contract fields:
+  - `forcing_path`
+  - `observed_harvest_path`
+  - `date_column`
+  - `measured_cumulative_column`
+  - `reporting_basis`
+  - `validation_start` / `validation_end`
+  - sanitized fixture pair
+
+This keeps the original rule intact: review-only FWDW conversion never becomes runnable by accident.
+
+Even with `--approve-runnable-contract`, the effect remains scoped to the generated **private overlay and generated private configs** under the chosen output root.
+
+- the committed public candidate snapshot remains review-only
+- public `promotion_surface.csv` semantics remain unchanged
+- this helper run must not be cited as a public promotion-clear signal by itself
+
+## Source mapping
+
+- basis metadata comes from `school_crop_info__metadata` when it already carries the runtime fields
+- otherwise basis metadata falls back to `40_작업·재배정보/토마토_재배정보_공통.xlsx`
+- greenhouse forcing comes from `school_greenhouse_environment__environment`
+- harvested fresh-weight signal comes from `school_trait_bundle__yield` in `comparison_daily`
+- cumulative harvested DW is derived with the explicit literature ratio configured in the helper
+
+For repeated local worktree runs, the cloned bundle can carry a local origin manifest:
+
+- `out/private-data/traitenv/.source_origin.json`
+
+This manifest records:
+
+- `source_traitenv_root`
+- `source_raw_repo_root`
+
+If present, the helper can run from the default cloned path and still recover the raw workbook fallback automatically.
+
+The helper currently also supports an adjacent `outputs/traitenv` layout inference. That legacy convenience is one reason the repo does **not** yet promote this path to a stricter source-sync automation policy.
+
+## Expected workflow
+
+```powershell
+poetry run python scripts/prepare_traitenv_school_validation.py --approve-runnable-contract
+poetry run python scripts/run_tomics_current_vs_promoted_factorial.py --config <generated current config> --mode both
+poetry run python scripts/run_tomics_knu_harvest_family_factorial.py --config <generated harvest config>
+poetry run python scripts/run_tomics_multidataset_harvest_factorial.py --config <generated multidataset config>
+poetry run python scripts/run_tomics_multidataset_harvest_promotion_gate.py --config <generated gate config>
+```
+
+All generated artifacts stay under the private output root and do not mutate the public review snapshot.
+
+## Reviewed derivative contract
+
+Inputs:
+
+- cloned `traitenv` root, either passed explicitly with `--traitenv-root` or available at `out/private-data/traitenv`
+- optional explicit `--raw-repo-root`
+- if no explicit raw root is passed, `.source_origin.json` may recover `source_raw_repo_root`
+- season and treatment selectors
+- explicit `--approve-runnable-contract` only when the operator intends to clear the review-only blocker in the generated private overlay
+
+Required metadata:
+
+- greenhouse environment rows for the selected season
+- school yield comparison rows for the selected season/treatment
+- crop start/end, area, and plant density from processed metadata or the raw common workbook fallback
+
+Outputs:
+
+- private forcing CSV
+- private cumulative harvested DW CSV
+- private overlay YAML/JSON
+- private manifest JSON
+- generated configs rooted under the same private output root
+
+Blockers that remain in force:
+
+- without explicit approval, `review_only_dry_matter_conversion` stays active
+- the committed public registry remains review-only regardless of local helper output
+- no helper run widens public promotion eligibility or replaces the incumbent TOMICS gate
+
+Runnable means only this:
+
+- the generated **private** overlay carries the missing runtime contract fields and clears the review-only blocker because the operator explicitly approved that private derivative contract
+
+Runnable does **not** mean:
+
+- the public registry became promotable
+- the repository default changed from manual-reviewed to automated source-sync
+- issue `#265` is complete without a separate branch/PR hygiene pass

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/contracts.py
@@ -35,6 +35,7 @@ HARVEST_MAPPING_BLOCKER_CODES = frozenset(
         "missing_date_column",
         "missing_measured_cumulative_column",
         "ambiguous_harvest_semantics",
+        "review_only_dry_matter_conversion",
     }
 )
 
@@ -140,6 +141,58 @@ class DatasetObservationContract:
 
 
 @dataclass(frozen=True, slots=True)
+class DatasetDryMatterConversionContract:
+    mode: str = "none"
+    fresh_weight_column: str | None = None
+    dry_matter_ratio: float | None = None
+    dry_matter_ratio_low: float | None = None
+    dry_matter_ratio_high: float | None = None
+    citations: tuple[str, ...] = ()
+    review_only: bool = True
+
+    def __post_init__(self) -> None:
+        mode = str(self.mode or "none").strip().lower()
+        if mode in {"", "disabled"}:
+            mode = "none"
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "fresh_weight_column", _normalize_optional_text(self.fresh_weight_column))
+        ratio = None if self.dry_matter_ratio in (None, "") else float(self.dry_matter_ratio)
+        ratio_low = None if self.dry_matter_ratio_low in (None, "") else float(self.dry_matter_ratio_low)
+        ratio_high = None if self.dry_matter_ratio_high in (None, "") else float(self.dry_matter_ratio_high)
+        for value, label in (
+            (ratio, "dry_matter_ratio"),
+            (ratio_low, "dry_matter_ratio_low"),
+            (ratio_high, "dry_matter_ratio_high"),
+        ):
+            if value is not None and not (0.0 < value < 1.0):
+                raise ValueError(f"{label} must be between 0 and 1 when provided.")
+        if ratio_low is not None and ratio_high is not None and ratio_low > ratio_high:
+            raise ValueError("dry_matter_ratio_low cannot exceed dry_matter_ratio_high.")
+        if ratio is not None and ratio_low is not None and ratio < ratio_low:
+            raise ValueError("dry_matter_ratio cannot be lower than dry_matter_ratio_low.")
+        if ratio is not None and ratio_high is not None and ratio > ratio_high:
+            raise ValueError("dry_matter_ratio cannot exceed dry_matter_ratio_high.")
+        object.__setattr__(self, "dry_matter_ratio", ratio)
+        object.__setattr__(self, "dry_matter_ratio_low", ratio_low)
+        object.__setattr__(self, "dry_matter_ratio_high", ratio_high)
+        object.__setattr__(
+            self,
+            "citations",
+            tuple(str(citation) for citation in self.citations if str(citation).strip()),
+        )
+        object.__setattr__(self, "review_only", bool(self.review_only))
+        if self.mode != "none" and self.dry_matter_ratio is None:
+            raise ValueError("dry_matter_ratio is required when dry-matter conversion mode is enabled.")
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode != "none" and self.dry_matter_ratio is not None
+
+    def to_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
 class DatasetManagementMetadata:
     pruning_records_path: Path | None = None
     defoliation_records_path: Path | None = None
@@ -215,6 +268,9 @@ class DatasetMetadataContract:
     source_refs: tuple[str, ...] = ()
     basis: DatasetBasisContract = field(default_factory=DatasetBasisContract)
     observation: DatasetObservationContract = field(default_factory=DatasetObservationContract)
+    dry_matter_conversion: DatasetDryMatterConversionContract = field(
+        default_factory=DatasetDryMatterConversionContract
+    )
     management: DatasetManagementMetadata = field(default_factory=DatasetManagementMetadata)
     sanitized_fixture: DatasetSanitizedFixtureContract = field(default_factory=DatasetSanitizedFixtureContract)
     priority_tags: tuple[str, ...] = ()
@@ -307,6 +363,7 @@ class DatasetMetadataContract:
             "season": self.season,
             "basis": self.basis.to_payload(),
             "observation": self.observation.to_payload(),
+            "dry_matter_conversion": self.dry_matter_conversion.to_payload(),
             "management": self.management.to_payload(),
             "sanitized_fixture": self.sanitized_fixture.to_payload(),
             "sanitized_fixture_path": (
@@ -363,7 +420,9 @@ def classify_blockers(dataset: DatasetMetadataContract) -> list[str]:
         if dataset.observation.measured_cumulative_column is None:
             blockers.append("missing_measured_cumulative_column")
         semantics = dataset.observation.measured_semantics.strip().lower()
-        if "cumulative_harvested" not in semantics:
+        if dataset.dry_matter_conversion.enabled and dataset.dry_matter_conversion.review_only:
+            blockers.append("review_only_dry_matter_conversion")
+        elif "cumulative_harvested" not in semantics:
             blockers.append("ambiguous_harvest_semantics")
         if not dataset.sanitized_fixture.is_complete:
             blockers.append("missing_sanitized_fixture")
@@ -402,6 +461,8 @@ def is_measured_harvest_runnable(dataset: DatasetMetadataContract) -> bool:
         return False
     if dataset.ingestion_status is not DatasetIngestionStatus.RUNNABLE:
         return False
+    if dataset.dry_matter_conversion.enabled and dataset.dry_matter_conversion.review_only:
+        return False
     if classify_blockers(dataset):
         return False
     semantics = dataset.observation.measured_semantics.strip().lower()
@@ -420,6 +481,7 @@ def is_measured_harvest_runnable(dataset: DatasetMetadataContract) -> bool:
 __all__ = [
     "DatasetBasisContract",
     "DatasetCapability",
+    "DatasetDryMatterConversionContract",
     "DatasetIngestionStatus",
     "DatasetManagementMetadata",
     "DatasetMetadataContract",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py
@@ -112,6 +112,11 @@ def dataset_registry_frame(datasets: list[DatasetMetadataContract]) -> pd.DataFr
                 "validation_end": payload["validation_end"],
                 "date_column": payload["observation"]["date_column"],
                 "measured_cumulative_column": payload["observation"]["measured_cumulative_column"],
+                "dry_matter_conversion_mode": payload["dry_matter_conversion"]["mode"],
+                "dry_matter_ratio": payload["dry_matter_conversion"]["dry_matter_ratio"],
+                "dry_matter_ratio_low": payload["dry_matter_conversion"]["dry_matter_ratio_low"],
+                "dry_matter_ratio_high": payload["dry_matter_conversion"]["dry_matter_ratio_high"],
+                "dry_matter_conversion_review_only": payload["dry_matter_conversion"]["review_only"],
                 "cultivar": payload["cultivar"],
                 "greenhouse": payload["greenhouse"],
                 "season": payload["season"],
@@ -177,6 +182,39 @@ BLOCKER_ACTIONS = {
     ),
 }
 
+DRY_MATTER_LITERATURE_REFS = (
+    (
+        "Ref 4",
+        "General mature-fruit DW/FW reported at 5.917-6.495% in a conservative whole-fruit comparison.",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC11339430/",
+    ),
+    (
+        "Ref 8",
+        "Greenhouse destructive measurements reported mean fruit dry-matter fraction 5.6%, range 4.9-6.9%.",
+        "https://linkinghub.elsevier.com/retrieve/pii/030442389400729Y",
+    ),
+    (
+        "Ref 3",
+        "Supplemental-light greenhouse tomatoes spanned 4.6-11.3%; larger-fruit lines centered near 6.6%, cherry near 9.5%.",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC8980428/",
+    ),
+    (
+        "Ref 6",
+        "Cherry tomato dry-matter fraction reached 8.2-13.9% under genotype/storage comparisons.",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC7760833/",
+    ),
+    (
+        "Ref 7",
+        "Greenhouse drought treatment shifted fruit DW/FW upward to about 9.30-9.72%.",
+        "https://pmc.ncbi.nlm.nih.gov/articles/PMC12251554/",
+    ),
+    (
+        "Ref 9",
+        "Mechanistic fruit-growth analysis reported maturity water content near 95%, supporting a review-only prior near 5% dry matter with condition-dependent spread.",
+        "https://academic.oup.com/jxb/article-lookup/doi/10.1093/jxb/erm202",
+    ),
+)
+
 
 def blocker_action_items(blocker_codes: list[str] | tuple[str, ...]) -> list[str]:
     actions: list[str] = []
@@ -187,15 +225,135 @@ def blocker_action_items(blocker_codes: list[str] | tuple[str, ...]) -> list[str
     return actions
 
 
+def _source_ref_preview(dataset: DatasetMetadataContract, *, limit: int = 3) -> str:
+    preview_refs = [str(ref) for ref in dataset.source_refs[:limit] if str(ref).strip()]
+    if not preview_refs:
+        return "no source refs recorded in the current inventory snapshot"
+    preview = "; ".join(preview_refs)
+    if len(dataset.source_refs) > limit:
+        preview += "; ..."
+    return preview
+
+
+def _default_basis_provenance_note(dataset: DatasetMetadataContract) -> str:
+    if dataset.basis.reporting_basis != "unknown":
+        return (
+            f"Reviewed basis is currently `{dataset.basis.reporting_basis}`. "
+            "Keep this provenance explicit if the dataset later becomes runnable."
+        )
+    partition_path = dataset.notes.get("candidate_partition_integrated_observations_path")
+    basis_fields_present = list(dataset.notes.get("candidate_basis_fields_present", []))
+    basis_fields_missing = list(dataset.notes.get("candidate_basis_fields_missing", []))
+    if partition_path and not basis_fields_present and basis_fields_missing:
+        return (
+            "Inventory-derived candidate only. Harmonized observation partition "
+            f"`{partition_path}` does not yet provide non-null basis evidence in `{basis_fields_missing}`. "
+            "Reporting basis remains unresolved and must be reviewed from upstream source metadata before promotion use."
+        )
+    if partition_path and basis_fields_present:
+        return (
+            "Inventory-derived candidate only. Harmonized observation partition "
+            f"`{partition_path}` exposes candidate basis-related fields `{basis_fields_present}`, but the reporting basis "
+            "still needs explicit review before promotion use."
+        )
+    return (
+        "Inventory-derived candidate only. Reporting basis is still unresolved and must be reviewed directly "
+        f"from the source files before promotion use. Source preview: {_source_ref_preview(dataset)}."
+    )
+
+
+def _default_cumulative_mapping_note(dataset: DatasetMetadataContract) -> str:
+    candidate_date_key = dataset.notes.get("candidate_date_key")
+    candidate_harvest_column = dataset.notes.get("candidate_harvest_column")
+    semantics_hint = dataset.notes.get("candidate_target_semantics_hint", dataset.observation.measured_semantics)
+    preferred_season = dataset.notes.get("candidate_preferred_validation_season")
+    preferred_window = dataset.notes.get("candidate_preferred_validation_window")
+    construction_hint = dataset.notes.get("candidate_cumulative_construction_hint")
+    preferred_window_note = ""
+    if preferred_season is not None and isinstance(preferred_window, dict):
+        start = preferred_window.get("validation_start_candidate")
+        end = preferred_window.get("validation_end_candidate")
+        row_count = preferred_window.get("harvest_row_count")
+        preferred_window_note = (
+            f" Preferred intake season is `{preferred_season}` with candidate window `{start}` -> `{end}` "
+            f"and `{row_count}` comparison rows."
+        )
+    construction_note = f" {construction_hint}" if construction_hint else ""
+    if candidate_harvest_column is not None:
+        return (
+            f"Candidate date hint `{candidate_date_key}` and daily harvest signal `{candidate_harvest_column}` are "
+            f"visible in the harmonized inventory, but `measured_cumulative_column` must remain unresolved until "
+            f"review confirms a valid cumulative-harvest construction and explicit dry-weight/public-basis semantics. "
+            f"Current semantics hint: `{semantics_hint}`.{preferred_window_note}{construction_note}"
+        )
+    if candidate_date_key is not None:
+        return (
+            f"Candidate date hint `{candidate_date_key}` is visible, but no direct standardized harvest signal is "
+            f"currently mapped for cumulative comparison. Keep `measured_cumulative_column` unresolved until a "
+            f"reviewed harvest source and construction rule are added. Current semantics hint: `{semantics_hint}`."
+            f"{preferred_window_note}"
+        )
+    return (
+        "No reviewed date/cumulative mapping is currently available in the inventory-derived contract. "
+        f"Current semantics hint: `{semantics_hint}`."
+    )
+
+
+def _default_fixture_provenance_note(dataset: DatasetMetadataContract) -> str:
+    return (
+        "This candidate is still inventory-backed only. Add a reproducible raw-to-sanitized fixture pair and wire "
+        "`forcing_path`, `observed_harvest_path`, and `sanitized_fixture` before promoting it beyond review/diagnostic "
+        f"use. Source preview: {_source_ref_preview(dataset)}."
+    )
+
+
+def _default_dry_matter_review_note(dataset: DatasetMetadataContract) -> str | None:
+    semantics_hint = str(
+        dataset.notes.get("candidate_target_semantics_hint", dataset.observation.measured_semantics)
+    ).lower()
+    if "dry_weight" not in semantics_hint:
+        return None
+    return (
+        "Review-only dry-matter prior: literature synthesis for whole-fruit tomato typically centers near "
+        "`5-8% DW/FW`, with fresh-market fruit commonly around `6-7%` and a practical review baseline near "
+        "`0.065 g DW / g FW`; cherry/high-solids or stress cases can shift upward toward `8-10%` or higher. "
+        "Keep these values as review guidance only and do not auto-convert this candidate from fresh-weight or "
+        "removed-fruit-weight signals into cumulative harvested dry weight until dataset-specific source semantics "
+        "are reviewed explicitly. [Ref 4][Ref 8][Ref 3][Ref 6][Ref 7][Ref 9]"
+    )
+
+
+def _dry_matter_literature_refs(dataset: DatasetMetadataContract) -> list[str]:
+    if _default_dry_matter_review_note(dataset) is None:
+        return []
+    return [f"[{ref_id}] {summary} {url}" for ref_id, summary, url in DRY_MATTER_LITERATURE_REFS]
+
+
 def build_dataset_review_template(dataset: DatasetMetadataContract) -> dict[str, Any]:
     payload = dataset.to_payload()
+    dry_matter_review_note = _default_dry_matter_review_note(dataset)
     candidate_schema_hints = {
         key: payload["notes"][key]
         for key in (
             "candidate_date_key",
+            "candidate_raw_date_columns",
             "candidate_harvest_column",
+            "candidate_raw_harvest_columns",
             "candidate_harvest_requires_cumulative_construction",
             "candidate_harvest_includes_fallen_fruit",
+            "candidate_target_semantics_hint",
+            "candidate_requires_dry_weight_review",
+            "candidate_validation_windows",
+            "candidate_preferred_validation_season",
+            "candidate_preferred_validation_window",
+            "candidate_cumulative_group_keys",
+            "candidate_cumulative_construction_hint",
+            "candidate_seasons_missing_harvest_signal",
+            "candidate_partition_integrated_observations_path",
+            "candidate_partition_integrated_measurements_long_path",
+            "candidate_partition_comparison_daily_path",
+            "candidate_basis_fields_present",
+            "candidate_basis_fields_missing",
             "comparison_daily_standard_names",
             "traitenv_bundle_ref",
         )
@@ -211,6 +369,7 @@ def build_dataset_review_template(dataset: DatasetMetadataContract) -> dict[str,
         "blocker_codes": list(dataset.blocker_codes),
         "next_actions": blocker_action_items(dataset.blocker_codes),
         "candidate_schema_hints": candidate_schema_hints,
+        "dry_matter_conversion": payload["dry_matter_conversion"],
         "promotion_ready_checklist": {
             "forcing_path": dataset.forcing_path is not None,
             "observed_harvest_path": dataset.observed_harvest_path is not None,
@@ -220,7 +379,9 @@ def build_dataset_review_template(dataset: DatasetMetadataContract) -> dict[str,
                 True if not dataset.basis.requires_plant_density else dataset.basis.plants_per_m2 is not None
             ),
             "date_column": dataset.observation.date_column is not None,
+            "daily_increment_column": dataset.observation.daily_increment_column is not None,
             "measured_cumulative_column": dataset.observation.measured_cumulative_column is not None,
+            "harvest_semantics_explicit": "cumulative_harvested" in dataset.observation.measured_semantics.lower(),
             "sanitized_fixture_pair": dataset.sanitized_fixture.is_complete,
         },
         "review_updates": {
@@ -232,6 +393,7 @@ def build_dataset_review_template(dataset: DatasetMetadataContract) -> dict[str,
                 "reporting_basis": payload["basis"]["reporting_basis"],
                 "plants_per_m2": payload["basis"]["plants_per_m2"],
             },
+            "dry_matter_conversion": payload["dry_matter_conversion"],
             "observation": {
                 "date_column": payload["observation"]["date_column"],
                 "measured_cumulative_column": payload["observation"]["measured_cumulative_column"],
@@ -245,9 +407,17 @@ def build_dataset_review_template(dataset: DatasetMetadataContract) -> dict[str,
             },
             "notes": {
                 "review_status": "todo",
-                "basis_provenance_note": None,
-                "cumulative_mapping_note": None,
-                "fixture_provenance_note": None,
+                "basis_provenance_note": _default_basis_provenance_note(dataset),
+                "cumulative_mapping_note": _default_cumulative_mapping_note(dataset),
+                "fixture_provenance_note": _default_fixture_provenance_note(dataset),
+                **(
+                    {
+                        "dry_matter_review_note": dry_matter_review_note,
+                        "dry_matter_literature_refs": _dry_matter_literature_refs(dataset),
+                    }
+                    if dry_matter_review_note is not None
+                    else {}
+                ),
             },
         },
     }
@@ -291,10 +461,24 @@ def build_dataset_blocker_report(datasets: list[DatasetMetadataContract]) -> str
         )
         for action in blocker_action_items(dataset.blocker_codes):
             lines.append(f"- next_action: {action}")
+        if dataset.observation.date_column is not None:
+            lines.append(f"- schema_hint: standardized date column `{dataset.observation.date_column}` is already identified.")
+        elif dataset.notes.get("candidate_raw_date_columns"):
+            raw_date_columns = ", ".join(f"`{value}`" for value in dataset.notes["candidate_raw_date_columns"])
+            lines.append(f"- schema_hint: raw date-like columns {raw_date_columns} were detected in the source inventory and still need explicit standardization review.")
         candidate_harvest_column = dataset.observation.daily_increment_column or dataset.notes.get("candidate_harvest_column")
         if candidate_harvest_column is not None:
             lines.append(
                 f"- schema_hint: standardized daily harvest signal `{candidate_harvest_column}` is available but cumulative mapping is not yet resolved."
+            )
+        elif dataset.notes.get("candidate_raw_harvest_columns"):
+            raw_harvest_columns = ", ".join(f"`{value}`" for value in dataset.notes["candidate_raw_harvest_columns"])
+            lines.append(
+                f"- schema_hint: raw harvest-like columns {raw_harvest_columns} were detected in the source inventory but are not yet promoted to a standardized cumulative target."
+            )
+        if "ambiguous_harvest_semantics" in dataset.blocker_codes:
+            lines.append(
+                f"- semantics_hint: `{dataset.notes.get('candidate_target_semantics_hint', dataset.observation.measured_semantics)}` still needs an explicit dry-weight or approved equivalent mapping."
             )
         lines.append("")
     for dataset in proxy_candidates:

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py
@@ -13,6 +13,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.data_contract 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
     DatasetCapability,
+    DatasetDryMatterConversionContract,
     DatasetIngestionStatus,
     DatasetManagementMetadata,
     DatasetMetadataContract,
@@ -90,6 +91,7 @@ def _build_dataset_from_config(
 ) -> DatasetMetadataContract:
     basis_cfg = _as_dict(raw.get("basis"))
     observation_cfg = _as_dict(raw.get("observation"))
+    dry_matter_cfg = _as_dict(raw.get("dry_matter_conversion"))
     management_cfg = _as_dict(raw.get("management"))
     fixture_cfg = _as_dict(raw.get("sanitized_fixture"))
     notes = _as_dict(raw.get("notes"))
@@ -137,6 +139,15 @@ def _build_dataset_from_config(
                 )
             ),
             daily_increment_column=observation_cfg.get("daily_increment_column"),
+        ),
+        dry_matter_conversion=DatasetDryMatterConversionContract(
+            mode=str(dry_matter_cfg.get("mode", "none")),
+            fresh_weight_column=dry_matter_cfg.get("fresh_weight_column"),
+            dry_matter_ratio=dry_matter_cfg.get("dry_matter_ratio"),
+            dry_matter_ratio_low=dry_matter_cfg.get("dry_matter_ratio_low"),
+            dry_matter_ratio_high=dry_matter_cfg.get("dry_matter_ratio_high"),
+            citations=tuple(str(value) for value in _as_list(dry_matter_cfg.get("citations"))),
+            review_only=bool(dry_matter_cfg.get("review_only", True)),
         ),
         management=DatasetManagementMetadata(
             pruning_records_path=_resolve_config_path(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/traitenv_school_validation.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/traitenv_school_validation.py
@@ -1,0 +1,887 @@
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+
+from .knu_data import _first_sheet_rows_from_xlsx
+
+SCHOOL_DATASET_ID = "school_trait_bundle__yield"
+SCHOOL_YIELD_STANDARD_NAME = "total_yield_weight_g"
+CANONICAL_DATE_COLUMN = "Date"
+CANONICAL_MEASURED_COLUMN = "Measured_Cumulative_Total_Fruit_DW (g/m^2)"
+CANONICAL_ESTIMATED_COLUMN = "Estimated_Cumulative_Total_Fruit_DW (g/m^2)"
+CANONICAL_DAILY_INCREMENT_COLUMN = "Source_Daily_Fruit_DW (g/m^2)"
+CANONICAL_REPORTING_BASIS = "floor_area_g_m2"
+DEFAULT_DRY_MATTER_RATIO = 0.065
+DEFAULT_PAR_UMOL_PER_W_M2 = 4.57
+DEFAULT_DRY_MATTER_CITATIONS = (
+    "Ref 4",
+    "Ref 8",
+    "Ref 3",
+    "Ref 6",
+    "Ref 7",
+    "Ref 9",
+)
+_SOURCE_ORIGIN_MANIFEST_NAME = ".source_origin.json"
+_RAW_COMMON_WORKBOOK_RELATIVE_PATH = Path("40_\uc791\uc5c5\u00b7\uc7ac\ubc30\uc815\ubcf4") / (
+    "\ud1a0\ub9c8\ud1a0_\uc7ac\ubc30\uc815\ubcf4_\uacf5\ud1b5.xlsx"
+)
+_COMMON_WORKBOOK_SEASON_COLUMN = "\uc0dd\uc721\uc870\uc0ac \ud56d\ubaa9"
+_COMMON_WORKBOOK_CULTIVAR_COLUMN = "\ud488\uc885"
+_COMMON_WORKBOOK_TREATMENT_COLUMN = "\ucc98\ub9ac"
+_COMMON_WORKBOOK_NOTE_COLUMN = "\ud30c\uc885, \ud050\ube0c \uac00\uc2dd, \uc815\uc2dd, \uccab\uc218\ud655"
+_COMMON_WORKBOOK_CROP_START_COLUMN = "\uc791\uae30 \uc2dc\uc791"
+_COMMON_WORKBOOK_CROP_END_COLUMN = "\uc791\uae30 \uc885\ub8cc"
+_COMMON_WORKBOOK_AREA_COLUMN = "\uc7ac\ubc30\uba74\uc801(m2)"
+_COMMON_WORKBOOK_PLANT_DENSITY_COLUMN = "\uc7ac\uc2dd\ubc00\ub3c4(plants/m2)"
+
+
+@dataclass(frozen=True, slots=True)
+class SchoolTraitenvSourcePaths:
+    crop_metadata_path: Path
+    environment_path: Path
+    yield_comparison_daily_path: Path
+    crop_common_workbook_path: Path | None = None
+    raw_repo_root: Path | None = None
+    raw_repo_resolution_mode: str = "unresolved"
+    source_origin_manifest_path: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SchoolTraitenvValidationBundle:
+    season: str
+    treatment: str
+    traitenv_root: Path
+    output_root: Path
+    forcing_csv_path: Path
+    yield_csv_path: Path
+    overlay_yaml_path: Path
+    overlay_json_path: Path
+    manifest_path: Path
+    generated_config_paths: dict[str, Path]
+    validation_start: str
+    validation_end: str
+    crop_start: str
+    crop_end: str
+    area_m2: float
+    plants_per_m2: float
+    dry_matter_ratio: float
+    approve_runnable_contract: bool
+    dataset_overlay: dict[str, Any]
+
+
+def _normalize_season_label(value: object) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    if re.fullmatch(r"\d+\.0", text):
+        return text.split(".", maxsplit=1)[0]
+    return text
+
+
+def _parse_date_like(value: object, *, label: str) -> pd.Timestamp:
+    numeric = pd.to_numeric(pd.Series([value]), errors="coerce").iloc[0]
+    if pd.notna(numeric):
+        numeric_value = float(numeric)
+        if 20_000 <= numeric_value <= 60_000:
+            return (pd.Timestamp("1899-12-30") + pd.to_timedelta(numeric_value, unit="D")).normalize()
+    parsed = pd.to_datetime(value, errors="coerce")
+    if pd.isna(parsed):
+        raise ValueError(f"Could not parse {label}: {value!r}")
+    return pd.Timestamp(parsed).normalize()
+
+
+def _parse_float_like(value: object, *, label: str) -> float:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        raise ValueError(f"Missing required numeric field {label}.")
+    cleaned = re.sub(r"[^0-9.+-]", "", str(value))
+    if cleaned in {"", ".", "-", "+"}:
+        raise ValueError(f"Could not parse numeric field {label}: {value!r}")
+    return float(cleaned)
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    return slug.strip("-") or "value"
+
+
+def _read_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, low_memory=False)
+
+
+def _first_nonnull_value(frame: pd.DataFrame, columns: tuple[str, ...]) -> object:
+    for column in columns:
+        if column not in frame.columns:
+            continue
+        series = frame[column].dropna()
+        if not series.empty:
+            return series.iloc[0]
+    return None
+
+
+def _resolve_existing_column(frame: pd.DataFrame, candidates: tuple[str, ...], *, label: str) -> str:
+    for candidate in candidates:
+        if candidate in frame.columns:
+            return candidate
+    raise ValueError(f"Could not resolve {label} column from candidates: {candidates!r}")
+
+
+def _resolve_raw_repo_root_from_traitenv_root(root: Path) -> tuple[Path | None, Path | None, str]:
+    if root.name == "traitenv" and root.parent.name == "outputs":
+        candidate = root.parent.parent
+        if (candidate / _RAW_COMMON_WORKBOOK_RELATIVE_PATH).exists():
+            return candidate, None, "adjacent_outputs_layout"
+    manifest_path = root / _SOURCE_ORIGIN_MANIFEST_NAME
+    if manifest_path.exists():
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None, manifest_path, "source_origin_manifest_invalid"
+        raw_repo_root = payload.get("source_raw_repo_root")
+        if isinstance(raw_repo_root, str) and raw_repo_root:
+            candidate = Path(raw_repo_root).expanduser().resolve()
+            if (candidate / _RAW_COMMON_WORKBOOK_RELATIVE_PATH).exists():
+                return candidate, manifest_path, "source_origin_manifest"
+        return None, manifest_path, "source_origin_manifest_missing_workbook"
+    return None, None, "unresolved"
+
+
+def resolve_school_traitenv_source_paths(
+    traitenv_root: str | Path,
+    *,
+    raw_repo_root: str | Path | None = None,
+) -> SchoolTraitenvSourcePaths:
+    root = Path(traitenv_root).expanduser().resolve()
+    manifest_path = root / _SOURCE_ORIGIN_MANIFEST_NAME
+    if raw_repo_root is not None:
+        resolved_raw_root = Path(raw_repo_root).expanduser().resolve()
+        raw_repo_resolution_mode = "explicit_arg"
+    else:
+        resolved_raw_root, inferred_manifest_path, raw_repo_resolution_mode = _resolve_raw_repo_root_from_traitenv_root(root)
+        if inferred_manifest_path is not None:
+            manifest_path = inferred_manifest_path
+    crop_common_workbook_path = None
+    if resolved_raw_root is not None:
+        candidate = resolved_raw_root / _RAW_COMMON_WORKBOOK_RELATIVE_PATH
+        if candidate.exists():
+            crop_common_workbook_path = candidate
+    paths = SchoolTraitenvSourcePaths(
+        crop_metadata_path=(
+            root
+            / "partitioned_csv"
+            / "integrated_observations"
+            / "dataset_family=school_crop_info"
+            / "observation_family=metadata"
+            / "data.csv"
+        ),
+        environment_path=(
+            root
+            / "partitioned_csv"
+            / "integrated_observations"
+            / "dataset_family=school_greenhouse_environment"
+            / "observation_family=environment"
+            / "data.csv"
+        ),
+        yield_comparison_daily_path=(
+            root
+            / "partitioned_csv"
+            / "comparison_daily"
+            / "dataset_family=school_trait_bundle"
+            / "observation_family=yield"
+            / "data.csv"
+        ),
+        crop_common_workbook_path=crop_common_workbook_path,
+        raw_repo_root=resolved_raw_root,
+        raw_repo_resolution_mode=raw_repo_resolution_mode,
+        source_origin_manifest_path=manifest_path if manifest_path.exists() else None,
+    )
+    required_paths = (
+        paths.crop_metadata_path,
+        paths.environment_path,
+        paths.yield_comparison_daily_path,
+    )
+    missing = [str(path) for path in required_paths if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"school traitenv private validation sources are missing: {missing}")
+    return paths
+
+
+def _rows_to_frame(rows: list[dict[int, Any]]) -> pd.DataFrame:
+    if not rows:
+        raise ValueError("Workbook is empty.")
+    header_map = rows[0]
+    if not header_map:
+        raise ValueError("Workbook header row is empty.")
+    max_idx = max(header_map)
+    headers = [str(header_map.get(idx, "")).strip() for idx in range(max_idx + 1)]
+    records: list[dict[str, Any]] = []
+    for raw_row in rows[1:]:
+        record: dict[str, Any] = {}
+        for idx, value in raw_row.items():
+            if idx > max_idx:
+                continue
+            header = headers[idx]
+            if header:
+                record[header] = value
+        if any(value not in (None, "") for value in record.values()):
+            records.append(record)
+    return pd.DataFrame.from_records(records)
+
+
+def _select_crop_context_from_processed_metadata(
+    crop_df: pd.DataFrame,
+    *,
+    season: str,
+    treatment: str,
+) -> tuple[float, float, pd.Timestamp, pd.Timestamp, dict[str, Any]]:
+    work = crop_df.copy()
+    work["season_label_norm"] = work.get("season_label", pd.Series(dtype=object)).map(_normalize_season_label)
+    season_rows = work.loc[work["season_label_norm"].eq(str(season))].copy()
+    if season_rows.empty:
+        raise ValueError(f"Could not resolve school crop metadata row for season={season!r}, treatment={treatment!r}.")
+
+    context_rows = season_rows
+    treatment_columns = [column for column in ("treatment", "treatment_plan") if column in work.columns]
+    for column in treatment_columns:
+        treatment_mask = season_rows[column].fillna("").astype(str).str.contains(treatment, case=False, na=False)
+        if treatment_mask.any():
+            context_rows = season_rows.loc[treatment_mask].copy()
+            break
+
+    area = _parse_float_like(
+        _first_nonnull_value(season_rows, ("crop_area_m2", "area_m2")),
+        label="school crop area",
+    )
+    plants_per_m2 = _parse_float_like(
+        _first_nonnull_value(season_rows, ("plants_per_m2", "plant_density_plants_m2")),
+        label="school plant density",
+    )
+    crop_start = _parse_date_like(_first_nonnull_value(season_rows, ("crop_start", "crop_start_date")), label="school crop start")
+    crop_end = _parse_date_like(_first_nonnull_value(season_rows, ("crop_end", "crop_end_date")), label="school crop end")
+    context = {
+        "cultivar": str(_first_nonnull_value(context_rows, ("cultivar",)) or "unknown"),
+        "treatment_label": str(_first_nonnull_value(context_rows, ("treatment_plan", "treatment")) or treatment),
+        "season_notes": str(_first_nonnull_value(season_rows, ("season_notes",)) or ""),
+        "metadata_source_kind": "processed_crop_metadata_csv",
+    }
+    return area, plants_per_m2, crop_start, crop_end, context
+
+
+def _select_crop_context_from_common_workbook(
+    crop_common_workbook_path: Path,
+    *,
+    season: str,
+    treatment: str,
+) -> tuple[float, float, pd.Timestamp, pd.Timestamp, dict[str, Any]]:
+    workbook_df = _rows_to_frame(_first_sheet_rows_from_xlsx(crop_common_workbook_path))
+    if _COMMON_WORKBOOK_SEASON_COLUMN not in workbook_df.columns:
+        raise ValueError(
+            f"Common crop workbook is missing required season column {_COMMON_WORKBOOK_SEASON_COLUMN!r}: {crop_common_workbook_path}"
+        )
+    season_mask = workbook_df[_COMMON_WORKBOOK_SEASON_COLUMN].fillna("").astype(str).str.contains(str(season), na=False)
+    season_rows = workbook_df.loc[season_mask].copy()
+    if season_rows.empty:
+        raise ValueError(
+            f"Could not resolve school crop workbook row for season={season!r}, treatment={treatment!r}: {crop_common_workbook_path}"
+        )
+
+    context_rows = season_rows
+    if _COMMON_WORKBOOK_TREATMENT_COLUMN in season_rows.columns:
+        treatment_mask = (
+            season_rows[_COMMON_WORKBOOK_TREATMENT_COLUMN].fillna("").astype(str).str.contains(treatment, case=False, na=False)
+        )
+        if treatment_mask.any():
+            context_rows = season_rows.loc[treatment_mask].copy()
+
+    area = _parse_float_like(_first_nonnull_value(season_rows, (_COMMON_WORKBOOK_AREA_COLUMN,)), label="school crop area")
+    plants_per_m2 = _parse_float_like(
+        _first_nonnull_value(season_rows, (_COMMON_WORKBOOK_PLANT_DENSITY_COLUMN,)),
+        label="school plant density",
+    )
+    crop_start = _parse_date_like(
+        _first_nonnull_value(season_rows, (_COMMON_WORKBOOK_CROP_START_COLUMN,)),
+        label="school crop start",
+    )
+    crop_end = _parse_date_like(
+        _first_nonnull_value(season_rows, (_COMMON_WORKBOOK_CROP_END_COLUMN,)),
+        label="school crop end",
+    )
+    context = {
+        "cultivar": str(_first_nonnull_value(context_rows, (_COMMON_WORKBOOK_CULTIVAR_COLUMN,)) or "unknown"),
+        "treatment_label": str(_first_nonnull_value(context_rows, (_COMMON_WORKBOOK_TREATMENT_COLUMN,)) or treatment),
+        "season_notes": str(_first_nonnull_value(season_rows, (_COMMON_WORKBOOK_NOTE_COLUMN,)) or ""),
+        "metadata_source_kind": "raw_common_workbook",
+        "metadata_source_path": str(crop_common_workbook_path),
+    }
+    return area, plants_per_m2, crop_start, crop_end, context
+
+
+def _select_crop_context(
+    crop_df: pd.DataFrame,
+    *,
+    season: str,
+    treatment: str,
+    crop_common_workbook_path: Path | None = None,
+) -> tuple[float, float, pd.Timestamp, pd.Timestamp, dict[str, Any]]:
+    try:
+        return _select_crop_context_from_processed_metadata(crop_df, season=season, treatment=treatment)
+    except ValueError:
+        if crop_common_workbook_path is None:
+            raise
+        return _select_crop_context_from_common_workbook(
+            crop_common_workbook_path,
+            season=season,
+            treatment=treatment,
+        )
+
+
+def _resolved_yield_value(series: pd.DataFrame) -> pd.Series:
+    for column in ("value_sum", "value_mean", "value"):
+        if column in series.columns:
+            return pd.to_numeric(series[column], errors="coerce")
+    raise ValueError("school traitenv comparison_daily file is missing value_sum/value_mean/value columns.")
+
+
+def build_school_traitenv_yield_frame(
+    *,
+    yield_daily_path: Path,
+    season: str,
+    treatment: str,
+    area_m2: float,
+    dry_matter_ratio: float,
+) -> tuple[pd.DataFrame, str, str]:
+    yield_daily_df = _read_csv(yield_daily_path)
+    work = yield_daily_df.copy()
+    work["season_label_norm"] = work.get("season_label", pd.Series(dtype=object)).map(_normalize_season_label)
+    work["parsed_date"] = pd.to_datetime(work.get("comparison_date"), errors="coerce").dt.normalize()
+    work["resolved_value"] = _resolved_yield_value(work)
+    mask = (
+        work["season_label_norm"].eq(str(season))
+        & work.get("standard_name", pd.Series(dtype=object)).fillna("").astype(str).eq(SCHOOL_YIELD_STANDARD_NAME)
+        & work["parsed_date"].notna()
+    )
+    if "treatment" in work.columns:
+        mask &= work["treatment"].fillna("").astype(str).str.contains(treatment, case=False, na=False)
+    filtered = work.loc[mask].copy()
+    if filtered.empty:
+        raise ValueError(
+            f"Could not find school traitenv yield comparison rows for season={season!r}, treatment={treatment!r}."
+        )
+    filtered["resolved_value"] = pd.to_numeric(filtered["resolved_value"], errors="coerce").fillna(0.0)
+    grouped = filtered.groupby("parsed_date", as_index=False).agg(
+        Source_Daily_Fresh_Weight_Total_g=("resolved_value", "sum"),
+        Source_Comparison_Entities=("comparison_entity", "nunique"),
+    )
+    grouped["Source_Daily_Fresh_Weight_g_m2"] = grouped["Source_Daily_Fresh_Weight_Total_g"] / float(area_m2)
+    grouped[CANONICAL_DAILY_INCREMENT_COLUMN] = grouped["Source_Daily_Fresh_Weight_g_m2"] * float(dry_matter_ratio)
+    grouped[CANONICAL_MEASURED_COLUMN] = grouped[CANONICAL_DAILY_INCREMENT_COLUMN].cumsum()
+    grouped[CANONICAL_ESTIMATED_COLUMN] = grouped[CANONICAL_MEASURED_COLUMN]
+    grouped["Source_Dry_Matter_Ratio"] = float(dry_matter_ratio)
+    grouped[CANONICAL_DATE_COLUMN] = grouped["parsed_date"].dt.strftime("%Y-%m-%d")
+    ordered = grouped[
+        [
+            CANONICAL_DATE_COLUMN,
+            "Source_Daily_Fresh_Weight_Total_g",
+            "Source_Daily_Fresh_Weight_g_m2",
+            CANONICAL_DAILY_INCREMENT_COLUMN,
+            CANONICAL_MEASURED_COLUMN,
+            CANONICAL_ESTIMATED_COLUMN,
+            "Source_Dry_Matter_Ratio",
+            "Source_Comparison_Entities",
+        ]
+    ].copy()
+    validation_start = str(ordered[CANONICAL_DATE_COLUMN].iloc[0])
+    validation_end = str(ordered[CANONICAL_DATE_COLUMN].iloc[-1])
+    return ordered, validation_start, validation_end
+
+
+def build_school_traitenv_forcing_frame(
+    *,
+    environment_path: Path,
+    season: str,
+    crop_start: pd.Timestamp,
+    crop_end: pd.Timestamp,
+    par_umol_per_w_m2: float,
+) -> pd.DataFrame:
+    env_df = _read_csv(environment_path)
+    work = env_df.copy()
+    work["season_label_norm"] = work.get("season_label", pd.Series(dtype=object)).map(_normalize_season_label)
+    work["parsed_timestamp"] = pd.to_datetime(work.get("Timestamp"), errors="coerce")
+    work["parsed_date"] = work["parsed_timestamp"].dt.normalize()
+    mask = (
+        work["season_label_norm"].eq(str(season))
+        & work["parsed_timestamp"].notna()
+        & work["parsed_date"].between(crop_start, crop_end, inclusive="both")
+    )
+    filtered = work.loc[mask].copy()
+    if filtered.empty:
+        raise ValueError(f"Could not find school greenhouse environment rows for season={season!r}.")
+    temp_column = _resolve_existing_column(
+        filtered,
+        ("Air temperature (°C)_mean", "Air temperature (째C)_mean", "온도_내부_mean", "Air temperature_mean"),
+        label="school air temperature",
+    )
+    radiation_column = _resolve_existing_column(
+        filtered,
+        (
+            "Inside radiation intensity (W/m2)_mean",
+            "내부-내부일사량_mean",
+            "Radiation intensity in_mean",
+        ),
+        label="school radiation",
+    )
+    co2_column = _resolve_existing_column(
+        filtered,
+        ("CO2 (ppm)_mean", "내부-내부CO2_mean", "CO2_mean"),
+        label="school CO2",
+    )
+    rh_column = _resolve_existing_column(
+        filtered,
+        ("RH (%)_mean", "RH_mean", "상대습도_내부_mean", "내부-내부습도_mean"),
+        label="school RH",
+    )
+    wind_column = _resolve_existing_column(
+        filtered,
+        ("Wind speed (m/s)_mean", "외부-외부풍속_mean", "풍속_외부_mean"),
+        label="school wind speed",
+    )
+    forcing = pd.DataFrame(
+        {
+            "datetime": filtered["parsed_timestamp"].dt.strftime("%Y-%m-%d %H:%M:%S"),
+            "T_air_C": pd.to_numeric(filtered[temp_column], errors="coerce"),
+            "PAR_umol": pd.to_numeric(filtered[radiation_column], errors="coerce") * float(par_umol_per_w_m2),
+            "CO2_ppm": pd.to_numeric(filtered[co2_column], errors="coerce"),
+            "RH_percent": pd.to_numeric(filtered[rh_column], errors="coerce"),
+            "wind_speed_ms": pd.to_numeric(filtered[wind_column], errors="coerce"),
+        }
+    )
+    forcing = forcing.dropna(subset=["T_air_C", "PAR_umol", "CO2_ppm", "RH_percent", "wind_speed_ms"]).copy()
+    forcing = forcing.sort_values("datetime").reset_index(drop=True)
+    if forcing.empty:
+        raise ValueError("Derived school traitenv forcing frame is empty after numeric filtering.")
+    return forcing
+
+
+def build_school_traitenv_dataset_overlay(
+    *,
+    traitenv_root: Path,
+    source_paths: SchoolTraitenvSourcePaths,
+    forcing_csv_path: Path,
+    yield_csv_path: Path,
+    season: str,
+    treatment: str,
+    validation_start: str,
+    validation_end: str,
+    crop_start: str,
+    crop_end: str,
+    area_m2: float,
+    plants_per_m2: float,
+    dry_matter_ratio: float,
+    approve_runnable_contract: bool,
+    crop_context: dict[str, Any],
+) -> dict[str, Any]:
+    source_path_payload = {
+        "crop_metadata_path": str(source_paths.crop_metadata_path),
+        "environment_path": str(source_paths.environment_path),
+        "yield_comparison_daily_path": str(source_paths.yield_comparison_daily_path),
+        "crop_common_workbook_path": (
+            str(source_paths.crop_common_workbook_path) if source_paths.crop_common_workbook_path is not None else None
+        ),
+        "raw_repo_root": str(source_paths.raw_repo_root) if source_paths.raw_repo_root is not None else None,
+        "raw_repo_resolution_mode": source_paths.raw_repo_resolution_mode,
+        "source_origin_manifest_path": (
+            str(source_paths.source_origin_manifest_path) if source_paths.source_origin_manifest_path is not None else None
+        ),
+    }
+    return {
+        "dataset_id": SCHOOL_DATASET_ID,
+        "dataset_kind": "traitenv_private_reviewed_candidate",
+        "display_name": "School measured harvest derived from traitenv private bundle",
+        "ingestion_status": None,
+        "blocker_codes": [],
+        "forcing_path": str(forcing_csv_path),
+        "observed_harvest_path": str(yield_csv_path),
+        "validation_start": validation_start,
+        "validation_end": validation_end,
+        "cultivar": str(crop_context.get("cultivar", "unknown")),
+        "greenhouse": "school_greenhouse",
+        "season": str(season),
+        "basis": {
+            "reporting_basis": CANONICAL_REPORTING_BASIS,
+            "plants_per_m2": float(plants_per_m2),
+        },
+        "observation": {
+            "date_column": CANONICAL_DATE_COLUMN,
+            "measured_cumulative_column": CANONICAL_MEASURED_COLUMN,
+            "estimated_cumulative_column": CANONICAL_ESTIMATED_COLUMN,
+            "measured_semantics": "cumulative_harvested_fruit_dry_weight_floor_area",
+            "daily_increment_column": CANONICAL_DAILY_INCREMENT_COLUMN,
+        },
+        "dry_matter_conversion": {
+            "mode": "literature_fixed_ratio",
+            "fresh_weight_column": "Source_Daily_Fresh_Weight_Total_g",
+            "dry_matter_ratio": float(dry_matter_ratio),
+            "dry_matter_ratio_low": 0.05,
+            "dry_matter_ratio_high": 0.10,
+            "citations": list(DEFAULT_DRY_MATTER_CITATIONS),
+            "review_only": not approve_runnable_contract,
+        },
+        "sanitized_fixture": {
+            "fixture_kind": "private_traitenv_reviewed_derivative",
+            "forcing_fixture_path": str(forcing_csv_path),
+            "observed_harvest_fixture_path": str(yield_csv_path),
+        },
+        "notes": {
+            "dataset_family": "school_trait_bundle",
+            "observation_family": "yield",
+            "dataset_role_hint": (
+                "measured_harvest_runnable" if approve_runnable_contract else "measured_harvest_review_only"
+            ),
+            "private_derivation_official_mode": "manual_reviewed_derivative",
+            "private_derivation_helper_role": "local_preparation_utility",
+            "private_derivation_public_promotion_default": "unchanged",
+            "private_derivation_kind": "traitenv_school_private_reviewed_bundle",
+            "private_derivation_approved_runnable_contract": bool(approve_runnable_contract),
+            "private_derivation_validation_season": str(season),
+            "private_derivation_treatment": str(treatment),
+            "private_derivation_crop_start": crop_start,
+            "private_derivation_crop_end": crop_end,
+            "private_derivation_validation_start": validation_start,
+            "private_derivation_validation_end": validation_end,
+            "private_derivation_area_m2": float(area_m2),
+            "private_derivation_plants_per_m2": float(plants_per_m2),
+            "private_derivation_dry_matter_ratio": float(dry_matter_ratio),
+            "private_derivation_traitenv_root": str(traitenv_root),
+            "private_derivation_source_paths": source_path_payload,
+            "private_derivation_crop_context": crop_context,
+        },
+    }
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _calibration_end_from_validation_start(validation_start: str) -> str:
+    return str((pd.Timestamp(validation_start) + pd.Timedelta(days=11)).date())
+
+
+def _school_config_slug(season: str, treatment: str) -> str:
+    return f"school-traitenv-{season}-{_slugify(treatment)}"
+
+
+def write_school_traitenv_generated_configs(
+    *,
+    repo_root: Path,
+    output_root: Path,
+    overlay_item: dict[str, Any],
+    forcing_csv_path: Path,
+    yield_csv_path: Path,
+    season: str,
+    treatment: str,
+    validation_start: str,
+    current_vs_promoted_base_config: Path,
+    harvest_factorial_base_config: Path,
+    multidataset_base_config: Path,
+    promotion_gate_base_config: Path,
+) -> dict[str, Path]:
+    config_slug = _school_config_slug(season, treatment)
+    config_root = output_root / "configs"
+    current_cfg_path = config_root / f"tomics_current_vs_promoted_factorial_{config_slug}.yaml"
+    harvest_cfg_path = config_root / f"tomics_harvest_family_factorial_{config_slug}.yaml"
+    multidataset_cfg_path = config_root / f"tomics_multidataset_harvest_factorial_{config_slug}.yaml"
+    gate_cfg_path = config_root / f"tomics_multidataset_harvest_promotion_gate_{config_slug}.yaml"
+
+    current_output_root = output_root / "architecture" / "current-factorial"
+    promoted_output_root = output_root / "architecture" / "promoted-factorial"
+    comparison_output_root = output_root / "architecture" / "comparison"
+    prepared_output_root = output_root / "prepared"
+    harvest_output_root = output_root / "harvest-family"
+    multidataset_output_root = output_root / "multidataset"
+
+    current_cfg = copy.deepcopy(_load_yaml(current_vs_promoted_base_config))
+    current_cfg["exp"]["name"] = f"tomics_current_vs_promoted_factorial_{config_slug}"
+    current_cfg["paths"] = {"repo_root": str(repo_root)}
+    current_cfg["validation"].update(
+        {
+            "forcing_csv_path": str(forcing_csv_path),
+            "yield_xlsx_path": str(yield_csv_path),
+            "prepared_output_root": str(prepared_output_root),
+            "resample_rule": "1D",
+            "calibration_end": _calibration_end_from_validation_start(validation_start),
+        }
+    )
+    current_cfg["current"]["base_config"] = str((repo_root / "configs" / "exp" / "tomics_allocation_factorial.yaml").resolve())
+    current_cfg["promoted"]["base_config"] = str(
+        (repo_root / "configs" / "exp" / "tomics_allocation_factorial.yaml").resolve()
+    )
+    current_cfg["paths"].update(
+        {
+            "current_output_root": str(current_output_root),
+            "promoted_output_root": str(promoted_output_root),
+            "comparison_output_root": str(comparison_output_root),
+        }
+    )
+    for section in ("plots",):
+        current_cfg[section] = {
+            key: str((repo_root / Path(value)).resolve()) if isinstance(value, str) and not Path(value).is_absolute() else value
+            for key, value in current_cfg.get(section, {}).items()
+        }
+    if "prior_selected_architecture_json" in current_cfg.get("current", {}):
+        prior_path = Path(str(current_cfg["current"]["prior_selected_architecture_json"]))
+        if not prior_path.is_absolute():
+            current_cfg["current"]["prior_selected_architecture_json"] = str((repo_root / prior_path).resolve())
+    _write_yaml(current_cfg_path, current_cfg)
+
+    harvest_cfg = copy.deepcopy(_load_yaml(harvest_factorial_base_config))
+    harvest_cfg["exp"]["name"] = f"tomics_harvest_family_factorial_{config_slug}"
+    harvest_cfg["paths"] = {"repo_root": str(repo_root)}
+    harvest_cfg["validation"].update(
+        {
+            "forcing_csv_path": str(forcing_csv_path),
+            "yield_xlsx_path": str(yield_csv_path),
+            "prepared_output_root": str(prepared_output_root),
+            "resample_rule": "1D",
+            "calibration_end": _calibration_end_from_validation_start(validation_start),
+        }
+    )
+    harvest_cfg["reference"] = {
+        "current_vs_promoted_config": str(current_cfg_path),
+        "current_output_root": str(current_output_root),
+        "promoted_output_root": str(promoted_output_root),
+    }
+    harvest_cfg["harvest_factorial"]["output_root"] = str(harvest_output_root)
+    for key, value in harvest_cfg["harvest_factorial"].items():
+        if key.endswith("_spec") and isinstance(value, str) and not Path(value).is_absolute():
+            harvest_cfg["harvest_factorial"][key] = str((repo_root / value).resolve())
+    _write_yaml(harvest_cfg_path, harvest_cfg)
+
+    multidataset_cfg = copy.deepcopy(_load_yaml(multidataset_base_config))
+    multidataset_cfg["exp"]["name"] = f"tomics_multidataset_harvest_factorial_{config_slug}"
+    datasets_cfg = multidataset_cfg.setdefault("validation", {}).setdefault("datasets", {})
+    existing_items = list(datasets_cfg.get("items", []))
+    merged_items = [item for item in existing_items if str(item.get("dataset_id", "")) != SCHOOL_DATASET_ID]
+    merged_items.append(overlay_item)
+    datasets_cfg["items"] = merged_items
+    multidataset_cfg["validation"]["multidataset_factorial"]["output_root"] = str(multidataset_output_root)
+    multidataset_cfg["validation"]["multidataset_factorial"].setdefault("dataset_factorial_roots", {})
+    multidataset_cfg["validation"]["multidataset_factorial"]["dataset_factorial_roots"][SCHOOL_DATASET_ID] = str(
+        harvest_output_root
+    )
+    _write_yaml(multidataset_cfg_path, multidataset_cfg)
+
+    gate_cfg = copy.deepcopy(_load_yaml(promotion_gate_base_config))
+    gate_cfg["exp"]["name"] = f"tomics_multidataset_harvest_promotion_gate_{config_slug}"
+    gate_cfg.setdefault("validation", {}).setdefault("multidataset_promotion_gate", {})
+    gate_cfg["validation"]["multidataset_promotion_gate"]["scorecard_root"] = str(multidataset_output_root)
+    gate_cfg["validation"]["multidataset_promotion_gate"]["output_root"] = str(multidataset_output_root)
+    _write_yaml(gate_cfg_path, gate_cfg)
+
+    return {
+        "current_vs_promoted_config": current_cfg_path,
+        "harvest_factorial_config": harvest_cfg_path,
+        "multidataset_factorial_config": multidataset_cfg_path,
+        "multidataset_promotion_gate_config": gate_cfg_path,
+    }
+
+
+def build_school_traitenv_validation_bundle(
+    *,
+    traitenv_root: str | Path,
+    output_root: str | Path,
+    repo_root: str | Path,
+    raw_repo_root: str | Path | None = None,
+    season: str = "2024",
+    treatment: str = "Control",
+    dry_matter_ratio: float = DEFAULT_DRY_MATTER_RATIO,
+    par_umol_per_w_m2: float = DEFAULT_PAR_UMOL_PER_W_M2,
+    approve_runnable_contract: bool = False,
+    current_vs_promoted_base_config: str | Path = "configs/exp/tomics_current_vs_promoted_factorial_knu.yaml",
+    harvest_factorial_base_config: str | Path = "configs/exp/tomics_knu_harvest_family_factorial.yaml",
+    multidataset_base_config: str | Path = "configs/exp/tomics_multidataset_harvest_factorial.yaml",
+    promotion_gate_base_config: str | Path = "configs/exp/tomics_multidataset_harvest_promotion_gate.yaml",
+) -> SchoolTraitenvValidationBundle:
+    traitenv_root_path = Path(traitenv_root).expanduser().resolve()
+    repo_root_path = Path(repo_root).expanduser().resolve()
+    output_root_path = Path(output_root).expanduser().resolve()
+    output_root_path.mkdir(parents=True, exist_ok=True)
+    source_paths = resolve_school_traitenv_source_paths(traitenv_root_path, raw_repo_root=raw_repo_root)
+
+    area_m2, plants_per_m2, crop_start, crop_end, crop_context = _select_crop_context(
+        _read_csv(source_paths.crop_metadata_path),
+        season=str(season),
+        treatment=treatment,
+        crop_common_workbook_path=source_paths.crop_common_workbook_path,
+    )
+    yield_frame, validation_start, validation_end = build_school_traitenv_yield_frame(
+        yield_daily_path=source_paths.yield_comparison_daily_path,
+        season=str(season),
+        treatment=treatment,
+        area_m2=area_m2,
+        dry_matter_ratio=float(dry_matter_ratio),
+    )
+    forcing_frame = build_school_traitenv_forcing_frame(
+        environment_path=source_paths.environment_path,
+        season=str(season),
+        crop_start=crop_start,
+        crop_end=crop_end,
+        par_umol_per_w_m2=float(par_umol_per_w_m2),
+    )
+
+    season_slug = _slugify(str(season))
+    treatment_slug = _slugify(treatment)
+    forcing_csv_path = output_root_path / f"school_traitenv_forcing_{season_slug}_{treatment_slug}.csv"
+    yield_csv_path = output_root_path / f"school_traitenv_yield_{season_slug}_{treatment_slug}.csv"
+    overlay_yaml_path = output_root_path / f"school_traitenv_dataset_overlay_{season_slug}_{treatment_slug}.yaml"
+    overlay_json_path = output_root_path / f"school_traitenv_dataset_overlay_{season_slug}_{treatment_slug}.json"
+    manifest_path = output_root_path / f"school_traitenv_bundle_manifest_{season_slug}_{treatment_slug}.json"
+    forcing_frame.to_csv(forcing_csv_path, index=False)
+    yield_frame.to_csv(yield_csv_path, index=False)
+
+    dataset_overlay = build_school_traitenv_dataset_overlay(
+        traitenv_root=traitenv_root_path,
+        source_paths=source_paths,
+        forcing_csv_path=forcing_csv_path,
+        yield_csv_path=yield_csv_path,
+        season=str(season),
+        treatment=treatment,
+        validation_start=validation_start,
+        validation_end=validation_end,
+        crop_start=str(crop_start.date()),
+        crop_end=str(crop_end.date()),
+        area_m2=area_m2,
+        plants_per_m2=plants_per_m2,
+        dry_matter_ratio=float(dry_matter_ratio),
+        approve_runnable_contract=approve_runnable_contract,
+        crop_context=crop_context,
+    )
+    overlay_json_path.write_text(json.dumps(dataset_overlay, indent=2, sort_keys=True), encoding="utf-8")
+    _write_yaml(overlay_yaml_path, {"validation": {"datasets": {"items": [dataset_overlay]}}})
+
+    generated_config_paths = write_school_traitenv_generated_configs(
+        repo_root=repo_root_path,
+        output_root=output_root_path,
+        overlay_item=dataset_overlay,
+        forcing_csv_path=forcing_csv_path,
+        yield_csv_path=yield_csv_path,
+        season=str(season),
+        treatment=treatment,
+        validation_start=validation_start,
+        current_vs_promoted_base_config=(repo_root_path / current_vs_promoted_base_config).resolve(),
+        harvest_factorial_base_config=(repo_root_path / harvest_factorial_base_config).resolve(),
+        multidataset_base_config=(repo_root_path / multidataset_base_config).resolve(),
+        promotion_gate_base_config=(repo_root_path / promotion_gate_base_config).resolve(),
+    )
+
+    manifest = {
+        "dataset_id": SCHOOL_DATASET_ID,
+        "season": str(season),
+        "treatment": treatment,
+        "traitenv_root": str(traitenv_root_path),
+        "source_paths": {
+            "crop_metadata_path": str(source_paths.crop_metadata_path),
+            "environment_path": str(source_paths.environment_path),
+            "yield_comparison_daily_path": str(source_paths.yield_comparison_daily_path),
+            "crop_common_workbook_path": (
+                str(source_paths.crop_common_workbook_path) if source_paths.crop_common_workbook_path is not None else None
+            ),
+            "raw_repo_root": str(source_paths.raw_repo_root) if source_paths.raw_repo_root is not None else None,
+            "raw_repo_resolution_mode": source_paths.raw_repo_resolution_mode,
+            "source_origin_manifest_path": (
+                str(source_paths.source_origin_manifest_path) if source_paths.source_origin_manifest_path is not None else None
+            ),
+        },
+        "output_root": str(output_root_path),
+        "forcing_csv_path": str(forcing_csv_path),
+        "yield_csv_path": str(yield_csv_path),
+        "overlay_yaml_path": str(overlay_yaml_path),
+        "overlay_json_path": str(overlay_json_path),
+        "validation_start": validation_start,
+        "validation_end": validation_end,
+        "crop_start": str(crop_start.date()),
+        "crop_end": str(crop_end.date()),
+        "area_m2": float(area_m2),
+        "plants_per_m2": float(plants_per_m2),
+        "dry_matter_ratio": float(dry_matter_ratio),
+        "approve_runnable_contract": bool(approve_runnable_contract),
+        "workflow_contract": {
+            "official_mode": "manual_reviewed_derivative",
+            "helper_role": "local_preparation_utility",
+            "runnable_approval_required": True,
+            "generated_private_overlay_is_locally_runnable": bool(approve_runnable_contract),
+            "public_registry_mutated": False,
+            "public_promotion_semantics_unchanged": True,
+            "raw_repo_resolution_mode": source_paths.raw_repo_resolution_mode,
+            "source_origin_manifest_path": (
+                str(source_paths.source_origin_manifest_path) if source_paths.source_origin_manifest_path is not None else None
+            ),
+        },
+        "generated_configs": {key: str(value) for key, value in generated_config_paths.items()},
+        "source_coverage": {
+            "forcing_rows": int(len(forcing_frame)),
+            "yield_rows": int(len(yield_frame)),
+            "yield_final_cumulative_g_m2": float(yield_frame[CANONICAL_MEASURED_COLUMN].iloc[-1]),
+        },
+        "dataset_overlay": dataset_overlay,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    return SchoolTraitenvValidationBundle(
+        season=str(season),
+        treatment=treatment,
+        traitenv_root=traitenv_root_path,
+        output_root=output_root_path,
+        forcing_csv_path=forcing_csv_path,
+        yield_csv_path=yield_csv_path,
+        overlay_yaml_path=overlay_yaml_path,
+        overlay_json_path=overlay_json_path,
+        manifest_path=manifest_path,
+        generated_config_paths=generated_config_paths,
+        validation_start=validation_start,
+        validation_end=validation_end,
+        crop_start=str(crop_start.date()),
+        crop_end=str(crop_end.date()),
+        area_m2=float(area_m2),
+        plants_per_m2=float(plants_per_m2),
+        dry_matter_ratio=float(dry_matter_ratio),
+        approve_runnable_contract=bool(approve_runnable_contract),
+        dataset_overlay=dataset_overlay,
+    )
+
+
+__all__ = [
+    "CANONICAL_DAILY_INCREMENT_COLUMN",
+    "CANONICAL_DATE_COLUMN",
+    "CANONICAL_ESTIMATED_COLUMN",
+    "CANONICAL_MEASURED_COLUMN",
+    "CANONICAL_REPORTING_BASIS",
+    "DEFAULT_DRY_MATTER_CITATIONS",
+    "DEFAULT_DRY_MATTER_RATIO",
+    "DEFAULT_PAR_UMOL_PER_W_M2",
+    "SCHOOL_DATASET_ID",
+    "SchoolTraitenvSourcePaths",
+    "SchoolTraitenvValidationBundle",
+    "build_school_traitenv_dataset_overlay",
+    "build_school_traitenv_forcing_frame",
+    "build_school_traitenv_validation_bundle",
+    "build_school_traitenv_yield_frame",
+    "resolve_school_traitenv_source_paths",
+    "write_school_traitenv_generated_configs",
+]

--- a/tests/test_traitenv_school_validation.py
+++ b/tests/test_traitenv_school_validation.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+import pandas as pd
+import pytest
+import yaml
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import load_config
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_repo_root
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_promoted import (
+    prepare_knu_bundle,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
+    DatasetCapability,
+    DatasetIngestionStatus,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    load_dataset_registry,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.traitenv_school_validation import (
+    CANONICAL_MEASURED_COLUMN,
+    SCHOOL_DATASET_ID,
+    build_school_traitenv_validation_bundle,
+)
+
+
+def _xlsx_col_ref(column_idx: int) -> str:
+    ref = ""
+    current = column_idx + 1
+    while current > 0:
+        current, remainder = divmod(current - 1, 26)
+        ref = chr(65 + remainder) + ref
+    return ref
+
+
+def _write_minimal_first_sheet_xlsx(path: Path, rows: list[list[object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row_xml: list[str] = []
+    for row_idx, row in enumerate(rows, start=1):
+        cells: list[str] = []
+        for col_idx, value in enumerate(row, start=0):
+            if value is None:
+                continue
+            ref = f"{_xlsx_col_ref(col_idx)}{row_idx}"
+            if isinstance(value, str):
+                escaped = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                cells.append(f'<c r="{ref}" t="inlineStr"><is><t>{escaped}</t></is></c>')
+            else:
+                cells.append(f'<c r="{ref}"><v>{value}</v></c>')
+        row_xml.append(f'<row r="{row_idx}">{"".join(cells)}</row>')
+
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>""",
+        )
+        archive.writestr(
+            "_rels/.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>""",
+        )
+        archive.writestr(
+            "xl/workbook.xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>""",
+        )
+        archive.writestr(
+            "xl/_rels/workbook.xml.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>""",
+        )
+        archive.writestr(
+            "xl/styles.xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellStyleXfs count="1"><xf/></cellStyleXfs>
+  <cellXfs count="1"><xf numFmtId="0"/></cellXfs>
+</styleSheet>""",
+        )
+        archive.writestr(
+            "xl/worksheets/sheet1.xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>"""
+            + "".join(row_xml)
+            + """</sheetData>
+</worksheet>""",
+        )
+
+
+def _write_school_common_workbook(raw_repo_root: Path) -> Path:
+    workbook_path = (
+        raw_repo_root
+        / "40_\uc791\uc5c5\u00b7\uc7ac\ubc30\uc815\ubcf4"
+        / "\ud1a0\ub9c8\ud1a0_\uc7ac\ubc30\uc815\ubcf4_\uacf5\ud1b5.xlsx"
+    )
+    _write_minimal_first_sheet_xlsx(
+        workbook_path,
+        rows=[
+            [
+                "\uc0dd\uc721\uc870\uc0ac \ud56d\ubaa9",
+                "\ud488\uc885",
+                "\ucc98\ub9ac",
+                "\ucc98\ub9ac \uc2dc\uc791",
+                "\ucc98\ub9ac \uc885\ub8cc",
+                "Control",
+                "Drought",
+                "\uc0d8\ud50c\ub9c1 \ub0a0\uc9dc",
+                "\ud30c\uc885, \ud050\ube0c \uac00\uc2dd, \uc815\uc2dd, \uccab\uc218\ud655",
+                "\uc791\uae30 \uc2dc\uc791",
+                "\uc791\uae30 \uc885\ub8cc",
+                "\uc7ac\ubc30\uba74\uc801(m2)",
+                "\uc7ac\uc2dd\ubc00\ub3c4(plants/m2)",
+            ],
+            [
+                "2024\ub144 \uc791\uae30",
+                "\ub300\ud504\ub2c8\uc2a4",
+                "Control (A,B,C,D)",
+                "-",
+                "-",
+                "-",
+                "-",
+                "5\uc6d4 9\uc77c, 6\uc6d4 13\uc77c, 8\uc6d4 8\uc77c",
+                "5\uc6d4 9\uc77c, \ud050\ube0c \uc0ac\uc6a9X, 6\uc6d4 13\uc77c, 8\uc6d4 8\uc77c",
+                45456,
+                45644,
+                100.757525,
+                1.9849634059590089,
+            ],
+        ],
+    )
+    return workbook_path
+
+
+def _write_school_traitenv_private_fixture(root: Path, *, notes_only_crop_metadata: bool = False) -> None:
+    crop_dir = (
+        root
+        / "partitioned_csv"
+        / "integrated_observations"
+        / "dataset_family=school_crop_info"
+        / "observation_family=metadata"
+    )
+    env_dir = (
+        root
+        / "partitioned_csv"
+        / "integrated_observations"
+        / "dataset_family=school_greenhouse_environment"
+        / "observation_family=environment"
+    )
+    yield_dir = (
+        root
+        / "partitioned_csv"
+        / "comparison_daily"
+        / "dataset_family=school_trait_bundle"
+        / "observation_family=yield"
+    )
+    crop_dir.mkdir(parents=True, exist_ok=True)
+    env_dir.mkdir(parents=True, exist_ok=True)
+    yield_dir.mkdir(parents=True, exist_ok=True)
+
+    pd.DataFrame(
+        [
+            {
+                "season_label": "2024",
+                "treatment": "Control (A,B)",
+                "cultivar": "Dafnis",
+                "crop_start": None if notes_only_crop_metadata else "2024-08-01",
+                "crop_end": None if notes_only_crop_metadata else "2024-08-21",
+                "season_notes": "5/9 sowing, 6/13 transplant, 8/8 first harvest",
+                "crop_area_m2": None if notes_only_crop_metadata else 100.0,
+                "plants_per_m2": None if notes_only_crop_metadata else 2.0,
+            }
+        ]
+    ).to_csv(crop_dir / "data.csv", index=False)
+
+    env_rows: list[dict[str, object]] = []
+    for idx, ts in enumerate(pd.date_range("2024-08-01", "2024-08-21", freq="D"), start=1):
+        env_rows.append(
+            {
+                "season_label": "2024",
+                "Timestamp": ts.strftime("%Y-%m-%d 00:00:00"),
+                "Air temperature (째C)_mean": 24.0 + idx * 0.1,
+                "Inside radiation intensity (W/m2)_mean": 150.0 + idx,
+                "CO2 (ppm)_mean": 420.0 + idx,
+                "RH (%)_mean": 70.0 - idx * 0.2,
+                "Wind speed (m/s)_mean": 0.5 + idx * 0.01,
+            }
+        )
+    pd.DataFrame(env_rows).to_csv(env_dir / "data.csv", index=False)
+
+    yield_rows: list[dict[str, object]] = []
+    for ts in pd.date_range("2024-08-08", "2024-08-21", freq="D"):
+        for entity, value in (("A", 100.0), ("B", 200.0)):
+            yield_rows.append(
+                {
+                    "season_label": "2024",
+                    "treatment": "Control",
+                    "comparison_entity": entity,
+                    "comparison_date": ts.strftime("%Y-%m-%d"),
+                    "standard_name": "total_yield_weight_g",
+                    "aggregation_stat": "sum",
+                    "value_sum": value,
+                }
+            )
+    pd.DataFrame(yield_rows).to_csv(yield_dir / "data.csv", index=False)
+
+
+def test_school_traitenv_bundle_stays_review_only_without_explicit_approval(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    traitenv_root = tmp_path / "traitenv"
+    output_root = tmp_path / "bundle-review"
+    _write_school_traitenv_private_fixture(traitenv_root)
+
+    bundle = build_school_traitenv_validation_bundle(
+        traitenv_root=traitenv_root,
+        output_root=output_root,
+        repo_root=repo_root,
+        approve_runnable_contract=False,
+    )
+
+    yield_df = pd.read_csv(bundle.yield_csv_path)
+    assert bundle.dataset_overlay["dry_matter_conversion"]["review_only"] is True
+    assert yield_df[CANONICAL_MEASURED_COLUMN].iloc[-1] == pytest.approx(14 * ((300.0 / 100.0) * 0.065))
+
+    config = load_config(bundle.generated_config_paths["multidataset_factorial_config"])
+    registry = load_dataset_registry(
+        config,
+        repo_root=repo_root,
+        config_path=bundle.generated_config_paths["multidataset_factorial_config"],
+    )
+    school_dataset = registry.require(SCHOOL_DATASET_ID)
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+
+    assert school_dataset.capability is DatasetCapability.MEASURED_HARVEST
+    assert school_dataset.ingestion_status is DatasetIngestionStatus.DRAFT_NEEDS_HARVEST_MAPPING
+    assert school_dataset.is_runnable_measured_harvest is False
+    assert "review_only_dry_matter_conversion" in school_dataset.blocker_codes
+    assert bundle.dataset_overlay["notes"]["private_derivation_official_mode"] == "manual_reviewed_derivative"
+    assert bundle.dataset_overlay["notes"]["private_derivation_public_promotion_default"] == "unchanged"
+    assert manifest["workflow_contract"]["official_mode"] == "manual_reviewed_derivative"
+    assert manifest["workflow_contract"]["generated_private_overlay_is_locally_runnable"] is False
+    assert manifest["workflow_contract"]["public_promotion_semantics_unchanged"] is True
+
+
+def test_school_traitenv_bundle_can_become_runnable_with_explicit_private_approval(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    traitenv_root = tmp_path / "traitenv"
+    output_root = tmp_path / "bundle-approved"
+    _write_school_traitenv_private_fixture(traitenv_root)
+
+    bundle = build_school_traitenv_validation_bundle(
+        traitenv_root=traitenv_root,
+        output_root=output_root,
+        repo_root=repo_root,
+        approve_runnable_contract=True,
+    )
+
+    config = load_config(bundle.generated_config_paths["multidataset_factorial_config"])
+    registry = load_dataset_registry(
+        config,
+        repo_root=repo_root,
+        config_path=bundle.generated_config_paths["multidataset_factorial_config"],
+    )
+    school_dataset = registry.require(SCHOOL_DATASET_ID)
+
+    assert school_dataset.is_runnable_measured_harvest is True
+    assert school_dataset.blocker_codes == ()
+    assert school_dataset.observation.measured_cumulative_column == CANONICAL_MEASURED_COLUMN
+    assert school_dataset.notes["dataset_role_hint"] == "measured_harvest_runnable"
+
+
+def test_school_traitenv_generated_current_config_resolves_repo_root_and_prepares_bundle(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    traitenv_root = tmp_path / "traitenv"
+    output_root = tmp_path / "bundle-config"
+    _write_school_traitenv_private_fixture(traitenv_root)
+
+    bundle = build_school_traitenv_validation_bundle(
+        traitenv_root=traitenv_root,
+        output_root=output_root,
+        repo_root=repo_root,
+        approve_runnable_contract=True,
+    )
+
+    current_config_path = bundle.generated_config_paths["current_vs_promoted_config"]
+    current_config = yaml.safe_load(current_config_path.read_text(encoding="utf-8"))
+
+    assert Path(current_config["paths"]["repo_root"]).resolve() == repo_root.resolve()
+    assert Path(current_config["validation"]["forcing_csv_path"]).resolve() == bundle.forcing_csv_path.resolve()
+    assert Path(current_config["validation"]["yield_xlsx_path"]).resolve() == bundle.yield_csv_path.resolve()
+
+    loaded_config = load_config(current_config_path)
+    resolved_repo_root = resolve_repo_root(loaded_config, config_path=current_config_path)
+    prepared_bundle = prepare_knu_bundle(loaded_config, repo_root=resolved_repo_root, config_path=current_config_path)
+
+    assert prepared_bundle.validation_start.date().isoformat() == "2024-08-08"
+    assert prepared_bundle.validation_end.date().isoformat() == "2024-08-21"
+    assert Path(prepared_bundle.data_contract.forcing_path).resolve() == bundle.forcing_csv_path.resolve()
+    assert Path(prepared_bundle.data_contract.yield_path).resolve() == bundle.yield_csv_path.resolve()
+
+
+def test_school_traitenv_bundle_falls_back_to_raw_common_workbook_for_basis_metadata(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    traitenv_root = tmp_path / "traitenv"
+    raw_repo_root = tmp_path / "raw-tomato"
+    output_root = tmp_path / "bundle-raw-workbook"
+    _write_school_traitenv_private_fixture(traitenv_root, notes_only_crop_metadata=True)
+    workbook_path = _write_school_common_workbook(raw_repo_root)
+
+    bundle = build_school_traitenv_validation_bundle(
+        traitenv_root=traitenv_root,
+        output_root=output_root,
+        repo_root=repo_root,
+        raw_repo_root=raw_repo_root,
+        approve_runnable_contract=True,
+    )
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+
+    assert bundle.area_m2 == pytest.approx(100.757525)
+    assert bundle.plants_per_m2 == pytest.approx(1.9849634059590089)
+    assert bundle.crop_start == "2024-06-13"
+    assert bundle.crop_end == "2024-12-18"
+    source_paths = bundle.dataset_overlay["notes"]["private_derivation_source_paths"]
+    assert Path(source_paths["crop_common_workbook_path"]).resolve() == workbook_path.resolve()
+    assert source_paths["raw_repo_resolution_mode"] == "explicit_arg"
+    assert bundle.dataset_overlay["notes"]["private_derivation_crop_context"]["metadata_source_kind"] == "raw_common_workbook"
+    assert manifest["workflow_contract"]["raw_repo_resolution_mode"] == "explicit_arg"
+
+
+def test_school_traitenv_bundle_resolves_raw_workbook_from_source_origin_manifest(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    traitenv_root = tmp_path / "traitenv"
+    raw_repo_root = tmp_path / "raw-tomato"
+    output_root = tmp_path / "bundle-source-origin"
+    _write_school_traitenv_private_fixture(traitenv_root, notes_only_crop_metadata=True)
+    workbook_path = _write_school_common_workbook(raw_repo_root)
+    (traitenv_root / ".source_origin.json").write_text(
+        json.dumps(
+            {
+                "source_traitenv_root": str(traitenv_root.resolve()),
+                "source_raw_repo_root": str(raw_repo_root.resolve()),
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_school_traitenv_validation_bundle(
+        traitenv_root=traitenv_root,
+        output_root=output_root,
+        repo_root=repo_root,
+        approve_runnable_contract=True,
+    )
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+
+    assert bundle.area_m2 == pytest.approx(100.757525)
+    assert bundle.plants_per_m2 == pytest.approx(1.9849634059590089)
+    source_paths = bundle.dataset_overlay["notes"]["private_derivation_source_paths"]
+    assert source_paths["raw_repo_resolution_mode"] == "source_origin_manifest"
+    assert Path(source_paths["source_origin_manifest_path"]).resolve() == (traitenv_root / ".source_origin.json").resolve()
+    assert Path(source_paths["crop_common_workbook_path"]).resolve() == workbook_path.resolve()
+    assert manifest["source_paths"]["raw_repo_resolution_mode"] == "source_origin_manifest"
+    assert Path(manifest["workflow_contract"]["source_origin_manifest_path"]).resolve() == (
+        traitenv_root / ".source_origin.json"
+    ).resolve()


### PR DESCRIPTION
## Background
This is the main-based landed form of the previously reviewed narrow dependent surface that was first opened on top of `feat/263-add-tomics-lane-matrix-comparison-architecture` while PR `#264` was still in flight.

## Why
This formalizes Option A, the TOMICS private-reviewed traitenv workflow for school validation, as a repo-visible contract without widening promotion semantics.

## Exact 7-file landing set
- `docs/architecture/delivery/tomics-traitenv-private-reviewed-workflow-decision.md`
- `docs/architecture/implementation/tomics-school-traitenv-private-validation.md`
- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/traitenv_school_validation.py`
- `tests/test_traitenv_school_validation.py`
- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/contracts.py`
- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py`
- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py`

## Why contracts/registry/metadata are minimal exceptions
The private-reviewed traitenv helper/test surface is not self-consistent on `main` without these three shared dataset files:
- `contracts.py` provides the capability / ingestion / blocker contract used by the helper and test
- `registry.py` preserves `dry_matter_conversion` and `blocker_codes` across config round-trips so review-only datasets do not reload as runnable
- `metadata.py` is imported by `registry.py` for dataset blocker and registry summary helpers

## Intentionally not included
- raw/private data
- local-only artifacts
- `validation/datasets/runtime.py`
- `validation/datasets/traitenv_loader.py`
- lane-matrix packages, configs, and scripts
- shared multidataset runtime/config surface beyond the minimum files above

## Validation
- `ruff` on the 7-file surface
- `pytest -q tests/test_traitenv_school_validation.py`

## Smoke
Helper smoke remains intentionally omitted because the helper entrypoint is outside this approved minimal landing set.

## Policy impact
- no raw/private data is committed
- this does not widen public promotion eligibility
- this does not auto-promote private-reviewed datasets
- this preserves the incumbent TOMICS gate policy

Part of #265