### PR TITLE
[Data Prep] Reconcile public_rda runnable registry state with canonical fixtures

### DIFF
--- a/configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json
+++ b/configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json
@@ -2575,37 +2575,31 @@
     },
     {
       "basis": {
-        "basis_unit_label": "unknown",
-        "plants_per_m2": null,
-        "reporting_basis": "unknown"
+        "basis_unit_label": "g/m^2",
+        "plants_per_m2": 4.0,
+        "reporting_basis": "floor_area_g_m2"
       },
-      "blocker_codes": [
-        "missing_date_column",
-        "missing_measured_cumulative_column",
-        "missing_observed_harvest_path",
-        "missing_raw_fixture",
-        "missing_reporting_basis",
-        "missing_sanitized_fixture",
-        "missing_validation_window"
-      ],
+      "blocker_codes": [],
       "capability": "measured_harvest",
-      "cultivar": "unknown",
+      "cultivar": "deirose",
       "dataset_family": "public_rda",
       "dataset_id": "public_rda__yield",
       "dataset_kind": "traitenv_candidate",
       "display_name": "public_rda / yield",
       "dry_matter_conversion": {
-        "citations": [],
-        "dry_matter_ratio": null,
-        "dry_matter_ratio_high": null,
-        "dry_matter_ratio_low": null,
-        "fresh_weight_column": null,
-        "mode": "none",
+        "citations": [
+          "user-provided tomato fruit dry matter literature synthesis dated 2026-03-21"
+        ],
+        "dry_matter_ratio": 0.065,
+        "dry_matter_ratio_high": 0.09,
+        "dry_matter_ratio_low": 0.05,
+        "fresh_weight_column": "raw_total_shipment_kg",
+        "mode": "derived_dw_from_measured_fresh_shipment",
         "review_only": true
       },
-      "forcing_path": null,
-      "greenhouse": "unknown",
-      "ingestion_status": "draft_needs_raw_fixture",
+      "forcing_path": "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato/forcing_fixture.csv",
+      "greenhouse": "vinyl",
+      "ingestion_status": "runnable",
       "management": {
         "defoliation_records_path": null,
         "ec_path": null,
@@ -2658,38 +2652,58 @@
           "Environment time series require controlled daily or event-window rollups before comparison."
         ],
         "traitenv_bundle_kind": "directory",
-        "traitenv_bundle_ref": "traitenv"
+        "traitenv_bundle_ref": "traitenv",
+        "selected_slice_id": "2018_farm10_season1_ripe_tomato",
+        "source_observed_quantity": "measured_fresh_shipment_mass",
+        "validation_target_quantity": "cumulative_total_fruit_dry_mass_floor_area",
+        "observed_harvest_derivation": "derived_dw_from_measured_fresh_shipment",
+        "is_direct_dry_weight": false,
+        "uses_literature_dry_matter_fraction": true,
+        "review_flags": [
+          "review_only_dry_matter_conversion"
+        ],
+        "floor_area_basis_source": "cultInfo total floor area; provenance.md floor_area_g_m2=1000.0",
+        "plants_per_m2_source": "provenance.md plant_density=4.0; supporting metadata only because reporting basis is floor area",
+        "dry_matter_conversion_method": "cumulative_DW_g_per_m2 = cumsum(sum(raw_total_shipment_kg_by_day) * 1000 * 0.065) / floor_area_g_m2",
+        "dry_matter_conversion_provenance": "provenance.md dry_matter_provenance: user-provided tomato fruit dry matter literature synthesis dated 2026-03-21",
+        "fixture_provenance_path": "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato/provenance.md"
       },
       "observation": {
         "daily_increment_column": null,
-        "date_column": null,
+        "date_column": "Date",
         "estimated_cumulative_column": null,
-        "measured_cumulative_column": null,
+        "measured_cumulative_column": "Measured_Cumulative_Total_Fruit_DW (g/m^2)",
         "measured_semantics": "cumulative_harvested_fruit_dry_weight_floor_area"
       },
       "observation_family": "yield",
