### PR TITLE
[Bug] Preserve review-only derived-DW gate fallback without review_flags

### DIFF
--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py
@@ -44,6 +44,12 @@ def _json_list(value: object) -> list[str]:
     return []
 
 
+def _column_or_default(frame: pd.DataFrame, column: str, default: object) -> pd.Series:
+    if column in frame.columns:
+        return frame[column]
+    return pd.Series(default, index=frame.index)
+
+
 def _selected_candidate_review_proxy_dataset_ids(
     registry_df: pd.DataFrame | None,
     candidate: pd.Series,
@@ -56,18 +62,18 @@ def _selected_candidate_review_proxy_dataset_ids(
     candidate_rows = registry_df.loc[registry_df["dataset_id"].astype(str).isin(selected_dataset_ids)].copy()
     if candidate_rows.empty:
         return []
-    review_flag_mask = candidate_rows.get("review_flags", pd.Series(dtype=object)).apply(
+    review_flag_mask = _column_or_default(candidate_rows, "review_flags", None).apply(
         lambda value: "review_only_dry_matter_conversion" in _json_list(value)
     )
     derivation_mask = (
-        candidate_rows.get("observed_harvest_derivation", pd.Series(dtype=object))
+        _column_or_default(candidate_rows, "observed_harvest_derivation", "")
         .fillna("")
         .astype(str)
         .str.strip()
         .str.startswith("derived_dw_from_measured_fresh_")
     )
     direct_dw_mask = (
-        candidate_rows.get("is_direct_dry_weight", pd.Series(dtype=object))
+        _column_or_default(candidate_rows, "is_direct_dry_weight", True)
         .fillna(True)
         .astype(str)
         .str.strip()
@@ -75,7 +81,7 @@ def _selected_candidate_review_proxy_dataset_ids(
         .isin({"true", "1", "yes"})
     )
     literature_ratio_mask = (
-        candidate_rows.get("uses_literature_dry_matter_fraction", pd.Series(dtype=object))
+        _column_or_default(candidate_rows, "uses_literature_dry_matter_fraction", False)
         .fillna(False)
         .astype(str)
         .str.strip()

--- a/tests/test_cross_dataset_gate.py
+++ b/tests/test_cross_dataset_gate.py
@@ -406,3 +406,41 @@ def test_cross_dataset_guardrail_counts_review_flagged_public_ai_competition_dat
     assert summary["selected_candidate"]["winner_not_promotion_grade_due_to_review_only_proxy_support"] is True
     assert summary["selected_candidate"]["passes"] is False
     assert "blocked" in summary["recommendation"].lower()
+
+
+def test_cross_dataset_guardrail_falls_back_without_review_flags_column(tmp_path: Path) -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _runnable_measured_dataset(tmp_path, "knu_actual", dataset_family="knu_actual"),
+            _review_flagged_public_ai_competition_derived_dw_dataset(
+                tmp_path,
+                "public_ai_competition__yield",
+            ),
+        ),
+        default_dataset_ids=("knu_actual", "public_ai_competition__yield"),
+    )
+    registry_df = registry.to_frame().drop(columns=["review_flags"])
+    scorecard = pd.DataFrame(
+        [
+            {
+                "fruit_harvest_family": "dekoning_fds",
+                "leaf_harvest_family": "vegetative_unit_pruning",
+                "fdmc_mode": "dekoning_fds",
+                "dataset_count": 2,
+                "dataset_ids": "[\"knu_actual\", \"public_ai_competition__yield\"]",
+                "mean_native_family_state_fraction": 0.9,
+                "mean_proxy_family_state_fraction": 0.1,
+                "mean_shared_tdvs_proxy_fraction": 0.0,
+                "cross_dataset_stability_score": 1.0,
+            }
+        ]
+    )
+
+    summary = build_cross_dataset_guardrail_summary(scorecard, registry_df=registry_df, min_dataset_count=2)
+
+    assert summary["measured_dataset_count"] == 2
+    assert summary["selected_candidate"]["winner_review_only_proxy_support_flag"] is True
+    assert summary["selected_candidate"]["winner_review_only_proxy_dataset_ids"] == [
+        "public_ai_competition__yield"
+    ]
+    assert summary["selected_candidate"]["passes"] is False


### PR DESCRIPTION
## Summary
- keep review-only derived-DW guardrails active when `build_cross_dataset_guardrail_summary()` receives a direct `registry_df` without a `review_flags` column
- make missing-column fallbacks in `_selected_candidate_review_proxy_dataset_ids()` return index-aligned Series so fallback derivation/direct-DW/literature-ratio checks still work
- add a regression test that reproduces the promotion-bypass case with `public_ai_competition__yield` in a direct `registry_df`

## Repro Covered
- direct `registry_df` input
- `public_ai_competition__yield` included in candidate `dataset_ids`
- no `review_flags` column present
- fallback fields still mark the winner as review-only proxy support

## Validation
- `poetry run python -m pytest -q tests/test_cross_dataset_gate.py`
- `poetry run ruff check src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py tests/test_cross_dataset_gate.py`
- inline `poetry run python -` repro confirming `winner_review_only_proxy_support_flag=True` and `passes=False`

Closes #272
