### PR TITLE
[Data Prep] Prepare school and KNU rootzone validation inputs for mixed TOMICS gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ logs/
 
 docs/references/source_papers/
 
+data/fixtures/knu_rootzone_sanitized/
+
 .env
 config.yaml

--- a/configs/data/knu_private_data_contract.template.yaml
+++ b/configs/data/knu_private_data_contract.template.yaml
@@ -2,6 +2,8 @@ private_data_root_env: PHYTORITAS_PRIVATE_DATA_ROOT
 private_data_root:
 forcing_relative_path: data/forcing/KNU_Tomato_Env.CSV
 yield_relative_path: data/forcing/tomato_validation_data_yield_260321.xlsx
+rootzone_relative_path: data/rootzone/KNU_Tomato_Rootzone.csv
+ec_relative_path: data/ec/KNU_Tomato_Rootzone_EC.csv
 reporting_basis: floor_area_g_m2
 plants_per_m2: 1.836091
 parser_assumptions:
@@ -10,3 +12,16 @@ parser_assumptions:
   units_policy: preserve_source_declared_units
   datetime_policy: naive_local_greenhouse_timestamps
   observation_semantics: cumulative_harvested_fruit_dry_weight_floor_area
+rootzone_parser_assumptions:
+  rootzone_parser: csv_datetime_first_class
+  theta_semantics: measured_substrate_water_content
+  slab_weight_semantics: measured_substrate_weight
+  datetime_policy: naive_local_greenhouse_timestamps
+  missing_policy: preserve_missing
+  long_format: true
+ec_parser_assumptions:
+  ec_parser: csv_datetime_first_class
+  ec_semantics: measured_substrate_ec
+  datetime_policy: naive_local_greenhouse_timestamps
+  missing_policy: preserve_missing
+  long_format: true

--- a/configs/exp/tomics_knu_rootzone_reconstruction.yaml
+++ b/configs/exp/tomics_knu_rootzone_reconstruction.yaml
@@ -17,4 +17,7 @@ rootzone_reconstruction:
   scenario_ids: [dry, moderate, wet]
   theta_min_hard: 0.40
   theta_max_hard: 0.85
+  measured_scenario_id: measured
+  measured_theta_coverage_min: 0.05
+  measured_theta_max_gap: 1h
   overlay_spec: configs/plotkit/tomics/knu_theta_proxy_diagnostics.yaml