-      "observed_harvest_path": null,
-      "priority_tags": [],
+      "observed_harvest_path": "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato/observed_harvest_fixture.csv",
+      "priority_tags": [
+        "public_data",
+        "review_only_derived_dw"
+      ],
       "provenance_tags": [
+        "derived_dw_proxy",
+        "floor_area_basis",
         "public_data",
         "public_rda",
+        "runnable_review_only",
         "yield"
       ],
       "sanitized_fixture": {
         "fixture_kind": "sanitized_csv_fixture",
-        "forcing_fixture_path": null,
-        "observed_harvest_fixture_path": null
+        "forcing_fixture_path": "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato/forcing_fixture.csv",
+        "observed_harvest_fixture_path": "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato/observed_harvest_fixture.csv"
       },
-      "sanitized_fixture_path": null,
-      "season": "unknown",
+      "sanitized_fixture_path": "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato",
+      "season": "season1",
       "source_refs": [
-        "70_\uacf5\uacf5\ub370\uc774\ud130/\uc2a4\ub9c8\ud2b8\ud31c\ucf54\ub9ac\uc544_\ub18d\ucd0c\uc9c4\ud765\uccad \ub370\uc774\ud130\uc14b/2018_sale.xlsx",
-        "70_\uacf5\uacf5\ub370\uc774\ud130/\uc2a4\ub9c8\ud2b8\ud31c\ucf54\ub9ac\uc544_\ub18d\ucd0c\uc9c4\ud765\uccad \ub370\uc774\ud130\uc14b/2019_sale.xlsx",
-        "70_\uacf5\uacf5\ub370\uc774\ud130/\uc2a4\ub9c8\ud2b8\ud31c\ucf54\ub9ac\uc544_\ub18d\ucd0c\uc9c4\ud765\uccad \ub370\uc774\ud130\uc14b/2020_sale.xlsx",
-        "70_\uacf5\uacf5\ub370\uc774\ud130/\uc2a4\ub9c8\ud2b8\ud31c\ucf54\ub9ac\uc544_\ub18d\ucd0c\uc9c4\ud765\uccad \ub370\uc774\ud130\uc14b/2021_sale.xlsx"
+        "2018_cultInfo.xlsx",
+        "2018_env.xlsx",
+        "2018_sale.xlsx",
+        "data/fixtures/public_rda_sanitized/2018_farm10_season1_ripe_tomato/provenance.md"
       ],
-      "validation_end": null,
-      "validation_start": null
+      "validation_end": "2019-06-30",
+      "validation_start": "2019-01-17"
     },
     {
       "basis": {
@@ -3632,9 +3646,9 @@
   ],
   "default_dataset_ids": [],
   "summary": {
-    "blocked_by_missing_basis_or_density": 2,
-    "blocked_by_missing_cumulative_mapping": 2,
-    "blocked_by_missing_raw_fixture": 31,
+    "blocked_by_missing_basis_or_density": 1,
+    "blocked_by_missing_cumulative_mapping": 1,
+    "blocked_by_missing_raw_fixture": 30,
     "capability_counts": {
       "context_only": 28,
       "harvest_proxy": 1,
@@ -3645,11 +3659,11 @@
       "draft_blocked": 0,
       "draft_needs_basis_metadata": 0,
       "draft_needs_harvest_mapping": 0,
-      "draft_needs_raw_fixture": 31,
-      "runnable": 1
+      "draft_needs_raw_fixture": 30,
+      "runnable": 2
     },
     "proxy_datasets": 1,
-    "runnable_measured_harvest_datasets": 1,
+    "runnable_measured_harvest_datasets": 2,
     "total_registry_datasets": 32
   }
 }

--- a/tests/test_multidataset_registry.py
+++ b/tests/test_multidataset_registry.py
@@ -386,6 +386,61 @@ def test_dataset_registry_accepts_review_flagged_public_ai_competition_derived_d
     assert json.loads(row["review_flags"]) == ["review_only_dry_matter_conversion"]
 
 
+def test_canonical_registry_treats_public_rda_as_review_flagged_derived_dw_runtime() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "configs" / "exp" / "tomics_multidataset_harvest_factorial_public_measured.yaml"
+    registry_config = {
+        "validation": {
+            "datasets": {
+                "registry_snapshot_path": "configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json"
+            }
+        }
+    }
+
+    registry = load_dataset_registry(registry_config, repo_root=repo_root, config_path=config_path)
+    dataset = registry.require("public_rda__yield")
+    row = registry.to_frame().loc[lambda frame: frame["dataset_id"] == "public_rda__yield"].iloc[0]
+
+    assert dataset.ingestion_status is DatasetIngestionStatus.RUNNABLE
+    assert dataset.is_runnable_measured_harvest is True
+    assert dataset.blocker_codes == ()
+    assert dataset.forcing_path == (
+        repo_root
+        / "data"
+        / "fixtures"
+        / "public_rda_sanitized"
+        / "2018_farm10_season1_ripe_tomato"
+        / "forcing_fixture.csv"
+    )
+    assert dataset.observed_harvest_path == (
+        repo_root
+        / "data"
+        / "fixtures"
+        / "public_rda_sanitized"
+        / "2018_farm10_season1_ripe_tomato"
+        / "observed_harvest_fixture.csv"
+    )
+    assert dataset.basis.reporting_basis == "floor_area_g_m2"
+    assert dataset.observation.date_column == "Date"
+    assert dataset.observation.measured_cumulative_column == "Measured_Cumulative_Total_Fruit_DW (g/m^2)"
+    assert dataset.validation_start == "2019-01-17"
+    assert dataset.validation_end == "2019-06-30"
+    assert dataset.dry_matter_conversion.mode == "derived_dw_from_measured_fresh_shipment"
+    assert dataset.dry_matter_conversion.fresh_weight_column == "raw_total_shipment_kg"
+    assert dataset.dry_matter_conversion.dry_matter_ratio == 0.065
+    assert dataset.dry_matter_conversion.review_only is True
+    assert dataset.notes["is_direct_dry_weight"] is False
+    assert dataset.notes["uses_literature_dry_matter_fraction"] is True
+    assert dataset.notes["observed_harvest_derivation"] == "derived_dw_from_measured_fresh_shipment"
+    assert "review_only_dry_matter_conversion" in dataset.notes["review_flags"]
+    assert "public_rda__yield" in {
+        item.dataset_id for item in registry.runnable_measured_harvest_datasets()
+    }
+    assert bool(row["accepted_review_only_derived_dw_runtime"]) is True
+    assert bool(row["is_direct_dry_weight"]) is False
+    assert json.loads(row["review_flags"]) == ["review_only_dry_matter_conversion"]
+
+
 def test_dataset_registry_explicit_items_overlay_snapshot_rows_instead_of_replacing_them(tmp_path: Path) -> None:
     snapshot_path = tmp_path / "snapshot.json"
     forcing_path = tmp_path / "forcing.csv"


### PR DESCRIPTION
﻿## Summary
- Reconciles canonical traitenv registry state for `public_rda__yield` with the existing main-based public RDA fixture/config path.
- Marks `public_rda__yield` as `runnable` only as `derived_dw_from_measured_fresh_shipment`, not direct measured fruit DW.
- Preserves `review_only_dry_matter_conversion` as a review flag/caveat and keeps blocker_codes empty only because fixture, basis, mapping, derivation, and provenance are explicit.

## Scope Guardrails
- Does not touch `school_trait_bundle__yield`, KNU private data, or `public_ai_competition__yield` registration semantics.
- Does not change architecture, THORP, partition_policy, or public promotion semantics.
- Uses existing repo-relative fixtures under `data/fixtures/public_rda_sanitized/...`.

## Validation
- `python -m json.tool configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json > $null`
- `poetry run pytest -q tests/test_multidataset_registry.py tests/test_cross_dataset_gate.py` -> 19 passed
- `poetry run ruff check tests/test_multidataset_registry.py src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/cross_dataset_gate.py` -> passed
- Note: `poetry run pytest -q tests/test_tomics_public_current_factorial_runner.py` timed out after 5 minutes; not treated as a blocking gate for this registry-only hygiene change.

Closes #284