--- a/poetry.lock
+++ b/poetry.lock
@@ -192,6 +192,19 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+description = "An implementation of lxml.xmlfile for the standard library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
+files = [
+    {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
+    {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
+]
+
+[[package]]
 name = "fonttools"
 version = "4.62.0"
 description = "Tools to manipulate font files"
@@ -613,6 +626,22 @@ files = [
     {file = "numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5"},
     {file = "numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd"},
 ]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
+files = [
+    {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
+    {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
+]
+
+[package.dependencies]
+et-xmlfile = "*"
 
 [[package]]
 name = "packaging"
@@ -1198,4 +1227,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "e49ae99eb9d25f1c6772a4ca1a808af431e857d7409938300728ba1c840d2656"
+content-hash = "cea9fabae15d23afe6504f0f5fe2b5e4d8761859c2b4176517a92e9650562250"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "pandas (>=3.0.1,<4.0.0)",
     "pyyaml (>=6.0.3,<7.0.0)",
     "pyarrow (>=23.0.1,<24.0.0)",
-    "matplotlib (>=3.10.8,<4.0.0)"
+    "matplotlib (>=3.10.8,<4.0.0)",
+    "openpyxl (>=3.1.5,<4.0.0)"
 ]
 
 

--- a/scripts/build_knu_rootzone_aligned_fixture.py
+++ b/scripts/build_knu_rootzone_aligned_fixture.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = PROJECT_ROOT / "data" / "fixtures" / "knu_rootzone_sanitized"
+RAW_ROOTZONE_NAME = "KNU_Tomato_Rootzone_fixture.csv"
+RAW_EC_NAME = "KNU_Tomato_Rootzone_EC_fixture.csv"
+ALIGNED_ROOTZONE_NAME = "KNU_Tomato_Rootzone_aligned_fixture.csv"
+ALIGNED_EC_NAME = "KNU_Tomato_Rootzone_EC_aligned_fixture.csv"
+ALIGNED_MANIFEST_NAME = "knu_rootzone_aligned_fixture_manifest.json"
+ALIGNED_PROVENANCE_NAME = "knu_rootzone_aligned_provenance.md"
+
+COL_SEASON_LABEL = "\uc0dd\uc721\uc870\uc0ac \ud56d\ubaa9"
+COL_SEASON_START = "\uc791\uae30 \uc2dc\uc791"
+COL_SEASON_END = "\uc791\uae30 \uc885\ub8cc"
+COL_CONTROL = "Control"
+COL_DROUGHT = "Drought"
+COMMON_METADATA_TOKEN = "\uacf5\ud1b5"
+
+
+@dataclass(frozen=True, slots=True)
+class SeasonWindow:
+    season_id: str
+    label: str
+    start: pd.Timestamp
+    end: pd.Timestamp
+    treatment_map: dict[str, str]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build metadata-window-aligned KNU rootzone fixtures with mean-imputed gaps."
+    )
+    parser.add_argument(
+        "--raw-root",
+        required=True,
+        help="Raw tomato workspace containing 40_* metadata and configs/loadcell_seasons.json.",
+    )
+    parser.add_argument(
+        "--fixture-root",
+        default=str(FIXTURE_ROOT),
+        help="Directory containing raw sanitized rootzone/EC fixtures and receiving aligned outputs.",
+    )
+    return parser.parse_args()
+
+
+def _find_common_metadata(raw_root: Path) -> Path:
+    candidates = [
+        path
+        for path in raw_root.glob("40_*/*.xlsx")
+        if COMMON_METADATA_TOKEN in path.name and not path.name.startswith("~$")
+    ]
+    if len(candidates) != 1:
+        raise FileNotFoundError(
+            f"Expected exactly one common metadata workbook under {raw_root}, found {len(candidates)}"
+        )
+    return candidates[0]
+
+
+def _end_of_day(value: Any) -> pd.Timestamp:
+    return pd.Timestamp(value).normalize() + pd.Timedelta(hours=23)
+
+
+def _load_metadata_windows(raw_root: Path) -> tuple[list[SeasonWindow], dict[str, Any]]:
+    metadata_path = _find_common_metadata(raw_root)
+    metadata = pd.read_excel(metadata_path).dropna(axis=0, how="all")
+    labels = metadata[COL_SEASON_LABEL].astype(str).str.strip()
+
+    def row_for(label: str) -> pd.Series:
+        matches = metadata.loc[labels == label]
+        if matches.empty:
+            raise KeyError(f"Missing metadata row: {label}")
+        return matches.iloc[0]
+
+    row_2024 = row_for("2024\ub144 \uc791\uae30")
+    row_2025_1 = row_for("2025\ub144 1\uc791\uae30")
+    row_2025_2 = row_for("2025\ub144 2\uc791\uae30")
+
+    windows = [
+        SeasonWindow(
+            season_id="2024",
+            label=str(row_2024[COL_SEASON_LABEL]),
+            start=pd.Timestamp(row_2024[COL_SEASON_START]).normalize(),
+            end=_end_of_day(row_2024[COL_SEASON_END]),
+            treatment_map={"RZ00": "Control"},
+        ),
+        SeasonWindow(
+            season_id="2025_1",
+            label=str(row_2025_1[COL_SEASON_LABEL]),
+            start=pd.Timestamp(row_2025_1[COL_SEASON_START]).normalize(),
+            end=_end_of_day(row_2025_1[COL_SEASON_END]),
+            treatment_map={
+                "RZ01": "Control",
+                "RZ02": "Control",
+                "RZ03": "Control",
+                "RZ04": "Drought",
+                "RZ05": "Drought",
+                "RZ06": "Drought",
+            },
+        ),
+        SeasonWindow(
+            season_id="2025_2",
+            label=str(row_2025_2[COL_SEASON_LABEL]),
+            start=pd.Timestamp(row_2025_2[COL_SEASON_START]).normalize(),
+            end=_end_of_day(row_2025_2[COL_SEASON_END]),
+            treatment_map={
+                "RZ01": "Control",
+                "RZ02": "Control",
+                "RZ03": "Control",
+                "RZ04": "Drought",
+                "RZ05": "Drought",
+                "RZ06": "Drought",
+            },
+        ),
+    ]
+
+    metadata_payload = {
+        "metadata_path": str(metadata_path),
+        "season_workbook_rows": {
+            "2024": {
+                "label": str(row_2024[COL_SEASON_LABEL]),
+                "start": pd.Timestamp(row_2024[COL_SEASON_START]).strftime("%Y-%m-%d"),
+                "end": pd.Timestamp(row_2024[COL_SEASON_END]).strftime("%Y-%m-%d"),
+                "control": str(row_2024.get(COL_CONTROL, "")),
+                "drought": str(row_2024.get(COL_DROUGHT, "")),
+            },
+            "2025_1": {
+                "label": str(row_2025_1[COL_SEASON_LABEL]),
+                "start": pd.Timestamp(row_2025_1[COL_SEASON_START]).strftime("%Y-%m-%d"),
+                "end": pd.Timestamp(row_2025_1[COL_SEASON_END]).strftime("%Y-%m-%d"),
+                "control": str(row_2025_1.get(COL_CONTROL, "")),
+                "drought": str(row_2025_1.get(COL_DROUGHT, "")),
+            },
+            "2025_2": {
+                "label": str(row_2025_2[COL_SEASON_LABEL]),
+                "start": pd.Timestamp(row_2025_2[COL_SEASON_START]).strftime("%Y-%m-%d"),
+                "end": pd.Timestamp(row_2025_2[COL_SEASON_END]).strftime("%Y-%m-%d"),
+                "control": str(row_2025_2.get(COL_CONTROL, "")),
+                "drought": str(row_2025_2.get(COL_DROUGHT, "")),
+            },
+        },
+    }
+    return windows, metadata_payload
+
+
+def _read_fixture(path: Path) -> pd.DataFrame:
+    frame = pd.read_csv(path)
+    frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce")
+    frame = frame.loc[frame["datetime"].notna()].copy()
+    return frame
+
+
+def _format_datetime(frame: pd.DataFrame) -> pd.DataFrame:
+    frame = frame.copy()
+    frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce").dt.strftime("%Y-%m-%d %H:%M:%S")
+    return frame
+
+
+def _aggregate_sensor_rows(frame: pd.DataFrame, value_columns: list[str]) -> pd.DataFrame:
+    aggregations = {column: "mean" for column in value_columns}
+    aggregations.update({"zone_id": "last", "depth_cm": "last"})
+    return (
+        frame.groupby(["datetime", "sensor_id"], as_index=False)
+        .agg(aggregations)
+        .sort_values(["datetime", "sensor_id"])
+    )
+
+
+def _align_sensor_values(
+    source: pd.DataFrame,
+    *,
+    season: SeasonWindow,
+    sensor_id: str,
+    value_columns: list[str],
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    hourly_index = pd.date_range(season.start, season.end, freq="1h", name="datetime")
+    sensor_source = source.loc[
+        (source["sensor_id"] == sensor_id)
+        & (source["datetime"] >= season.start)
+        & (source["datetime"] <= season.end)
+    ].copy()
+    sensor_source = _aggregate_sensor_rows(sensor_source, value_columns)
+    indexed = sensor_source.set_index("datetime").reindex(hourly_index)
+
+    zone_id = sensor_source["zone_id"].dropna().iloc[0] if sensor_source["zone_id"].notna().any() else sensor_id
+    depth_cm = sensor_source["depth_cm"].dropna().iloc[0] if sensor_source["depth_cm"].notna().any() else pd.NA
+
+    aligned = pd.DataFrame(
+        {
+            "datetime": hourly_index,
+            "season_id": season.season_id,
+            "season_label": season.label,
+            "treatment": season.treatment_map[sensor_id],
+            "sensor_id": sensor_id,
+            "zone_id": zone_id,
+            "depth_cm": depth_cm,
+            "metadata_window_start": season.start.strftime("%Y-%m-%d %H:%M:%S"),
+            "metadata_window_end": season.end.strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    )
+
+    stats: dict[str, Any] = {
+        "season_id": season.season_id,
+        "sensor_id": sensor_id,
+        "treatment": season.treatment_map[sensor_id],
+        "row_count": int(len(aligned)),
+        "source_start": None,
+        "source_end": None,
+        "columns": {},
+    }
+    if not sensor_source.empty:
+        stats["source_start"] = sensor_source["datetime"].min().strftime("%Y-%m-%d %H:%M:%S")
+        stats["source_end"] = sensor_source["datetime"].max().strftime("%Y-%m-%d %H:%M:%S")
+
+    for column in value_columns:
+        values = pd.to_numeric(indexed[column], errors="coerce")
+        observed_mask = values.notna()
+        mean_value = values.mean()
+        filled_values = values.copy()
+        fillable_mask = values.isna() & pd.notna(mean_value)
+        filled_values.loc[fillable_mask] = mean_value
+
+        aligned[column] = filled_values.to_numpy()
+        aligned[f"{column}_source"] = "measured"
+        aligned.loc[fillable_mask.to_numpy(), f"{column}_source"] = "imputed_period_mean"
+        aligned.loc[
+            (values.isna() & pd.isna(mean_value)).to_numpy(),
+            f"{column}_source",
+        ] = "missing_no_period_mean"
+        aligned[f"{column}_is_imputed"] = fillable_mask.to_numpy()
+
+        stats["columns"][column] = {
+            "observed_count": int(observed_mask.sum()),
+            "imputed_count": int(fillable_mask.sum()),
+            "missing_after_count": int(aligned[column].isna().sum()),
+            "period_mean": None if pd.isna(mean_value) else float(mean_value),
+        }
+
+    return aligned, stats
+
+
+def _align_fixture(
+    source: pd.DataFrame,
+    *,
+    windows: list[SeasonWindow],
+    value_columns: list[str],
+) -> tuple[pd.DataFrame, list[dict[str, Any]]]:
+    frames: list[pd.DataFrame] = []
+    stats: list[dict[str, Any]] = []
+    for season in windows:
+        for sensor_id in season.treatment_map:
+            aligned, sensor_stats = _align_sensor_values(
+                source,
+                season=season,
+                sensor_id=sensor_id,
+                value_columns=value_columns,
+            )
+            frames.append(aligned)
+            stats.append(sensor_stats)
+    return pd.concat(frames, ignore_index=True), stats
+
+
+def _reorder_rootzone(frame: pd.DataFrame) -> pd.DataFrame:
+    ordered = [
+        "datetime",
+        "season_id",
+        "season_label",
+        "treatment",
+        "theta_substrate",
+        "theta_substrate_source",
+        "theta_substrate_is_imputed",
+        "slab_weight_kg",
+        "slab_weight_kg_source",
+        "slab_weight_kg_is_imputed",
+        "sensor_id",
+        "zone_id",
+        "depth_cm",
+        "metadata_window_start",
+        "metadata_window_end",
+    ]
+    return _format_datetime(frame[ordered])
+
+
+def _reorder_ec(frame: pd.DataFrame) -> pd.DataFrame:
+    ordered = [
+        "datetime",
+        "season_id",
+        "season_label",
+        "treatment",
+        "rootzone_ec_dS_m",
+        "rootzone_ec_dS_m_source",
+        "rootzone_ec_dS_m_is_imputed",
+        "sensor_id",
+        "zone_id",
+        "depth_cm",
+        "metadata_window_start",
+        "metadata_window_end",
+    ]
+    return _format_datetime(frame[ordered])
+
+
+def _summarize_frame(frame: pd.DataFrame, value_columns: list[str]) -> dict[str, Any]:
+    dt = pd.to_datetime(frame["datetime"], errors="coerce")
+    summary: dict[str, Any] = {
+        "row_count": int(len(frame)),
+        "start": dt.min().strftime("%Y-%m-%d %H:%M:%S"),
+        "end": dt.max().strftime("%Y-%m-%d %H:%M:%S"),
+        "season_count": int(frame["season_id"].nunique()),
+        "sensor_count": int(frame["sensor_id"].nunique()),
+        "by_season": {},
+        "columns": {},
+    }
+    for season_id, season_frame in frame.groupby("season_id"):
+        summary["by_season"][season_id] = {
+            "row_count": int(len(season_frame)),
+            "sensor_count": int(season_frame["sensor_id"].nunique()),
+            "start": pd.to_datetime(season_frame["datetime"]).min().strftime("%Y-%m-%d %H:%M:%S"),
+            "end": pd.to_datetime(season_frame["datetime"]).max().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    for column in value_columns:
+        source_col = f"{column}_source"
+        summary["columns"][column] = {
+            "missing_after_count": int(frame[column].isna().sum()),
+            "source_counts": {
+                str(key): int(value)
+                for key, value in frame[source_col].value_counts(dropna=False).sort_index().items()
+            },
+        }
+    return summary
+
+
+def _write_manifest(
+    *,
+    fixture_root: Path,
+    metadata_payload: dict[str, Any],
+    rootzone_frame: pd.DataFrame,
+    ec_frame: pd.DataFrame,
+    rootzone_stats: list[dict[str, Any]],
+    ec_stats: list[dict[str, Any]],
+) -> None:
+    payload = {
+        "dataset_id": "knu_actual",
+        "fixture_kind": "knu_rootzone_aligned_mean_imputed",
+        "timezone": "Asia/Seoul",
+        "rootzone_path": f"data/fixtures/knu_rootzone_sanitized/{ALIGNED_ROOTZONE_NAME}",
+        "ec_path": f"data/fixtures/knu_rootzone_sanitized/{ALIGNED_EC_NAME}",
+        "raw_sanitized_rootzone_path": f"data/fixtures/knu_rootzone_sanitized/{RAW_ROOTZONE_NAME}",
+        "raw_sanitized_ec_path": f"data/fixtures/knu_rootzone_sanitized/{RAW_EC_NAME}",
+        "provenance_path": f"data/fixtures/knu_rootzone_sanitized/{ALIGNED_PROVENANCE_NAME}",
+        "units": {
+            "theta_substrate": "fraction",
+            "slab_weight_kg": "kg",
+            "rootzone_ec_dS_m": "dS/m",
+            "depth_cm": "cm",
+        },
+        "metadata_source": metadata_payload,
+        "alignment_rule": "hourly grid from metadata transplant/season start through metadata season end",
+        "missing_policy": (
+            "for each season_id and sensor_id, fill missing measured value with the whole-period "
+            "mean of available values for the same column; preserve per-value source and is_imputed labels"
+        ),
+        "treatment_mapping": {
+            "2024": {"RZ00": "Control"},
+            "2025_1": {
+                "RZ01": "Control",
+                "RZ02": "Control",
+                "RZ03": "Control",
+                "RZ04": "Drought",
+                "RZ05": "Drought",
+                "RZ06": "Drought",
+            },
+            "2025_2": {
+                "RZ01": "Control",
+                "RZ02": "Control",
+                "RZ03": "Control",
+                "RZ04": "Drought",
+                "RZ05": "Drought",
+                "RZ06": "Drought",
+            },
+            "harvest_individual_mapping_note": "2025 harvest sheets use 1-9 Control and 10-18 Drought; rootzone loadcell channels available in the current fixture are 1-6.",
+        },
+        "harvest_availability_note": {
+            "2025_1": "summer season harvest workbook is not present yet; rootzone fixture is prepared for later harvest intake",
+            "2025_2": "winter harvest workbook exists and was handled in school_knu__yield fixtures",
+        },
+        "rootzone_summary": _summarize_frame(rootzone_frame, ["theta_substrate", "slab_weight_kg"]),
+        "ec_summary": _summarize_frame(ec_frame, ["rootzone_ec_dS_m"]),
+        "rootzone_sensor_stats": rootzone_stats,
+        "ec_sensor_stats": ec_stats,
+        "notes": {
+            "raw_fixture_policy": "raw sanitized fixtures are kept unchanged; aligned fixtures are the completed mean-imputed analysis inputs",
+            "not_included": [
+                "irrigation_event_flag",
+                "rootzone_multistress",
+                "rootzone_saturation",
+                "derived stress scores",
+            ],
+        },
+    }
+    (fixture_root / ALIGNED_MANIFEST_NAME).write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _write_provenance(fixture_root: Path, metadata_payload: dict[str, Any]) -> None:
+    rows = metadata_payload["season_workbook_rows"]
+    text = "\n".join(
+        [
+            "# KNU rootzone aligned fixture provenance",
+            "",
+            "- dataset_id: knu_actual",
+            "- fixture_kind: knu_rootzone_aligned_mean_imputed",
+            f"- source_metadata: {metadata_payload['metadata_path']}",
+            f"- raw_rootzone_fixture: data/fixtures/knu_rootzone_sanitized/{RAW_ROOTZONE_NAME}",
+            f"- raw_ec_fixture: data/fixtures/knu_rootzone_sanitized/{RAW_EC_NAME}",
+            f"- aligned_rootzone_fixture: data/fixtures/knu_rootzone_sanitized/{ALIGNED_ROOTZONE_NAME}",
+            f"- aligned_ec_fixture: data/fixtures/knu_rootzone_sanitized/{ALIGNED_EC_NAME}",
+            "- alignment_rule: use metadata season start/end columns; expand each season/sensor to hourly timestamps.",
+            "- missing_policy: fill missing loadcell/rootzone values with the season+sensor whole-period mean and label the filled cells.",
+            "- 2024_window: "
+            + f"{rows['2024']['start']} -> {rows['2024']['end']} ({rows['2024']['label']})",
+            "- 2025_1_window: "
+            + f"{rows['2025_1']['start']} -> {rows['2025_1']['end']} ({rows['2025_1']['label']})",
+            "- 2025_2_window: "
+            + f"{rows['2025_2']['start']} -> {rows['2025_2']['end']} ({rows['2025_2']['label']})",
+            "- 2025_rootzone_treatment_map: Control=RZ01,RZ02,RZ03; Drought=RZ04,RZ05,RZ06.",
+            "- 2025_harvest_individual_map: Control=individual sheets 1-9; Drought=individual sheets 10-18.",
+            "- 2025_1_harvest_status: pending; summer harvest raw workbook is not in the current raw workspace yet.",
+            "- 2025_2_harvest_status: available; handled by school_knu__yield fixture generation.",
+            "",
+        ]
+    )
+    (fixture_root / ALIGNED_PROVENANCE_NAME).write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    args = _parse_args()
+    raw_root = Path(args.raw_root).expanduser().resolve()
+    fixture_root = Path(args.fixture_root).expanduser().resolve()
+    fixture_root.mkdir(parents=True, exist_ok=True)
+
+    windows, metadata_payload = _load_metadata_windows(raw_root)
+    rootzone_source = _read_fixture(fixture_root / RAW_ROOTZONE_NAME)
+    ec_source = _read_fixture(fixture_root / RAW_EC_NAME)
+
+    rootzone_aligned, rootzone_stats = _align_fixture(
+        rootzone_source,
+        windows=windows,
+        value_columns=["theta_substrate", "slab_weight_kg"],
+    )
+    ec_aligned, ec_stats = _align_fixture(
+        ec_source,
+        windows=windows,
+        value_columns=["rootzone_ec_dS_m"],
+    )
+
+    rootzone_aligned = _reorder_rootzone(rootzone_aligned)
+    ec_aligned = _reorder_ec(ec_aligned)
+
+    rootzone_aligned.to_csv(fixture_root / ALIGNED_ROOTZONE_NAME, index=False, encoding="utf-8", na_rep="")
+    ec_aligned.to_csv(fixture_root / ALIGNED_EC_NAME, index=False, encoding="utf-8", na_rep="")
+    _write_manifest(
+        fixture_root=fixture_root,
+        metadata_payload=metadata_payload,
+        rootzone_frame=rootzone_aligned,
+        ec_frame=ec_aligned,
+        rootzone_stats=rootzone_stats,
+        ec_stats=ec_stats,
+    )
+    _write_provenance(fixture_root, metadata_payload)
+
+    print(
+        json.dumps(
+            {
+                "rootzone_path": str(fixture_root / ALIGNED_ROOTZONE_NAME),
+                "ec_path": str(fixture_root / ALIGNED_EC_NAME),
+                "manifest_path": str(fixture_root / ALIGNED_MANIFEST_NAME),
+                "provenance_path": str(fixture_root / ALIGNED_PROVENANCE_NAME),
+                "rootzone_summary": _summarize_frame(
+                    rootzone_aligned, ["theta_substrate", "slab_weight_kg"]
+                ),
+                "ec_summary": _summarize_frame(ec_aligned, ["rootzone_ec_dS_m"]),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_knu_rootzone_sanitized.py
+++ b/scripts/build_knu_rootzone_sanitized.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = PROJECT_ROOT / "data" / "fixtures" / "knu_rootzone_sanitized"
+DEFAULT_MANIFEST_PATH = FIXTURE_ROOT / "knu_rootzone_fixture_manifest.json"
+DEFAULT_ROOTZONE_PATH = FIXTURE_ROOT / "KNU_Tomato_Rootzone_fixture.csv"
+DEFAULT_EC_PATH = FIXTURE_ROOT / "KNU_Tomato_Rootzone_EC_fixture.csv"
+
+
+@dataclass(frozen=True, slots=True)
+class SeasonWindow:
+    season_id: str
+    start: pd.Timestamp
+    end: pd.Timestamp
+
+
+SEASON_WINDOWS: tuple[SeasonWindow, ...] = (
+    SeasonWindow("2024", pd.Timestamp("2024-06-13 00:00:00"), pd.Timestamp("2024-12-18 23:59:59")),
+    SeasonWindow("2025_1", pd.Timestamp("2025-06-04 00:00:00"), pd.Timestamp("2025-09-03 23:59:59")),
+    SeasonWindow("2025_2", pd.Timestamp("2025-10-22 00:00:00"), pd.Timestamp("2026-02-21 23:59:59")),
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build sanitized KNU rootzone and EC fixtures.")
+    parser.add_argument(
+        "--raw-root",
+        required=True,
+        help="Path to the raw tomato workspace that contains outputs/loadcell and 2024 CR1000X sources.",
+    )
+    parser.add_argument(
+        "--output-root",
+        default=str(FIXTURE_ROOT),
+        help="Output directory for sanitized fixtures.",
+    )
+    return parser.parse_args()
+
+
+def _format_datetime(series: pd.Series) -> pd.Series:
+    return pd.to_datetime(series, errors="coerce").dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _sensor_id(index: int) -> str:
+    return f"RZ{index:02d}"
+
+
+def _zone_id(index: int) -> str:
+    return f"BED{index:02d}"
+
+
+def _combine_excel_datetime(date_series: pd.Series, time_series: pd.Series) -> pd.Series:
+    date_text = pd.to_datetime(date_series, errors="coerce").dt.strftime("%Y-%m-%d")
+    time_text = (
+        time_series.astype(str)
+        .str.extract(r"(\d{2}:\d{2}:\d{2})", expand=False)
+        .where(lambda value: value.str.fullmatch(r"\d{2}:\d{2}:\d{2}"), None)
+    )
+    return pd.to_datetime(date_text + " " + time_text, errors="coerce")
+
+
+def _iter_2024_cr1000x_files(raw_root: Path) -> list[Path]:
+    env_root = next(
+        (path for path in raw_root.iterdir() if path.is_dir() and path.name.startswith("30_")),
+        None,
+    )
+    if env_root is None:
+        raise FileNotFoundError(f"Could not locate 30_* environment root under {raw_root}")
+    files = [path for path in env_root.rglob("*.xlsx") if "CR1000X" in path.as_posix()]
+    if not files:
+        raise FileNotFoundError(f"Could not locate 2024 CR1000X workbook bundle under {env_root}")
+    return sorted(files)
+
+
+def _parse_2024_frames(raw_root: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rootzone_frames: list[pd.DataFrame] = []
+    ec_frames: list[pd.DataFrame] = []
+    window = next(season for season in SEASON_WINDOWS if season.season_id == "2024")
+    for workbook in _iter_2024_cr1000x_files(raw_root):
+        raw_df = pd.read_excel(workbook, sheet_name="hourly", header=None, skiprows=4, usecols=[0, 1, 4, 5])
+        raw_df.columns = ["date", "time", "theta_substrate", "rootzone_ec_dS_m"]
+        raw_df["datetime"] = _combine_excel_datetime(raw_df["date"], raw_df["time"])
+        raw_df = raw_df.dropna(subset=["datetime"]).copy()
+        raw_df = raw_df[(raw_df["datetime"] >= window.start) & (raw_df["datetime"] <= window.end)].copy()
+        if raw_df.empty:
+            continue
+
+        base = pd.DataFrame(
+            {
+                "datetime": raw_df["datetime"],
+                "sensor_id": "RZ00",
+                "zone_id": "BED00",
+                "depth_cm": pd.NA,
+            }
+        )
+
+        theta_frame = base.copy()
+        theta_values = pd.to_numeric(raw_df["theta_substrate"], errors="coerce")
+        theta_frame["theta_substrate"] = theta_values.where((theta_values >= 0.0) & (theta_values <= 2.0))
+        theta_frame["slab_weight_kg"] = pd.NA
+        theta_frame = theta_frame.loc[
+            theta_frame["theta_substrate"].notna() | theta_frame["slab_weight_kg"].notna()
+        ].copy()
+        if not theta_frame.empty:
+            rootzone_frames.append(theta_frame)
+
+        ec_frame = base.copy()
+        ec_frame["rootzone_ec_dS_m"] = pd.to_numeric(raw_df["rootzone_ec_dS_m"], errors="coerce")
+        ec_frame = ec_frame.loc[ec_frame["rootzone_ec_dS_m"].notna()].copy()
+        if not ec_frame.empty:
+            ec_frames.append(ec_frame)
+
+    if not rootzone_frames:
+        raise ValueError("No 2024 rootzone records were parsed from CR1000X hourly sheets.")
+    return pd.concat(rootzone_frames, ignore_index=True), pd.concat(ec_frames, ignore_index=True)
+
+
+def _select_2025_parquet_files(raw_root: Path, season: SeasonWindow) -> list[Path]:
+    loadcell_root = raw_root / "outputs" / "loadcell"
+    if not loadcell_root.exists():
+        raise FileNotFoundError(f"Could not locate loadcell outputs at {loadcell_root}")
+
+    selected: list[Path] = []
+    for directory in sorted(path for path in loadcell_root.iterdir() if path.is_dir()):
+        for parquet_path in sorted(directory.glob("*.parquet")):
+            try:
+                file_day = pd.Timestamp(parquet_path.stem)
+            except ValueError:
+                continue
+            if season.start.normalize() <= file_day.normalize() <= season.end.normalize():
+                selected.append(parquet_path)
+    return selected
+
+
+def _hourly_mean_frame(path: Path, *, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+    frame = pd.read_parquet(path)
+    if not isinstance(frame.index, pd.DatetimeIndex):
+        frame.index = pd.to_datetime(frame.index, errors="coerce")
+    frame = frame.loc[frame.index.notna()].sort_index()
+    frame = frame[(frame.index >= start) & (frame.index <= end)]
+    if frame.empty:
+        return frame
+    return frame.resample("1h").mean(numeric_only=True)
+
+
+def _parse_2025_frames(raw_root: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rootzone_frames: list[pd.DataFrame] = []
+    ec_frames: list[pd.DataFrame] = []
+    for season in SEASON_WINDOWS:
+        if not season.season_id.startswith("2025"):
+            continue
+        parquet_files = _select_2025_parquet_files(raw_root, season)
+        for parquet_path in parquet_files:
+            hourly = _hourly_mean_frame(parquet_path, start=season.start, end=season.end)
+            if hourly.empty:
+                continue
+            hourly = hourly.reset_index(names="datetime")
+            for sensor_index in range(1, 7):
+                theta_col = f"moisture_{sensor_index}_percent"
+                weight_col = f"loadcell_{sensor_index}_kg"
+                ec_col = f"ec_{sensor_index}_ds"
+                meta = {
+                    "sensor_id": _sensor_id(sensor_index),
+                    "zone_id": _zone_id(sensor_index),
+                    "depth_cm": pd.NA,
+                }
+                theta_frame = pd.DataFrame(
+                    {
+                        "datetime": hourly["datetime"],
+                        "theta_substrate": pd.to_numeric(hourly.get(theta_col), errors="coerce") / 100.0,
+                        "slab_weight_kg": pd.to_numeric(hourly.get(weight_col), errors="coerce"),
+                        **meta,
+                    }
+                )
+                theta_frame = theta_frame.loc[
+                    theta_frame["theta_substrate"].notna() | theta_frame["slab_weight_kg"].notna()
+                ].copy()
+                if not theta_frame.empty:
+                    rootzone_frames.append(theta_frame)
+
+                ec_frame = pd.DataFrame(
+                    {
+                        "datetime": hourly["datetime"],
+                        "rootzone_ec_dS_m": pd.to_numeric(hourly.get(ec_col), errors="coerce"),
+                        **meta,
+                    }
+                )
+                ec_frame = ec_frame.loc[ec_frame["rootzone_ec_dS_m"].notna()].copy()
+                if not ec_frame.empty:
+                    ec_frames.append(ec_frame)
+
+    if not rootzone_frames:
+        raise ValueError("No 2025 rootzone records were parsed from loadcell parquet outputs.")
+    return pd.concat(rootzone_frames, ignore_index=True), pd.concat(ec_frames, ignore_index=True)
+
+
+def _finalize_rootzone_frame(frames: Iterable[pd.DataFrame]) -> pd.DataFrame:
+    frame = pd.concat(list(frames), ignore_index=True)
+    frame = frame.sort_values(["datetime", "sensor_id"]).reset_index(drop=True)
+    frame["datetime"] = _format_datetime(frame["datetime"])
+    ordered = ["datetime", "theta_substrate", "slab_weight_kg", "sensor_id", "zone_id", "depth_cm"]
+    return frame[ordered]
+
+
+def _finalize_ec_frame(frames: Iterable[pd.DataFrame]) -> pd.DataFrame:
+    frame = pd.concat(list(frames), ignore_index=True)
+    frame = frame.sort_values(["datetime", "sensor_id"]).reset_index(drop=True)
+    frame["datetime"] = _format_datetime(frame["datetime"])
+    ordered = ["datetime", "rootzone_ec_dS_m", "sensor_id", "zone_id", "depth_cm"]
+    return frame[ordered]
+
+
+def _frame_coverage(frame: pd.DataFrame) -> dict[str, object]:
+    if frame.empty:
+        return {"row_count": 0, "start": None, "end": None, "sensor_count": 0}
+    dt = pd.to_datetime(frame["datetime"], errors="coerce")
+    return {
+        "row_count": int(len(frame)),
+        "start": dt.min().strftime("%Y-%m-%d %H:%M:%S"),
+        "end": dt.max().strftime("%Y-%m-%d %H:%M:%S"),
+        "sensor_count": int(frame["sensor_id"].nunique()),
+    }
+
+
+def _season_windows_payload() -> dict[str, dict[str, str]]:
+    return {
+        season.season_id: {
+            "start": season.start.strftime("%Y-%m-%d %H:%M:%S"),
+            "end": season.end.strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        for season in SEASON_WINDOWS
+    }
+
+
+def _theta_range(frame: pd.DataFrame) -> dict[str, float | None]:
+    series = pd.to_numeric(frame["theta_substrate"], errors="coerce").dropna()
+    if series.empty:
+        return {"min": None, "max": None}
+    return {"min": float(series.min()), "max": float(series.max())}
+
+
+def _write_manifest(
+    *,
+    output_root: Path,
+    rootzone_frame: pd.DataFrame,
+    ec_frame: pd.DataFrame,
+    raw_root: Path,
+) -> Path:
+    payload = {
+        "dataset_id": "knu_actual",
+        "fixture_kind": "knu_rootzone_sanitized",
+        "timezone": "Asia/Seoul",
+        "rootzone_path": "data/fixtures/knu_rootzone_sanitized/KNU_Tomato_Rootzone_fixture.csv",
+        "ec_path": "data/fixtures/knu_rootzone_sanitized/KNU_Tomato_Rootzone_EC_fixture.csv",
+        "irrigation_path": None,
+        "units": {
+            "theta_substrate": "fraction",
+            "slab_weight_kg": "kg",
+            "rootzone_ec_dS_m": "dS/m",
+            "depth_cm": "cm",
+        },
+        "sensor_layout": "representative probe layout for KNU tomato greenhouse",
+        "aggregation_rule": "one row per timestamp per sensor",
+        "missing_policy": "keep missing as blank; do not forward-fill in raw sanitized fixture",
+        "source_refs": [
+            "2024 CR1000X hourly substrate workbook bundle under the raw tomato workspace 30_* environment tree",
+            "outputs/loadcell/*/*.parquet within 2025 season windows",
+        ],
+        "notes": {
+            "contains_irrigation_events": False,
+            "includes_only_measured_values": True,
+            "derived_rootzone_stress_metrics_are_excluded": True,
+            "season_windows": _season_windows_payload(),
+            "rootzone_coverage": _frame_coverage(rootzone_frame),
+            "ec_coverage": _frame_coverage(ec_frame),
+            "theta_range": _theta_range(rootzone_frame),
+            "theta_substrate_semantics": (
+                "2024 values come from CR1000X VWC_Avg. 2025 values come from moisture_i_percent / 100 without clipping."
+            ),
+            "theta_cleanup_note": "2024 CR1000X VWC_Avg values outside 0-2 were treated as logger sentinel missing values and left blank.",
+            "slab_weight_note": "2024 CR1000X source has no slab_weight_kg field; rows remain blank for that column.",
+            "depth_note": "depth_cm metadata is unavailable in the current raw source and is preserved as blank.",
+        },
+    }
+    manifest_path = output_root / DEFAULT_MANIFEST_PATH.name
+    manifest_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+    return manifest_path
+
+
+def _ensure_output_root(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_csv(frame: pd.DataFrame, path: Path) -> None:
+    frame.to_csv(path, index=False, encoding="utf-8", na_rep="")
+
+
+def main() -> int:
+    args = _parse_args()
+    raw_root = Path(args.raw_root).expanduser().resolve()
+    output_root = _ensure_output_root(Path(args.output_root).expanduser().resolve())
+    if not raw_root.exists():
+        raise FileNotFoundError(f"Raw root does not exist: {raw_root}")
+
+    rootzone_2024, ec_2024 = _parse_2024_frames(raw_root)
+    rootzone_2025, ec_2025 = _parse_2025_frames(raw_root)
+    rootzone_frame = _finalize_rootzone_frame([rootzone_2024, rootzone_2025])
+    ec_frame = _finalize_ec_frame([ec_2024, ec_2025])
+
+    rootzone_path = output_root / DEFAULT_ROOTZONE_PATH.name
+    ec_path = output_root / DEFAULT_EC_PATH.name
+    _write_csv(rootzone_frame, rootzone_path)
+    _write_csv(ec_frame, ec_path)
+    manifest_path = _write_manifest(
+        output_root=output_root,
+        rootzone_frame=rootzone_frame,
+        ec_frame=ec_frame,
+        raw_root=raw_root,
+    )
+
+    summary = {
+        "rootzone_path": str(rootzone_path),
+        "ec_path": str(ec_path),
+        "manifest_path": str(manifest_path),
+        "rootzone_row_count": int(len(rootzone_frame)),
+        "ec_row_count": int(len(ec_frame)),
+        "theta_min": _theta_range(rootzone_frame)["min"],
+        "theta_max": _theta_range(rootzone_frame)["max"],
+    }
+    print(json.dumps(summary, indent=2, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_traitenv_school_validation.py
+++ b/scripts/prepare_traitenv_school_validation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.traitenv_school_validation import (
+    build_school_traitenv_validation_bundle,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare a private-reviewed school traitenv validation bundle.",
+    )
+    parser.add_argument(
+        "--traitenv-root",
+        type=Path,
+        default=Path("out/private-data/traitenv"),
+        help="Cloned traitenv root that contains the school partition tables.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("out/private-data/tomics_school_traitenv_validation"),
+        help="Local output root for generated private forcing/harvest/config artifacts.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the current repo.",
+    )
+    parser.add_argument(
+        "--raw-repo-root",
+        type=Path,
+        default=None,
+        help="Optional raw tomato repo root used for workbook fallback metadata recovery.",
+    )
+    parser.add_argument("--season", default="2024", help="Season label selector.")
+    parser.add_argument("--treatment", default="Control", help="Treatment selector.")
+    parser.add_argument(
+        "--dry-matter-ratio",
+        type=float,
+        default=0.065,
+        help="Literature dry-matter ratio applied to fresh harvest totals.",
+    )
+    parser.add_argument(
+        "--par-umol-per-w-m2",
+        type=float,
+        default=2.3,
+        help="PAR conversion factor for the greenhouse forcing bundle.",
+    )
+    parser.add_argument(
+        "--approve-runnable-contract",
+        action="store_true",
+        help="Clear the review-only blocker inside the generated private overlay only.",
+    )
+    parser.add_argument(
+        "--current-vs-promoted-base-config",
+        type=Path,
+        default=Path("configs/exp/tomics_current_vs_promoted_factorial_knu.yaml"),
+        help="Base config used to generate the school current-vs-promoted config.",
+    )
+    parser.add_argument(
+        "--harvest-factorial-base-config",
+        type=Path,
+        default=Path("configs/exp/tomics_knu_harvest_family_factorial.yaml"),
+        help="Base config used to generate the school harvest-family config.",
+    )
+    parser.add_argument(
+        "--multidataset-base-config",
+        type=Path,
+        default=Path("configs/exp/tomics_multidataset_harvest_factorial.yaml"),
+        help="Base config used to generate the multidataset factorial config.",
+    )
+    parser.add_argument(
+        "--promotion-gate-base-config",
+        type=Path,
+        default=Path("configs/exp/tomics_multidataset_harvest_promotion_gate.yaml"),
+        help="Base config used to generate the multidataset promotion gate config.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    bundle = build_school_traitenv_validation_bundle(
+        traitenv_root=args.traitenv_root,
+        output_root=args.output_root,
+        repo_root=args.repo_root,
+        raw_repo_root=args.raw_repo_root,
+        season=args.season,
+        treatment=args.treatment,
+        dry_matter_ratio=args.dry_matter_ratio,
+        par_umol_per_w_m2=args.par_umol_per_w_m2,
+        approve_runnable_contract=args.approve_runnable_contract,
+        current_vs_promoted_base_config=args.current_vs_promoted_base_config,
+        harvest_factorial_base_config=args.harvest_factorial_base_config,
+        multidataset_base_config=args.multidataset_base_config,
+        promotion_gate_base_config=args.promotion_gate_base_config,
+    )
+    summary = {
+        "forcing_csv_path": str(bundle.forcing_csv_path),
+        "yield_csv_path": str(bundle.yield_csv_path),
+        "manifest_path": str(bundle.manifest_path),
+        "season": bundle.season,
+        "treatment": bundle.treatment,
+        "validation_start": bundle.validation_start,
+        "validation_end": bundle.validation_end,
+        "generated_config_paths": {key: str(value) for key, value in bundle.generated_config_paths.items()},
+        "approve_runnable_contract": bundle.approve_runnable_contract,
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tomics_knu_rootzone_reconstruction.py
+++ b/scripts/run_tomics_knu_rootzone_reconstruction.py
@@ -16,6 +16,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_promoted import (  # noqa: E402
     prepare_knu_bundle,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.runtime import (  # noqa: E402
+    read_rootzone_table,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.rootzone_inversion import (  # noqa: E402
     reconstruct_rootzone,
     write_rootzone_manifest,
@@ -60,6 +63,12 @@ def main() -> int:
         scenario_ids=tuple(rootzone_cfg.get("scenario_ids", ["dry", "moderate", "wet"])),
         theta_min_hard=float(rootzone_cfg.get("theta_min_hard", 0.40)),
         theta_max_hard=float(rootzone_cfg.get("theta_max_hard", 0.85)),
+        measured_rootzone_df=read_rootzone_table(prepared_bundle.data_contract.rootzone_path)
+        if prepared_bundle.data_contract.rootzone_path is not None
+        else None,
+        measured_scenario_id=str(rootzone_cfg.get("measured_scenario_id", "measured")),
+        measured_theta_coverage_min=float(rootzone_cfg.get("measured_theta_coverage_min", 0.50)),
+        measured_theta_max_gap=str(rootzone_cfg.get("measured_theta_max_gap", "1h")),
     )
     result.summary_df.to_csv(output_root / "rootzone_summary.csv", index=False)
     result.band_df.to_csv(output_root / "theta_uncertainty_band.csv", index=False)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py
@@ -88,8 +88,16 @@ def _selected_candidate_review_proxy_dataset_ids(
         .str.lower()
         .isin({"true", "1", "yes"})
     )
+    review_grade_mask = (
+        _column_or_default(candidate_rows, "dry_weight_derivation_review_grade", "")
+        .fillna("")
+        .astype(str)
+        .str.strip()
+        .str.lower()
+        .eq("manual_reviewed_private")
+    )
     flagged = candidate_rows.loc[
-        review_flag_mask | (derivation_mask & (~direct_dw_mask) & literature_ratio_mask),
+        review_flag_mask | (derivation_mask & (~direct_dw_mask) & literature_ratio_mask & (~review_grade_mask)),
         "dataset_id",
     ]
     return sorted({str(value) for value in flagged.dropna()})

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/data_contract.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/data_contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +23,12 @@ class KnuDataContractPaths:
     reporting_basis: str
     plants_per_m2: float
     parser_assumptions: dict[str, Any]
+    rootzone_path: Path | None = None
+    ec_path: Path | None = None
+    rootzone_source_kind: str | None = None
+    ec_source_kind: str | None = None
+    rootzone_parser_assumptions: dict[str, Any] = field(default_factory=dict)
+    ec_parser_assumptions: dict[str, Any] = field(default_factory=dict)
     date_column: str | None = None
     measured_cumulative_column: str | None = None
     estimated_cumulative_column: str | None = None
@@ -103,6 +109,22 @@ def _resolve_source_path(
     return repo_candidate, "missing"
 
 
+def _resolve_optional_source_path(
+    *,
+    repo_candidate: Path,
+    private_root: str | None,
+    configured_relative_path: str | None,
+) -> tuple[Path | None, str | None]:
+    resolved_path, source_kind = _resolve_source_path(
+        repo_candidate=repo_candidate,
+        private_root=private_root,
+        configured_relative_path=configured_relative_path,
+    )
+    if source_kind == "missing":
+        return None, None
+    return resolved_path, source_kind
+
+
 def resolve_knu_data_contract(
     *,
     validation_cfg: dict[str, Any],
@@ -120,8 +142,18 @@ def resolve_knu_data_contract(
 
     forcing_raw = validation_cfg.get("forcing_csv_path", "data/forcing/KNU_Tomato_Env.CSV")
     yield_raw = validation_cfg.get("yield_xlsx_path", "data/forcing/tomato_validation_data_yield_260321.xlsx")
+    rootzone_raw = validation_cfg.get(
+        "rootzone_csv_path",
+        contract.get("rootzone_relative_path", "data/rootzone/KNU_Tomato_Rootzone.csv"),
+    )
+    ec_raw = validation_cfg.get(
+        "ec_csv_path",
+        contract.get("ec_relative_path", "data/ec/KNU_Tomato_Rootzone_EC.csv"),
+    )
     forcing_repo_candidate = _resolve_existing_path(str(forcing_raw), repo_root=repo_root, config_path=config_path)
     yield_repo_candidate = _resolve_existing_path(str(yield_raw), repo_root=repo_root, config_path=config_path)
+    rootzone_repo_candidate = _resolve_existing_path(str(rootzone_raw), repo_root=repo_root, config_path=config_path)
+    ec_repo_candidate = _resolve_existing_path(str(ec_raw), repo_root=repo_root, config_path=config_path)
 
     forcing_path, forcing_source_kind = _resolve_source_path(
         repo_candidate=forcing_repo_candidate,
@@ -132,6 +164,16 @@ def resolve_knu_data_contract(
         repo_candidate=yield_repo_candidate,
         private_root=private_root,
         configured_relative_path=str(contract.get("yield_relative_path", yield_repo_candidate.name)),
+    )
+    rootzone_path, rootzone_source_kind = _resolve_optional_source_path(
+        repo_candidate=rootzone_repo_candidate,
+        private_root=private_root,
+        configured_relative_path=str(contract.get("rootzone_relative_path", rootzone_repo_candidate.name)),
+    )
+    ec_path, ec_source_kind = _resolve_optional_source_path(
+        repo_candidate=ec_repo_candidate,
+        private_root=private_root,
+        configured_relative_path=str(contract.get("ec_relative_path", ec_repo_candidate.name)),
     )
     if forcing_source_kind == "missing":
         raise FileNotFoundError(
@@ -166,6 +208,23 @@ def resolve_knu_data_contract(
         **contract_parser_assumptions,
     }
     parser_assumptions["observation_semantics"] = measured_semantics
+    rootzone_parser_assumptions = {
+        "rootzone_parser": "csv_datetime_first_class",
+        "theta_semantics": "measured_substrate_water_content",
+        "slab_weight_semantics": "measured_substrate_weight",
+        "datetime_policy": "naive_local_greenhouse_timestamps",
+        "missing_policy": "preserve_missing",
+        "long_format": True,
+        **_as_dict(contract.get("rootzone_parser_assumptions")),
+    }
+    ec_parser_assumptions = {
+        "ec_parser": "csv_datetime_first_class",
+        "ec_semantics": "measured_substrate_ec",
+        "datetime_policy": "naive_local_greenhouse_timestamps",
+        "missing_policy": "preserve_missing",
+        "long_format": True,
+        **_as_dict(contract.get("ec_parser_assumptions")),
+    }
     return KnuDataContractPaths(
         forcing_path=forcing_path,
         yield_path=yield_path,
@@ -198,6 +257,12 @@ def resolve_knu_data_contract(
         ),
         measured_semantics=measured_semantics,
         parser_assumptions=parser_assumptions,
+        rootzone_path=rootzone_path,
+        ec_path=ec_path,
+        rootzone_source_kind=rootzone_source_kind,
+        ec_source_kind=ec_source_kind,
+        rootzone_parser_assumptions=rootzone_parser_assumptions,
+        ec_parser_assumptions=ec_parser_assumptions,
         private_data_root=private_root,
         contract_path=contract_path,
     )
@@ -214,8 +279,12 @@ def write_data_contract_manifest(
     payload = {
         "forcing_source_path": str(contract.forcing_path.resolve()),
         "yield_source_path": str(contract.yield_path.resolve()),
+        "rootzone_source_path": str(contract.rootzone_path.resolve()) if contract.rootzone_path is not None else None,
+        "ec_source_path": str(contract.ec_path.resolve()) if contract.ec_path is not None else None,
         "forcing_source_kind": contract.forcing_source_kind,
         "yield_source_kind": contract.yield_source_kind,
+        "rootzone_source_kind": contract.rootzone_source_kind,
+        "ec_source_kind": contract.ec_source_kind,
         "private_data_root": contract.private_data_root,
         "contract_path": str(contract.contract_path.resolve()) if contract.contract_path is not None else None,
         "reporting_basis": contract.reporting_basis,
@@ -233,6 +302,8 @@ def write_data_contract_manifest(
             "yield_end": data.yield_summary["end"],
         },
         "parser_assumptions": contract.parser_assumptions,
+        "rootzone_parser_assumptions": contract.rootzone_parser_assumptions,
+        "ec_parser_assumptions": contract.ec_parser_assumptions,
     }
     manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return manifest_path
@@ -242,6 +313,8 @@ def contract_payload(contract: KnuDataContractPaths) -> dict[str, Any]:
     payload = asdict(contract)
     payload["forcing_path"] = str(contract.forcing_path)
     payload["yield_path"] = str(contract.yield_path)
+    payload["rootzone_path"] = str(contract.rootzone_path) if contract.rootzone_path is not None else None
+    payload["ec_path"] = str(contract.ec_path) if contract.ec_path is not None else None
     payload["contract_path"] = str(contract.contract_path) if contract.contract_path is not None else None
     return payload
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/metadata.py
@@ -125,6 +125,9 @@ def dataset_registry_frame(datasets: list[DatasetMetadataContract]) -> pd.DataFr
                 "uses_literature_dry_matter_fraction": payload["notes"].get(
                     "uses_literature_dry_matter_fraction"
                 ),
+                "dry_weight_derivation_review_grade": payload["notes"].get(
+                    "dry_weight_derivation_review_grade"
+                ),
                 "review_flags": json.dumps(dataset_review_flags(dataset), sort_keys=True),
                 "cultivar": payload["cultivar"],
                 "greenhouse": payload["greenhouse"],

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/registry.py
@@ -249,7 +249,10 @@ def _default_knu_dataset(
             estimated_cumulative_column=data.estimated_column,
             measured_semantics="cumulative_harvested_fruit_dry_weight_floor_area",
         ),
-        management=DatasetManagementMetadata(),
+        management=DatasetManagementMetadata(
+            ec_path=contract.ec_path,
+            rootzone_path=contract.rootzone_path,
+        ),
         sanitized_fixture=DatasetSanitizedFixtureContract(
             forcing_fixture_path=(repo_root / "tests" / "fixtures" / "knu_sanitized" / "KNU_Tomato_Env_fixture.csv"),
             observed_harvest_fixture_path=(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/runtime.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +27,21 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.theta_proxy im
 
 
 CANONICAL_REPORTING_BASIS = "floor_area_g_m2"
+ROOTZONE_REQUIRED_COLUMNS = (
+    "datetime",
+    "theta_substrate",
+    "slab_weight_kg",
+    "sensor_id",
+    "zone_id",
+    "depth_cm",
+)
+ROOTZONE_EC_REQUIRED_COLUMNS = (
+    "datetime",
+    "rootzone_ec_dS_m",
+    "sensor_id",
+    "zone_id",
+    "depth_cm",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +69,11 @@ class PreparedMeasuredHarvestBundle:
     basis_normalization_resolved: bool
     normalization_factor_to_floor_area: float
     manifest_summary: dict[str, object]
+    rootzone_df: pd.DataFrame | None = None
+    rootzone_ec_df: pd.DataFrame | None = None
+    rootzone_path: Path | None = None
+    rootzone_ec_path: Path | None = None
+    rootzone_summary: dict[str, object] = field(default_factory=dict)
 
 
 def _as_list(raw: object) -> list[Any]:
@@ -92,6 +112,80 @@ def read_dataset_observation_table(path: str | Path) -> pd.DataFrame:
     if suffix in {".xlsx", ".xlsm"}:
         return _read_first_sheet_frame(resolved_path)
     raise ValueError(f"Unsupported observation table format {resolved_path.suffix!r}.")
+
+
+def _read_csv_with_required_columns(
+    path: str | Path,
+    *,
+    required_columns: tuple[str, ...],
+    numeric_columns: tuple[str, ...],
+    table_label: str,
+) -> pd.DataFrame:
+    resolved_path = Path(path)
+    frame = pd.read_csv(resolved_path)
+    missing = [column for column in required_columns if column not in frame.columns]
+    if missing:
+        raise ValueError(f"{table_label} {resolved_path} is missing required columns: {missing}")
+
+    frame = frame.copy()
+    frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce")
+    if frame["datetime"].isna().any():
+        raise ValueError(f"{table_label} {resolved_path} contains blank or invalid datetime values.")
+    for column in numeric_columns:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+
+    sort_columns = ["datetime", *[column for column in ("sensor_id", "zone_id", "depth_cm") if column in frame.columns]]
+    return frame.sort_values(sort_columns).reset_index(drop=True)
+
+
+def read_rootzone_table(path: str | Path) -> pd.DataFrame:
+    """Read measured KNU substrate water content and slab weight without imputing blanks."""
+
+    return _read_csv_with_required_columns(
+        path,
+        required_columns=ROOTZONE_REQUIRED_COLUMNS,
+        numeric_columns=("theta_substrate", "slab_weight_kg", "depth_cm"),
+        table_label="Rootzone table",
+    )
+
+
+def read_rootzone_ec_table(path: str | Path) -> pd.DataFrame:
+    """Read measured KNU substrate EC without deriving rootzone stress metrics."""
+
+    return _read_csv_with_required_columns(
+        path,
+        required_columns=ROOTZONE_EC_REQUIRED_COLUMNS,
+        numeric_columns=("rootzone_ec_dS_m", "depth_cm"),
+        table_label="Rootzone EC table",
+    )
+
+
+def _filter_by_validation_window(
+    frame: pd.DataFrame,
+    *,
+    validation_start: pd.Timestamp,
+    validation_end: pd.Timestamp,
+) -> pd.DataFrame:
+    end_exclusive = validation_end.normalize() + pd.Timedelta(days=1)
+    return frame.loc[
+        frame["datetime"].ge(validation_start.normalize()) & frame["datetime"].lt(end_exclusive)
+    ].reset_index(drop=True)
+
+
+def _time_series_summary(frame: pd.DataFrame | None, *, value_columns: tuple[str, ...]) -> dict[str, object]:
+    if frame is None:
+        return {"rows": 0, "start": None, "end": None, "sensor_count": 0, "non_null_counts": {}}
+    if frame.empty:
+        return {"rows": 0, "start": None, "end": None, "sensor_count": 0, "non_null_counts": {}}
+    return {
+        "rows": int(len(frame)),
+        "start": str(frame["datetime"].min()),
+        "end": str(frame["datetime"].max()),
+        "sensor_count": int(frame["sensor_id"].nunique(dropna=True)) if "sensor_id" in frame.columns else 0,
+        "non_null_counts": {
+            column: int(frame[column].notna().sum()) for column in value_columns if column in frame.columns
+        },
+    }
 
 
 def _normalization_factor(dataset: DatasetMetadataContract) -> float:
@@ -191,6 +285,40 @@ def prepare_measured_harvest_bundle(
     observed_df, normalization_factor = _canonical_observed_frame(dataset)
     validation_start = pd.Timestamp(dataset.validation_start).normalize()
     validation_end = pd.Timestamp(dataset.validation_end).normalize()
+    rootzone_path = dataset.management.rootzone_path
+    rootzone_ec_path = dataset.management.ec_path
+    rootzone_df = (
+        _filter_by_validation_window(
+            read_rootzone_table(rootzone_path),
+            validation_start=validation_start,
+            validation_end=validation_end,
+        )
+        if rootzone_path is not None
+        else None
+    )
+    rootzone_ec_df = (
+        _filter_by_validation_window(
+            read_rootzone_ec_table(rootzone_ec_path),
+            validation_start=validation_start,
+            validation_end=validation_end,
+        )
+        if rootzone_ec_path is not None
+        else None
+    )
+    rootzone_summary = {
+        "rootzone_path": str(rootzone_path) if rootzone_path is not None else None,
+        "rootzone_ec_path": str(rootzone_ec_path) if rootzone_ec_path is not None else None,
+        "rootzone": _time_series_summary(
+            rootzone_df,
+            value_columns=("theta_substrate", "slab_weight_kg"),
+        ),
+        "rootzone_ec": _time_series_summary(
+            rootzone_ec_df,
+            value_columns=("rootzone_ec_dS_m",),
+        ),
+        "missing_policy": "preserve_missing_no_forward_fill",
+        "derived_rootzone_stress_metrics_included": False,
+    }
     if validation_cfg.get("calibration_end"):
         calibration_end = pd.Timestamp(validation_cfg["calibration_end"]).normalize()
     else:
@@ -233,6 +361,8 @@ def prepare_measured_harvest_bundle(
             "measured_cumulative_column": dataset.observation.measured_cumulative_column,
             "estimated_cumulative_column": dataset.observation.estimated_cumulative_column,
             "measured_semantics": dataset.observation.measured_semantics,
+            "management": dataset.management.to_payload(),
+            "rootzone_measurements": rootzone_summary,
             "sanitized_fixture": dataset.sanitized_fixture.to_payload(),
         },
     )
@@ -253,7 +383,13 @@ def prepare_measured_harvest_bundle(
         manifest_summary={
             "observed_harvest_canonical_csv": str(observed_canonical_path),
             "observation_contract_manifest_json": str(observation_contract_manifest_path),
+            "rootzone_measurements": rootzone_summary,
         },
+        rootzone_df=rootzone_df,
+        rootzone_ec_df=rootzone_ec_df,
+        rootzone_path=rootzone_path,
+        rootzone_ec_path=rootzone_ec_path,
+        rootzone_summary=rootzone_summary,
     )
 
 
@@ -263,4 +399,6 @@ __all__ = [
     "PreparedMeasuredHarvestBundle",
     "prepare_measured_harvest_bundle",
     "read_dataset_observation_table",
+    "read_rootzone_ec_table",
+    "read_rootzone_table",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/parameter_budget.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/parameter_budget.py
@@ -158,12 +158,16 @@ def load_fairness_candidates(
     config_path: Path,
 ) -> tuple[CanonicalWinnerIds, list[CalibrationCandidate], dict[str, Any]]:
     reference_cfg = _as_dict(fairness_config.get("reference"))
-    current_vs_promoted_path = _resolve_config_path(
-        reference_cfg.get("current_vs_promoted_config", "configs/exp/tomics_current_vs_promoted_factorial_knu.yaml"),
-        repo_root=repo_root,
-        config_path=config_path,
-    )
-    current_vs_promoted_cfg = load_config(current_vs_promoted_path)
+    if not reference_cfg and {"current", "promoted", "paths"}.issubset(fairness_config):
+        current_vs_promoted_path = config_path
+        current_vs_promoted_cfg = fairness_config
+    else:
+        current_vs_promoted_path = _resolve_config_path(
+            reference_cfg.get("current_vs_promoted_config", "configs/exp/tomics_current_vs_promoted_factorial_knu.yaml"),
+            repo_root=repo_root,
+            config_path=config_path,
+        )
+        current_vs_promoted_cfg = load_config(current_vs_promoted_path)
     output_paths = _as_dict(current_vs_promoted_cfg.get("paths"))
     current_output_root = _resolve_config_path(
         reference_cfg.get("current_output_root", output_paths.get("current_output_root", "out/tomics/validation/knu/architecture/current-factorial")),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/rootzone_inversion.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/rootzone_inversion.py
@@ -12,6 +12,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_promoted import (
     prepare_knu_bundle,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.runtime import (
+    read_rootzone_table,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.irrigation_proxy import (
     infer_irrigation_proxy,
 )
@@ -45,9 +48,105 @@ def _stress_activation_days(frame: pd.DataFrame, *, threshold: float = 0.20) -> 
 
 
 def _recharge_event_count(frame: pd.DataFrame) -> int:
-    flags = pd.to_numeric(frame.get("irrigation_proxy_flag"), errors="coerce").fillna(0.0) > 0.0
+    if "irrigation_proxy_flag" in frame.columns:
+        raw_flags = frame["irrigation_proxy_flag"]
+    elif "irrigation_recharge_flag" in frame.columns:
+        raw_flags = frame["irrigation_recharge_flag"]
+    else:
+        raw_flags = pd.Series(0.0, index=frame.index)
+    flags = pd.to_numeric(raw_flags, errors="coerce").fillna(0.0) > 0.0
     starts = flags & ~flags.shift(fill_value=False)
     return int(starts.sum())
+
+
+def _measured_rootzone_frame(
+    forcing_df: pd.DataFrame,
+    measured_rootzone_df: pd.DataFrame,
+    *,
+    scenario_id: str,
+    theta_min_hard: float,
+    theta_max_hard: float,
+    measured_theta_max_gap: str | pd.Timedelta = "1h",
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    measured = measured_rootzone_df.copy()
+    missing = [column for column in ("datetime", "theta_substrate") if column not in measured.columns]
+    if missing:
+        raise ValueError(f"Measured rootzone table is missing required columns: {missing}")
+    measured["datetime"] = pd.to_datetime(measured["datetime"], errors="coerce")
+    measured["theta_substrate"] = pd.to_numeric(measured["theta_substrate"], errors="coerce")
+    measured = measured.dropna(subset=["datetime"])
+    measured = (
+        measured.groupby("datetime", as_index=False)
+        .agg(
+            theta_measured_raw=("theta_substrate", "mean"),
+            measured_sensor_count=("theta_substrate", "count"),
+        )
+        .sort_values("datetime")
+    )
+
+    base = apply_theta_substrate_proxy(
+        forcing_df,
+        mode="flat_constant",
+        scenario="moderate",
+        theta_min_hard=theta_min_hard,
+        theta_max_hard=theta_max_hard,
+    )
+    base = base.sort_values("datetime").reset_index(drop=True)
+    aligned = pd.merge_asof(
+        base,
+        measured,
+        on="datetime",
+        direction="nearest",
+        tolerance=pd.Timedelta(measured_theta_max_gap),
+    )
+    coverage_fraction = float(aligned["theta_measured_raw"].notna().mean()) if not aligned.empty else 0.0
+    period_mean = pd.to_numeric(aligned["theta_measured_raw"], errors="coerce").mean()
+    if pd.isna(period_mean):
+        return base, {
+            "used": False,
+            "scenario_id": scenario_id,
+            "coverage_fraction": coverage_fraction,
+            "period_mean_theta_substrate": None,
+            "fill_policy": "missing aligned values are filled with the aligned period mean",
+            "clip_policy": "theta_substrate is clipped to theta_min_hard/theta_max_hard for model diagnostics",
+            "max_alignment_gap": str(pd.Timedelta(measured_theta_max_gap)),
+            "filled_row_count": int(len(aligned)),
+            "clipped_row_count": 0,
+            "skip_reason": "no_numeric_theta_after_alignment",
+        }
+
+    filled_raw = aligned["theta_measured_raw"].fillna(float(period_mean))
+    clipped_theta = filled_raw.clip(lower=theta_min_hard, upper=theta_max_hard)
+    scenario_cfg = DEFAULT_SCENARIOS["moderate"]
+    saturation = ((clipped_theta - scenario_cfg.saturation_start) / max(theta_max_hard - scenario_cfg.saturation_start, 1e-6)).clip(
+        lower=0.0,
+        upper=1.0,
+    )
+    aligned["theta_proxy_mode"] = "measured_rootzone"
+    aligned["theta_proxy_scenario"] = scenario_id
+    aligned["theta_substrate"] = clipped_theta
+    aligned["theta_measurement_source"] = aligned["theta_measured_raw"].notna().map(
+        {True: "measured", False: "filled_with_period_mean"}
+    )
+    aligned["theta_measurement_was_clipped"] = clipped_theta.ne(filled_raw)
+    aligned["theta_measurement_period_mean"] = float(period_mean)
+    aligned["rootzone_saturation"] = saturation
+    aligned["rootzone_multistress"] = (
+        0.65 * aligned["rootzone_saturation"] + 0.35 * aligned["rootzone_temperature_stress"]
+    ).clip(lower=0.0, upper=1.0)
+    aligned["irrigation_recharge_flag"] = 0
+    summary = {
+        "used": True,
+        "scenario_id": scenario_id,
+        "coverage_fraction": coverage_fraction,
+        "period_mean_theta_substrate": float(period_mean),
+        "fill_policy": "missing aligned values are filled with the aligned period mean",
+        "clip_policy": "theta_substrate is clipped to theta_min_hard/theta_max_hard for model diagnostics",
+        "max_alignment_gap": str(pd.Timedelta(measured_theta_max_gap)),
+        "filled_row_count": int(aligned["theta_measured_raw"].isna().sum()),
+        "clipped_row_count": int(aligned["theta_measurement_was_clipped"].sum()),
+    }
+    return aligned, summary
 
 
 def reconstruct_rootzone(
@@ -57,6 +156,10 @@ def reconstruct_rootzone(
     scenario_ids: tuple[str, ...] = ("dry", "moderate", "wet"),
     theta_min_hard: float = 0.40,
     theta_max_hard: float = 0.85,
+    measured_rootzone_df: pd.DataFrame | None = None,
+    measured_scenario_id: str = "measured",
+    measured_theta_coverage_min: float = 0.50,
+    measured_theta_max_gap: str | pd.Timedelta = "1h",
 ) -> RootzoneInversionResult:
     scenario_frames: dict[str, pd.DataFrame] = {}
     summary_rows: list[dict[str, object]] = []
@@ -71,6 +174,28 @@ def reconstruct_rootzone(
         proxy = infer_irrigation_proxy(proxy)
         scenario_frames[scenario_id] = proxy
 
+    measured_summary: dict[str, object] = {
+        "used": False,
+        "scenario_id": measured_scenario_id,
+        "coverage_fraction": 0.0,
+        "minimum_coverage_fraction": float(measured_theta_coverage_min),
+    }
+    if measured_rootzone_df is not None:
+        measured_frame, measured_summary = _measured_rootzone_frame(
+            forcing_df,
+            measured_rootzone_df,
+            scenario_id=measured_scenario_id,
+            theta_min_hard=theta_min_hard,
+            theta_max_hard=theta_max_hard,
+            measured_theta_max_gap=measured_theta_max_gap,
+        )
+        measured_summary["minimum_coverage_fraction"] = float(measured_theta_coverage_min)
+        if float(measured_summary["coverage_fraction"]) >= float(measured_theta_coverage_min):
+            scenario_frames[measured_scenario_id] = measured_frame
+        else:
+            measured_summary["used"] = False
+            measured_summary["skip_reason"] = "coverage_below_minimum"
+
     theta_stack = pd.DataFrame({"datetime": pd.to_datetime(next(iter(scenario_frames.values()))["datetime"])})
     for scenario_id, frame in scenario_frames.items():
         theta_stack[f"theta_{scenario_id}"] = pd.to_numeric(frame["theta_substrate"], errors="coerce")
@@ -81,19 +206,21 @@ def reconstruct_rootzone(
 
     mean_uncertainty = float(pd.to_numeric(theta_stack["proxy_uncertainty_width"], errors="coerce").mean())
     for scenario_id, frame in scenario_frames.items():
-        scenario_cfg = DEFAULT_SCENARIOS[scenario_id]
         theta = pd.to_numeric(frame["theta_substrate"], errors="coerce")
+        scenario_cfg = DEFAULT_SCENARIOS.get(scenario_id)
+        mode_label = str(frame["theta_proxy_mode"].iloc[0]) if "theta_proxy_mode" in frame.columns else theta_proxy_mode
         summary_rows.append(
             {
-                "theta_proxy_mode": theta_proxy_mode,
+                "theta_proxy_mode": mode_label,
                 "theta_proxy_scenario": scenario_id,
+                "theta_source": "proxy" if scenario_cfg is not None else "measured_rootzone",
                 "mean_theta": float(theta.mean()),
                 "theta_range": float(theta.max() - theta.min()),
                 "recharge_event_count": _recharge_event_count(frame),
                 "oversaturation_days": _oversaturation_days(frame),
                 "proxy_uncertainty_width": mean_uncertainty,
                 "rootzone_stress_activation_days": _stress_activation_days(frame),
-                "scenario_center": scenario_cfg.center,
+                "scenario_center": scenario_cfg.center if scenario_cfg is not None else float(theta.mean()),
             }
         )
 
@@ -107,8 +234,9 @@ def reconstruct_rootzone(
         "assumptions": [
             "Greenhouse-soilless proxy bounds are conservative and explicit.",
             "Irrigation timing is inferred from daylight demand windows when measured irrigation is unavailable.",
-            "Measured root-zone variables may override the proxy in future runs if supplied.",
+            "Measured root-zone theta_substrate is added as a separate scenario when supplied with sufficient coverage.",
         ],
+        "measured_rootzone": measured_summary,
     }
     return RootzoneInversionResult(
         summary_df=pd.DataFrame(summary_rows),
@@ -164,6 +292,12 @@ def run_knu_rootzone_reconstruction(*, config_path: str | Path) -> dict[str, obj
         scenario_ids=tuple(str(value) for value in rootzone_cfg.get("scenario_ids", ["dry", "moderate", "wet"])),
         theta_min_hard=float(rootzone_cfg.get("theta_min_hard", 0.40)),
         theta_max_hard=float(rootzone_cfg.get("theta_max_hard", 0.85)),
+        measured_rootzone_df=read_rootzone_table(prepared_bundle.data_contract.rootzone_path)
+        if prepared_bundle.data_contract.rootzone_path is not None
+        else None,
+        measured_scenario_id=str(rootzone_cfg.get("measured_scenario_id", "measured")),
+        measured_theta_coverage_min=float(rootzone_cfg.get("measured_theta_coverage_min", 0.50)),
+        measured_theta_max_gap=str(rootzone_cfg.get("measured_theta_max_gap", "1h")),
     )
     result.summary_df.to_csv(output_root / "rootzone_summary.csv", index=False)
     result.band_df.to_csv(output_root / "theta_uncertainty_band.csv", index=False)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/traitenv_school_validation.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/traitenv_school_validation.py
@@ -546,6 +546,12 @@ def build_school_traitenv_dataset_overlay(
             "dataset_role_hint": (
                 "measured_harvest_runnable" if approve_runnable_contract else "measured_harvest_review_only"
             ),
+            "observed_harvest_derivation": "derived_dw_from_measured_fresh_school_harvest",
+            "is_direct_dry_weight": False,
+            "uses_literature_dry_matter_fraction": True,
+            "dry_weight_derivation_review_grade": (
+                "manual_reviewed_private" if approve_runnable_contract else "review_only"
+            ),
             "private_derivation_official_mode": "manual_reviewed_derivative",
             "private_derivation_helper_role": "local_preparation_utility",
             "private_derivation_public_promotion_default": "unchanged",
@@ -680,6 +686,10 @@ def write_school_traitenv_generated_configs(
     merged_items = [item for item in existing_items if str(item.get("dataset_id", "")) != SCHOOL_DATASET_ID]
     merged_items.append(overlay_item)
     datasets_cfg["items"] = merged_items
+    default_dataset_ids = [str(value) for value in datasets_cfg.get("default_dataset_ids", [])]
+    if SCHOOL_DATASET_ID not in default_dataset_ids:
+        default_dataset_ids.append(SCHOOL_DATASET_ID)
+    datasets_cfg["default_dataset_ids"] = default_dataset_ids
     multidataset_cfg["validation"]["multidataset_factorial"]["output_root"] = str(multidataset_output_root)
     multidataset_cfg["validation"]["multidataset_factorial"].setdefault("dataset_factorial_roots", {})
     multidataset_cfg["validation"]["multidataset_factorial"]["dataset_factorial_roots"][SCHOOL_DATASET_ID] = str(

--- a/tests/test_cross_dataset_gate.py
+++ b/tests/test_cross_dataset_gate.py
@@ -120,6 +120,68 @@ def _review_flagged_public_ai_competition_derived_dw_dataset(
     )
 
 
+def _manual_reviewed_school_derived_dw_dataset(
+    tmp_path: Path,
+    dataset_id: str,
+) -> DatasetMetadataContract:
+    fixture_root = tmp_path / dataset_id
+    fixture_root.mkdir(parents=True, exist_ok=True)
+    forcing_path = fixture_root / "forcing_fixture.csv"
+    harvest_path = fixture_root / "observed_harvest_fixture.csv"
+    forcing_path.write_text(
+        (
+            "datetime,T_air_C,PAR_umol,CO2_ppm,RH_percent,wind_speed_ms\n"
+            "2024-08-08 00:00:00,24.0,345.0,420.0,70.0,0.5\n"
+        ),
+        encoding="utf-8",
+    )
+    harvest_path.write_text(
+        (
+            "Date,Measured_Cumulative_Total_Fruit_DW (g/m^2)\n"
+            "2024-08-08,0.195\n"
+            "2024-08-21,2.730\n"
+        ),
+        encoding="utf-8",
+    )
+    return DatasetMetadataContract(
+        dataset_id=dataset_id,
+        dataset_kind="traitenv_private_reviewed_candidate",
+        display_name=dataset_id,
+        dataset_family="school_trait_bundle",
+        observation_family="yield",
+        capability=DatasetCapability.MEASURED_HARVEST,
+        ingestion_status=DatasetIngestionStatus.RUNNABLE,
+        source_refs=("school/2024_tomato_harvest.xlsx",),
+        forcing_path=forcing_path,
+        observed_harvest_path=harvest_path,
+        validation_start="2024-08-08",
+        validation_end="2024-08-21",
+        basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=1.98),
+        observation=DatasetObservationContract(
+            date_column="Date",
+            measured_cumulative_column="Measured_Cumulative_Total_Fruit_DW (g/m^2)",
+        ),
+        dry_matter_conversion=DatasetDryMatterConversionContract(
+            mode="literature_fixed_ratio",
+            fresh_weight_column="Source_Daily_Fresh_Weight_Total_g",
+            dry_matter_ratio=0.065,
+            citations=("manual-reviewed school private bundle",),
+            review_only=False,
+        ),
+        sanitized_fixture=DatasetSanitizedFixtureContract(
+            forcing_fixture_path=forcing_path,
+            observed_harvest_fixture_path=harvest_path,
+        ),
+        provenance_tags=("school_private_reviewed", "derived_dw_manual_reviewed"),
+        notes={
+            "is_direct_dry_weight": False,
+            "uses_literature_dry_matter_fraction": True,
+            "observed_harvest_derivation": "derived_dw_from_measured_fresh_school_harvest",
+            "dry_weight_derivation_review_grade": "manual_reviewed_private",
+        },
+    )
+
+
 def test_cross_dataset_proxy_guardrail_blocks_single_dataset_proxy_heavy_winner() -> None:
     candidate = pd.Series(
         {
@@ -444,3 +506,36 @@ def test_cross_dataset_guardrail_falls_back_without_review_flags_column(tmp_path
         "public_ai_competition__yield"
     ]
     assert summary["selected_candidate"]["passes"] is False
+
+
+def test_cross_dataset_guardrail_does_not_flag_manual_reviewed_school_private_derivation(tmp_path: Path) -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _runnable_measured_dataset(tmp_path, "knu_actual", dataset_family="knu_actual"),
+            _manual_reviewed_school_derived_dw_dataset(tmp_path, "school_trait_bundle__yield"),
+        ),
+        default_dataset_ids=("knu_actual", "school_trait_bundle__yield"),
+    )
+    scorecard = pd.DataFrame(
+        [
+            {
+                "fruit_harvest_family": "dekoning_fds",
+                "leaf_harvest_family": "vegetative_unit_pruning",
+                "fdmc_mode": "dekoning_fds",
+                "dataset_count": 2,
+                "dataset_ids": "[\"knu_actual\", \"school_trait_bundle__yield\"]",
+                "mean_native_family_state_fraction": 0.9,
+                "mean_proxy_family_state_fraction": 0.1,
+                "mean_shared_tdvs_proxy_fraction": 0.0,
+                "cross_dataset_stability_score": 1.0,
+            }
+        ]
+    )
+
+    summary = build_cross_dataset_guardrail_summary(scorecard, registry=registry, min_dataset_count=2)
+
+    assert summary["measured_dataset_count"] == 2
+    assert summary["measured_dataset_ids"] == ["knu_actual", "school_trait_bundle__yield"]
+    assert summary["selected_candidate"]["winner_review_only_proxy_support_flag"] is False
+    assert summary["selected_candidate"]["winner_review_only_proxy_dataset_ids"] == []
+    assert summary["selected_candidate"]["passes"] is True

--- a/tests/test_multidataset_runtime.py
+++ b/tests/test_multidataset_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -29,6 +30,41 @@ def _write_forcing_fixture(path: Path) -> None:
             "CO2_ppm": [420.0, 425.0, 430.0],
             "RH_percent": [70.0, 72.0, 68.0],
             "wind_speed_ms": [0.4, 0.5, 0.4],
+        }
+    ).to_csv(path, index=False)
+
+
+def _write_rootzone_fixture(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2025-01-01 00:00:00",
+                "2025-01-02 00:00:00",
+                "2025-01-03 00:00:00",
+                "2025-01-04 00:00:00",
+            ],
+            "theta_substrate": [0.63, 0.62, None, 0.61],
+            "slab_weight_kg": [11.42, 11.38, 11.36, 11.35],
+            "sensor_id": ["RZ01", "RZ01", "RZ01", "RZ01"],
+            "zone_id": ["A", "A", "A", "A"],
+            "depth_cm": [10, 10, 10, 10],
+        }
+    ).to_csv(path, index=False)
+
+
+def _write_rootzone_ec_fixture(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "datetime": [
+                "2025-01-01 00:00:00",
+                "2025-01-02 00:00:00",
+                "2025-01-03 00:00:00",
+                "2025-01-04 00:00:00",
+            ],
+            "rootzone_ec_dS_m": [2.8, 2.9, 3.0, 3.1],
+            "sensor_id": ["EC01", "EC01", "EC01", "EC01"],
+            "zone_id": ["A", "A", "A", "A"],
+            "depth_cm": [10, 10, 10, 10],
         }
     ).to_csv(path, index=False)
 
@@ -86,3 +122,67 @@ def test_prepare_measured_harvest_bundle_honors_contract_columns_and_basis_conve
     assert bundle.basis_normalization_resolved is True
     assert bundle.normalization_factor_to_floor_area == 2.0
     assert (bundle.prepared_root / "observation_contract_manifest.json").exists()
+
+
+def test_prepare_measured_harvest_bundle_loads_optional_rootzone_measurements(tmp_path: Path) -> None:
+    forcing_path = tmp_path / "forcing.csv"
+    observed_path = tmp_path / "observed.csv"
+    rootzone_path = tmp_path / "rootzone.csv"
+    rootzone_ec_path = tmp_path / "rootzone_ec.csv"
+    _write_forcing_fixture(forcing_path)
+    _write_rootzone_fixture(rootzone_path)
+    _write_rootzone_ec_fixture(rootzone_ec_path)
+    pd.DataFrame(
+        {
+            "Date": ["2025-01-02", "2025-01-03"],
+            "Measured_Cumulative_Total_Fruit_DW (g/m^2)": [2.0, 3.0],
+        }
+    ).to_csv(observed_path, index=False)
+    dataset = DatasetMetadataContract(
+        dataset_id="demo_rootzone",
+        dataset_kind="measured_harvest",
+        display_name="Demo rootzone harvest",
+        forcing_path=forcing_path,
+        observed_harvest_path=observed_path,
+        validation_start="2025-01-02",
+        validation_end="2025-01-03",
+        cultivar="cv",
+        greenhouse="gh",
+        season="winter",
+        basis=DatasetBasisContract(reporting_basis="floor_area_g_m2"),
+        observation=DatasetObservationContract(
+            date_column="Date",
+            measured_cumulative_column="Measured_Cumulative_Total_Fruit_DW (g/m^2)",
+            measured_semantics="cumulative_harvested_fruit_dry_weight_floor_area",
+        ),
+        management=DatasetManagementMetadata(
+            rootzone_path=rootzone_path,
+            ec_path=rootzone_ec_path,
+        ),
+        sanitized_fixture=DatasetSanitizedFixtureContract(
+            forcing_fixture_path=forcing_path,
+            observed_harvest_fixture_path=observed_path,
+        ),
+    )
+
+    bundle = prepare_measured_harvest_bundle(
+        dataset,
+        validation_cfg={
+            "resample_rule": "1D",
+            "theta_proxy_mode": "bucket_irrigated",
+            "theta_proxy_scenarios": ["moderate"],
+        },
+        prepared_root=tmp_path / "prepared",
+    )
+
+    assert bundle.rootzone_df is not None
+    assert bundle.rootzone_ec_df is not None
+    assert list(bundle.rootzone_df["datetime"].dt.strftime("%Y-%m-%d")) == ["2025-01-02", "2025-01-03"]
+    assert list(bundle.rootzone_ec_df["datetime"].dt.strftime("%Y-%m-%d")) == ["2025-01-02", "2025-01-03"]
+    assert bundle.rootzone_df["theta_substrate"].isna().sum() == 1
+    assert bundle.rootzone_summary["rootzone"]["rows"] == 2
+    assert bundle.rootzone_summary["rootzone"]["non_null_counts"]["theta_substrate"] == 1
+    manifest = json.loads((bundle.prepared_root / "observation_contract_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["management"]["rootzone_path"] == str(rootzone_path)
+    assert manifest["management"]["ec_path"] == str(rootzone_ec_path)
+    assert manifest["rootzone_measurements"]["derived_rootzone_stress_metrics_included"] is False

--- a/tests/test_tomics_knu_data_contract.py
+++ b/tests/test_tomics_knu_data_contract.py
@@ -10,6 +10,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.data_contract 
     resolve_knu_data_contract,
     write_data_contract_manifest,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
+    load_dataset_registry,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_operator import (
     observed_floor_area_yield,
 )
@@ -18,13 +21,36 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.knu_data impor
 
 def test_knu_data_contract_resolves_private_root_and_writes_manifest(tmp_path: Path, monkeypatch) -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    private_root = tmp_path / "private_root" / "data" / "forcing"
-    private_root.mkdir(parents=True, exist_ok=True)
+    private_data_root = tmp_path / "private_root" / "data"
+    forcing_root = private_data_root / "forcing"
+    rootzone_root = private_data_root / "rootzone"
+    ec_root = private_data_root / "ec"
+    forcing_root.mkdir(parents=True, exist_ok=True)
+    rootzone_root.mkdir(parents=True, exist_ok=True)
+    ec_root.mkdir(parents=True, exist_ok=True)
     forcing_fixture = repo_root / "tests" / "fixtures" / "knu_sanitized" / "KNU_Tomato_Env_fixture.csv"
     yield_fixture = repo_root / "tests" / "fixtures" / "knu_sanitized" / "tomato_validation_data_yield_fixture.csv"
-    (private_root / "KNU_Tomato_Env.CSV").write_text(forcing_fixture.read_text(encoding="utf-8"), encoding="utf-8")
-    (private_root / "tomato_validation_data_yield_260222.csv").write_text(
+    (forcing_root / "KNU_Tomato_Env.CSV").write_text(forcing_fixture.read_text(encoding="utf-8"), encoding="utf-8")
+    (forcing_root / "tomato_validation_data_yield_260222.csv").write_text(
         yield_fixture.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (rootzone_root / "KNU_Tomato_Rootzone.csv").write_text(
+        "\n".join(
+            [
+                "datetime,theta_substrate,slab_weight_kg,sensor_id,zone_id,depth_cm",
+                "2025-01-01 00:00:00,0.62,11.4,RZ01,BED01,10",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (ec_root / "KNU_Tomato_Rootzone_EC.csv").write_text(
+        "\n".join(
+            [
+                "datetime,rootzone_ec_dS_m,sensor_id,zone_id,depth_cm",
+                "2025-01-01 00:00:00,2.8,RZ01,BED01,10",
+            ]
+        ),
         encoding="utf-8",
     )
     contract_path = tmp_path / "contract.yaml"
@@ -34,8 +60,25 @@ def test_knu_data_contract_resolves_private_root_and_writes_manifest(tmp_path: P
                 "private_data_root_env": "PHYTORITAS_PRIVATE_DATA_ROOT",
                 "forcing_relative_path": "data/forcing/KNU_Tomato_Env.CSV",
                 "yield_relative_path": "data/forcing/tomato_validation_data_yield_260222.csv",
+                "rootzone_relative_path": "data/rootzone/KNU_Tomato_Rootzone.csv",
+                "ec_relative_path": "data/ec/KNU_Tomato_Rootzone_EC.csv",
                 "reporting_basis": "floor_area_g_m2",
                 "plants_per_m2": 1.836091,
+                "rootzone_parser_assumptions": {
+                    "rootzone_parser": "csv_datetime_first_class",
+                    "theta_semantics": "measured_substrate_water_content",
+                    "slab_weight_semantics": "measured_substrate_weight",
+                    "datetime_policy": "naive_local_greenhouse_timestamps",
+                    "missing_policy": "preserve_missing",
+                    "long_format": True,
+                },
+                "ec_parser_assumptions": {
+                    "ec_parser": "csv_datetime_first_class",
+                    "ec_semantics": "measured_substrate_ec",
+                    "datetime_policy": "naive_local_greenhouse_timestamps",
+                    "missing_policy": "preserve_missing",
+                    "long_format": True,
+                },
                 "observation": {
                     "date_column": "Date",
                     "measured_cumulative_column": "Measured_Cumulative_Total_Fruit_DW (g/m^2)",
@@ -57,9 +100,15 @@ def test_knu_data_contract_resolves_private_root_and_writes_manifest(tmp_path: P
     contract = resolve_knu_data_contract(validation_cfg=validation_cfg, repo_root=repo_root, config_path=contract_path)
     assert contract.forcing_source_kind == "private_root"
     assert contract.yield_source_kind == "private_root"
+    assert contract.rootzone_source_kind == "private_root"
+    assert contract.ec_source_kind == "private_root"
+    assert contract.rootzone_path == rootzone_root / "KNU_Tomato_Rootzone.csv"
+    assert contract.ec_path == ec_root / "KNU_Tomato_Rootzone_EC.csv"
     assert contract.date_column == "Date"
     assert contract.measured_cumulative_column == "Measured_Cumulative_Total_Fruit_DW (g/m^2)"
     assert contract.estimated_cumulative_column == "Estimated_Cumulative_Total_Fruit_DW (g/m^2)"
+    assert contract.rootzone_parser_assumptions["theta_semantics"] == "measured_substrate_water_content"
+    assert contract.ec_parser_assumptions["ec_semantics"] == "measured_substrate_ec"
     data = load_knu_validation_data(forcing_path=contract.forcing_path, yield_path=contract.yield_path)
     manifest_path = write_data_contract_manifest(output_root=tmp_path / "out", contract=contract, data=data)
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -67,6 +116,10 @@ def test_knu_data_contract_resolves_private_root_and_writes_manifest(tmp_path: P
     assert manifest["plants_per_m2"] == 1.836091
     assert manifest["observation_columns"]["date"] == "Date"
     assert manifest["parser_assumptions"]["observation_semantics"] == "cumulative_harvested_fruit_dry_weight_floor_area"
+    assert manifest["rootzone_source_kind"] == "private_root"
+    assert manifest["ec_source_kind"] == "private_root"
+    assert manifest["rootzone_source_path"].endswith("KNU_Tomato_Rootzone.csv")
+    assert manifest["ec_source_path"].endswith("KNU_Tomato_Rootzone_EC.csv")
 
 
 def test_load_knu_validation_data_honors_explicit_observation_columns(tmp_path: Path) -> None:
@@ -126,3 +179,64 @@ def test_observed_floor_area_yield_normalizes_per_plant_input_to_floor_area() ->
 
     assert observed["measured_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [2.0, 4.0]
     assert observed["estimated_cumulative_harvested_fruit_dry_weight_floor_area"].tolist() == [3.0, 5.0]
+
+
+def test_load_dataset_registry_default_knu_dataset_includes_rootzone_and_ec_management_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    private_root = tmp_path / "private_root"
+    forcing_root = private_root / "data" / "forcing"
+    rootzone_root = private_root / "data" / "rootzone"
+    ec_root = private_root / "data" / "ec"
+    forcing_root.mkdir(parents=True, exist_ok=True)
+    rootzone_root.mkdir(parents=True, exist_ok=True)
+    ec_root.mkdir(parents=True, exist_ok=True)
+
+    forcing_fixture = repo_root / "tests" / "fixtures" / "knu_sanitized" / "KNU_Tomato_Env_fixture.csv"
+    yield_fixture = repo_root / "tests" / "fixtures" / "knu_sanitized" / "tomato_validation_data_yield_fixture.csv"
+    (forcing_root / "KNU_Tomato_Env.CSV").write_text(forcing_fixture.read_text(encoding="utf-8"), encoding="utf-8")
+    (forcing_root / "tomato_validation_data_yield_260222.csv").write_text(
+        yield_fixture.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (rootzone_root / "KNU_Tomato_Rootzone.csv").write_text(
+        "datetime,theta_substrate,slab_weight_kg,sensor_id,zone_id,depth_cm\n",
+        encoding="utf-8",
+    )
+    (ec_root / "KNU_Tomato_Rootzone_EC.csv").write_text(
+        "datetime,rootzone_ec_dS_m,sensor_id,zone_id,depth_cm\n",
+        encoding="utf-8",
+    )
+
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(
+        yaml.safe_dump(
+            {
+                "private_data_root_env": "PHYTORITAS_PRIVATE_DATA_ROOT",
+                "forcing_relative_path": "data/forcing/KNU_Tomato_Env.CSV",
+                "yield_relative_path": "data/forcing/tomato_validation_data_yield_260222.csv",
+                "rootzone_relative_path": "data/rootzone/KNU_Tomato_Rootzone.csv",
+                "ec_relative_path": "data/ec/KNU_Tomato_Rootzone_EC.csv",
+                "reporting_basis": "floor_area_g_m2",
+                "plants_per_m2": 1.836091,
+            },
+            sort_keys=False,
+            allow_unicode=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PHYTORITAS_PRIVATE_DATA_ROOT", str(private_root))
+    config = {
+        "validation": {
+            "forcing_csv_path": "missing/KNU_Tomato_Env.CSV",
+            "yield_xlsx_path": "missing/tomato_validation_data_yield_260222.csv",
+            "private_data_contract_path": str(contract_path),
+        }
+    }
+
+    dataset = load_dataset_registry(config, repo_root=repo_root, config_path=contract_path).require("knu_actual")
+
+    assert dataset.management.rootzone_path == rootzone_root / "KNU_Tomato_Rootzone.csv"
+    assert dataset.management.ec_path == ec_root / "KNU_Tomato_Rootzone_EC.csv"

--- a/tests/test_tomics_knu_rootzone_inversion.py
+++ b/tests/test_tomics_knu_rootzone_inversion.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
+
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.knu_data import read_knu_forcing_csv
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.rootzone_inversion import (
     _recharge_event_count,
@@ -17,7 +19,73 @@ def test_rootzone_inversion_writes_uncertainty_band_from_fixture() -> None:
     assert not result.summary_df.empty
     assert "proxy_uncertainty_width" in result.band_df.columns
     assert float(result.band_df["proxy_uncertainty_width"].max()) >= 0.0
-    assert "Measured root-zone variables may override the proxy in future runs if supplied." in result.manifest["assumptions"]
+    assert result.manifest["measured_rootzone"]["used"] is False
+
+
+def test_rootzone_inversion_adds_measured_theta_scenario_with_labeled_mean_fill() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    forcing = read_knu_forcing_csv(repo_root / "tests" / "fixtures" / "knu_sanitized" / "KNU_Tomato_Env_fixture.csv")
+    measured = forcing[["datetime"]].copy()
+    measured["theta_substrate"] = [0.60, None, 0.62, 0.63, *([0.61] * (len(measured) - 4))]
+    measured["sensor_id"] = "RZ01"
+    measured["zone_id"] = "A"
+    measured["depth_cm"] = 10
+
+    result = reconstruct_rootzone(
+        forcing,
+        theta_proxy_mode="bucket_irrigated",
+        scenario_ids=("moderate",),
+        measured_rootzone_df=measured,
+        measured_theta_coverage_min=0.50,
+    )
+
+    assert {"moderate", "measured"} == set(result.scenario_frames)
+    measured_frame = result.scenario_frames["measured"]
+    assert "filled_with_period_mean" in set(measured_frame["theta_measurement_source"])
+    assert measured_frame["theta_substrate"].between(0.40, 0.85).all()
+    assert result.manifest["measured_rootzone"]["used"] is True
+    assert result.manifest["measured_rootzone"]["filled_row_count"] == 1
+    summary = result.summary_df.set_index("theta_proxy_scenario")
+    assert summary.loc["measured", "theta_source"] == "measured_rootzone"
+
+
+def test_rootzone_inversion_skips_measured_theta_when_alignment_has_no_coverage() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    forcing = read_knu_forcing_csv(repo_root / "tests" / "fixtures" / "knu_sanitized" / "KNU_Tomato_Env_fixture.csv")
+    measured = forcing[["datetime"]].copy()
+    measured["datetime"] = measured["datetime"] + pd.Timedelta(days=365)
+    measured["theta_substrate"] = 0.62
+
+    result = reconstruct_rootzone(
+        forcing,
+        theta_proxy_mode="bucket_irrigated",
+        scenario_ids=("moderate",),
+        measured_rootzone_df=measured,
+        measured_theta_coverage_min=0.50,
+    )
+
+    assert {"moderate"} == set(result.scenario_frames)
+    assert result.manifest["measured_rootzone"]["used"] is False
+    assert result.manifest["measured_rootzone"]["skip_reason"] == "coverage_below_minimum"
+
+
+def test_rootzone_inversion_uses_sparse_measured_theta_when_threshold_allows() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    forcing = read_knu_forcing_csv(repo_root / "tests" / "fixtures" / "knu_sanitized" / "KNU_Tomato_Env_fixture.csv")
+    measured = forcing[["datetime"]].iloc[[0]].copy()
+    measured["theta_substrate"] = 0.62
+
+    result = reconstruct_rootzone(
+        forcing,
+        theta_proxy_mode="bucket_irrigated",
+        scenario_ids=("moderate",),
+        measured_rootzone_df=measured,
+        measured_theta_coverage_min=0.05,
+    )
+
+    assert {"moderate", "measured"} == set(result.scenario_frames)
+    assert result.manifest["measured_rootzone"]["used"] is True
+    assert result.manifest["measured_rootzone"]["coverage_fraction"] >= 0.05
 
 
 def test_recharge_event_count_counts_rising_edges_not_flagged_timesteps() -> None:

--- a/tests/test_traitenv_school_validation.py
+++ b/tests/test_traitenv_school_validation.py
@@ -285,11 +285,19 @@ def test_school_traitenv_bundle_can_become_runnable_with_explicit_private_approv
         config_path=bundle.generated_config_paths["multidataset_factorial_config"],
     )
     school_dataset = registry.require(SCHOOL_DATASET_ID)
+    registry_frame = registry.to_frame()
+    school_row = registry_frame.loc[registry_frame["dataset_id"] == SCHOOL_DATASET_ID].iloc[0]
 
     assert school_dataset.is_runnable_measured_harvest is True
     assert school_dataset.blocker_codes == ()
     assert school_dataset.observation.measured_cumulative_column == CANONICAL_MEASURED_COLUMN
     assert school_dataset.notes["dataset_role_hint"] == "measured_harvest_runnable"
+    assert school_dataset.notes["observed_harvest_derivation"] == "derived_dw_from_measured_fresh_school_harvest"
+    assert school_dataset.notes["is_direct_dry_weight"] is False
+    assert school_dataset.notes["uses_literature_dry_matter_fraction"] is True
+    assert school_dataset.notes["dry_weight_derivation_review_grade"] == "manual_reviewed_private"
+    assert SCHOOL_DATASET_ID in config["validation"]["datasets"]["default_dataset_ids"]
+    assert school_row["dry_weight_derivation_review_grade"] == "manual_reviewed_private"
 
 
 def test_school_traitenv_generated_current_config_resolves_repo_root_and_prepares_bundle(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep the school private-reviewed harvest bundle as the stronger mixed-gate support lane from the first commit
- add reproducible KNU rootzone/EC fixture builders without committing the actual KNU fixture CSVs
- extend the KNU private data contract, default registry metadata, and measured-harvest runtime bundle to carry optional rootzone and EC measurement tables
- add measured rootzone as a diagnostic-only reconstruction scenario when coverage is sufficient; proxy dry/moderate/wet scenarios remain intact
- keep actual KNU rootzone fixture files local/private via `data/fixtures/knu_rootzone_sanitized/` in `.gitignore`

## KNU rootzone fixture handoff
- rootzone fixture path used for local smoke: `data/fixtures/knu_rootzone_sanitized/KNU_Tomato_Rootzone_aligned_fixture.csv`
- EC fixture path used for local smoke: `data/fixtures/knu_rootzone_sanitized/KNU_Tomato_Rootzone_EC_aligned_fixture.csv`
- aligned local rows reported by the fixture handoff: 35,496 rootzone/EC rows
- 2024 slab weight remains missing because the source has no slab-weight column for that period
- 2025 treatment labels are preserved as Control for RZ01-RZ03 and Drought for RZ04-RZ06

## Runtime semantics
- measured rootzone is diagnostic-only in this PR
- it does not replace allocation validation theta inputs
- it does not add irrigation-event handling; irrigation events remain absent
- EC is loaded and summarized in the measured-harvest runtime bundle, but rootzone reconstruction currently consumes theta only

## Validation
- `poetry run pytest -q tests/test_multidataset_runtime.py tests/test_tomics_knu_data_contract.py tests/test_tomics_knu_rootzone_inversion.py tests/test_multidataset_contracts.py` -> 24 passed
- `poetry run ruff check configs scripts src tests` -> passed
- `poetry run python scripts/run_tomics_knu_rootzone_reconstruction.py --config out/private-data/knu_rootzone_aligned_smoke/tomics_knu_rootzone_reconstruction_aligned_smoke.yaml` -> scenario_count 4
- aligned smoke output: `out/private-data/knu_rootzone_aligned_smoke/rootzone-reconstruction/rootzone_summary.csv`
- full `poetry run pytest -q` was attempted and timed out after 10 minutes without a failure log; the timed-out pytest processes were stopped

## Prior validation from first commit
- `poetry run python -m pytest -q tests/test_traitenv_school_validation.py tests/test_cross_dataset_gate.py tests/test_multidataset_registry.py tests/test_traitenv_loader.py`
- `poetry run ruff check src tests scripts`
- school private lane and mixed KNU+public+school scorecard/gate were rerun in the prior commit output path

## Notes
- no raw/private KNU fixture CSVs are committed
- no public proxy promotion semantics are widened
- measured rootzone remains a reconstruction diagnostic, not a new physiology/model architecture implementation
- remaining decision after this PR: whether a later issue should feed measured rootzone into allocation validation beyond reconstruction diagnostics

Closes #278
