### PR TITLE
[Cleanup] Add lane-matrix diagnostic runtime scoring

### DIFF
--- a/docs/architecture/tomics-lane-matrix-architecture.md
+++ b/docs/architecture/tomics-lane-matrix-architecture.md
@@ -107,8 +107,8 @@ The diagnostic surface may include:
 - non-promotable harvest profiles
 - context-only datasets
 
-In the current staged implementation, context-only dataset roles stay visible on the shared scorecard and diagnostic surface as explicit placeholder diagnostic rows.
-They do not yet run observer/regime diagnostic metrics through the measured-harvest runtime.
+Context-only dataset roles stay visible on the shared scorecard and diagnostic surface as diagnostic-runtime rows when a forcing fixture and basis contract are available.
+They run the same harvest-family runtime with `no_observed_harvest_default_init`, but their observed columns remain missing and their RMSE fields stay excluded from promotion scoring.
 
 Diagnostic winners must not be treated as promotion winners.
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/__init__.py
@@ -24,8 +24,10 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.regis
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.runtime import (
     CANONICAL_REPORTING_BASIS,
+    PreparedDatasetRuntimeBundle,
     PreparedDatasetThetaScenario,
     PreparedMeasuredHarvestBundle,
+    prepare_dataset_runtime_bundle,
     prepare_measured_harvest_bundle,
     read_dataset_observation_table,
 )
@@ -45,6 +47,7 @@ __all__ = [
     "DatasetObservationContract",
     "DatasetRegistry",
     "DatasetSanitizedFixtureContract",
+    "PreparedDatasetRuntimeBundle",
     "PreparedDatasetThetaScenario",
     "PreparedMeasuredHarvestBundle",
     "TraitenvInventoryBundle",
@@ -60,6 +63,7 @@ __all__ = [
     "load_dataset_registry",
     "load_traitenv_inventory",
     "missing_required_fields",
+    "prepare_dataset_runtime_bundle",
     "prepare_measured_harvest_bundle",
     "read_dataset_observation_table",
 ]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/runtime.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/runtime.py
@@ -54,6 +54,26 @@ class PreparedDatasetThetaScenario:
 
 
 @dataclass(frozen=True, slots=True)
+class PreparedDatasetRuntimeBundle:
+    dataset_id: str
+    validation_start: pd.Timestamp
+    validation_end: pd.Timestamp
+    prepared_root: Path
+    scenarios: dict[str, PreparedDatasetThetaScenario]
+    source_unit_label: str
+    reporting_basis_in: str
+    reporting_basis_canonical: str
+    basis_normalization_resolved: bool
+    normalization_factor_to_floor_area: float
+    manifest_summary: dict[str, object]
+    rootzone_df: pd.DataFrame | None = None
+    rootzone_ec_df: pd.DataFrame | None = None
+    rootzone_path: Path | None = None
+    rootzone_ec_path: Path | None = None
+    rootzone_summary: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedMeasuredHarvestBundle:
     dataset_id: str
     observed_df: pd.DataFrame
@@ -264,16 +284,12 @@ def _canonical_observed_frame(dataset: DatasetMetadataContract) -> tuple[pd.Data
     return observed_df, factor
 
 
-def prepare_measured_harvest_bundle(
+def prepare_dataset_runtime_bundle(
     dataset: DatasetMetadataContract,
     *,
     validation_cfg: dict[str, Any],
     prepared_root: Path,
-) -> PreparedMeasuredHarvestBundle:
-    if not is_measured_harvest_runnable(dataset):
-        raise ValueError(
-            f"Dataset {dataset.dataset_id!r} is not a runnable measured-harvest dataset."
-        )
+) -> PreparedDatasetRuntimeBundle:
     prepared_root = ensure_dir(prepared_root)
     resample_rule = str(validation_cfg.get("resample_rule", "1h"))
     theta_mode = str(validation_cfg.get("theta_proxy_mode", "bucket_irrigated"))
@@ -282,9 +298,9 @@ def prepare_measured_harvest_bundle(
     if dataset.forcing_path is None:
         raise ValueError(f"Dataset {dataset.dataset_id!r} does not define a forcing_path.")
     forcing_df = read_knu_forcing_csv(dataset.forcing_path)
-    observed_df, normalization_factor = _canonical_observed_frame(dataset)
     validation_start = pd.Timestamp(dataset.validation_start).normalize()
     validation_end = pd.Timestamp(dataset.validation_end).normalize()
+    normalization_factor = _normalization_factor(dataset)
     rootzone_path = dataset.management.rootzone_path
     rootzone_ec_path = dataset.management.ec_path
     rootzone_df = (
@@ -319,12 +335,6 @@ def prepare_measured_harvest_bundle(
         "missing_policy": "preserve_missing_no_forward_fill",
         "derived_rootzone_stress_metrics_included": False,
     }
-    if validation_cfg.get("calibration_end"):
-        calibration_end = pd.Timestamp(validation_cfg["calibration_end"]).normalize()
-    else:
-        midpoint = len(observed_df) // 2
-        calibration_end = pd.Timestamp(observed_df["date"].iloc[max(midpoint - 1, 0)]).normalize()
-    holdout_start = calibration_end + pd.Timedelta(days=1)
 
     prepared_dir = ensure_dir(prepared_root / "prepared_forcing")
     scenarios: dict[str, PreparedDatasetThetaScenario] = {}
@@ -341,7 +351,71 @@ def prepare_measured_harvest_bundle(
             summary=theta_proxy_summary(minute_df),
         )
 
-    observed_canonical_path = prepared_root / "observed_harvest_canonical.csv"
+    runtime_contract_manifest_path = prepared_root / "runtime_contract_manifest.json"
+    write_json(
+        runtime_contract_manifest_path,
+        {
+            "dataset_id": dataset.dataset_id,
+            "forcing_path": str(dataset.forcing_path),
+            "validation_start": dataset.validation_start,
+            "validation_end": dataset.validation_end,
+            "reporting_basis_in": dataset.basis.reporting_basis,
+            "reporting_basis_canonical": CANONICAL_REPORTING_BASIS,
+            "basis_normalization_resolved": True,
+            "normalization_factor_to_floor_area": normalization_factor,
+            "plants_per_m2": float(dataset.basis.plants_per_m2) if dataset.basis.plants_per_m2 is not None else None,
+            "management": dataset.management.to_payload(),
+            "rootzone_measurements": rootzone_summary,
+            "sanitized_fixture": dataset.sanitized_fixture.to_payload(),
+        },
+    )
+    return PreparedDatasetRuntimeBundle(
+        dataset_id=dataset.dataset_id,
+        validation_start=validation_start,
+        validation_end=validation_end,
+        prepared_root=prepared_root,
+        scenarios=scenarios,
+        source_unit_label=dataset.basis.basis_unit_label,
+        reporting_basis_in=dataset.basis.reporting_basis,
+        reporting_basis_canonical=CANONICAL_REPORTING_BASIS,
+        basis_normalization_resolved=True,
+        normalization_factor_to_floor_area=normalization_factor,
+        manifest_summary={
+            "runtime_contract_manifest_json": str(runtime_contract_manifest_path),
+            "rootzone_measurements": rootzone_summary,
+        },
+        rootzone_df=rootzone_df,
+        rootzone_ec_df=rootzone_ec_df,
+        rootzone_path=rootzone_path,
+        rootzone_ec_path=rootzone_ec_path,
+        rootzone_summary=rootzone_summary,
+    )
+
+
+def prepare_measured_harvest_bundle(
+    dataset: DatasetMetadataContract,
+    *,
+    validation_cfg: dict[str, Any],
+    prepared_root: Path,
+) -> PreparedMeasuredHarvestBundle:
+    if not is_measured_harvest_runnable(dataset):
+        raise ValueError(
+            f"Dataset {dataset.dataset_id!r} is not a runnable measured-harvest dataset."
+        )
+    runtime_bundle = prepare_dataset_runtime_bundle(
+        dataset,
+        validation_cfg=validation_cfg,
+        prepared_root=prepared_root,
+    )
+    observed_df, _ = _canonical_observed_frame(dataset)
+    if validation_cfg.get("calibration_end"):
+        calibration_end = pd.Timestamp(validation_cfg["calibration_end"]).normalize()
+    else:
+        midpoint = len(observed_df) // 2
+        calibration_end = pd.Timestamp(observed_df["date"].iloc[max(midpoint - 1, 0)]).normalize()
+    holdout_start = calibration_end + pd.Timedelta(days=1)
+
+    observed_canonical_path = runtime_bundle.prepared_root / "observed_harvest_canonical.csv"
     observed_df.to_csv(observed_canonical_path, index=False)
     observation_contract_manifest_path = prepared_root / "observation_contract_manifest.json"
     write_json(
@@ -355,48 +429,50 @@ def prepare_measured_harvest_bundle(
             "reporting_basis_in": dataset.basis.reporting_basis,
             "reporting_basis_canonical": CANONICAL_REPORTING_BASIS,
             "basis_normalization_resolved": True,
-            "normalization_factor_to_floor_area": normalization_factor,
+            "normalization_factor_to_floor_area": runtime_bundle.normalization_factor_to_floor_area,
             "plants_per_m2": float(dataset.basis.plants_per_m2) if dataset.basis.plants_per_m2 is not None else None,
             "date_column": dataset.observation.date_column,
             "measured_cumulative_column": dataset.observation.measured_cumulative_column,
             "estimated_cumulative_column": dataset.observation.estimated_cumulative_column,
             "measured_semantics": dataset.observation.measured_semantics,
             "management": dataset.management.to_payload(),
-            "rootzone_measurements": rootzone_summary,
+            "rootzone_measurements": runtime_bundle.rootzone_summary,
             "sanitized_fixture": dataset.sanitized_fixture.to_payload(),
         },
     )
     return PreparedMeasuredHarvestBundle(
-        dataset_id=dataset.dataset_id,
+        dataset_id=runtime_bundle.dataset_id,
         observed_df=observed_df,
-        validation_start=validation_start,
-        validation_end=validation_end,
+        validation_start=runtime_bundle.validation_start,
+        validation_end=runtime_bundle.validation_end,
         calibration_end=calibration_end,
         holdout_start=holdout_start,
-        prepared_root=prepared_root,
-        scenarios=scenarios,
-        source_unit_label=dataset.basis.basis_unit_label,
-        reporting_basis_in=dataset.basis.reporting_basis,
-        reporting_basis_canonical=CANONICAL_REPORTING_BASIS,
-        basis_normalization_resolved=True,
-        normalization_factor_to_floor_area=normalization_factor,
+        prepared_root=runtime_bundle.prepared_root,
+        scenarios=runtime_bundle.scenarios,
+        source_unit_label=runtime_bundle.source_unit_label,
+        reporting_basis_in=runtime_bundle.reporting_basis_in,
+        reporting_basis_canonical=runtime_bundle.reporting_basis_canonical,
+        basis_normalization_resolved=runtime_bundle.basis_normalization_resolved,
+        normalization_factor_to_floor_area=runtime_bundle.normalization_factor_to_floor_area,
         manifest_summary={
+            **runtime_bundle.manifest_summary,
             "observed_harvest_canonical_csv": str(observed_canonical_path),
             "observation_contract_manifest_json": str(observation_contract_manifest_path),
-            "rootzone_measurements": rootzone_summary,
         },
-        rootzone_df=rootzone_df,
-        rootzone_ec_df=rootzone_ec_df,
-        rootzone_path=rootzone_path,
-        rootzone_ec_path=rootzone_ec_path,
-        rootzone_summary=rootzone_summary,
+        rootzone_df=runtime_bundle.rootzone_df,
+        rootzone_ec_df=runtime_bundle.rootzone_ec_df,
+        rootzone_path=runtime_bundle.rootzone_path,
+        rootzone_ec_path=runtime_bundle.rootzone_ec_path,
+        rootzone_summary=runtime_bundle.rootzone_summary,
     )
 
 
 __all__ = [
     "CANONICAL_REPORTING_BASIS",
+    "PreparedDatasetRuntimeBundle",
     "PreparedDatasetThetaScenario",
     "PreparedMeasuredHarvestBundle",
+    "prepare_dataset_runtime_bundle",
     "prepare_measured_harvest_bundle",
     "read_dataset_observation_table",
     "read_rootzone_ec_table",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/allocation_lane_registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/allocation_lane_registry.py
@@ -81,15 +81,30 @@ def default_allocation_lane_specs() -> tuple[AllocationLaneSpec, ...]:
     )
 
 
+def _requested_lane_ids(
+    lane_ids: Iterable[str] | None,
+    *,
+    available_ids: Iterable[str],
+) -> set[str] | None:
+    if lane_ids is None:
+        return None
+    requested = {str(value) for value in lane_ids}
+    unknown_ids = sorted(requested.difference(str(value) for value in available_ids))
+    if unknown_ids:
+        raise ValueError(f"Unknown allocation lane ids requested: {', '.join(unknown_ids)}")
+    return requested
+
+
 def resolve_allocation_lanes(
     candidates: Iterable[CalibrationCandidate],
     *,
     lane_ids: Iterable[str] | None = None,
 ) -> list[ResolvedAllocationLane]:
+    specs = default_allocation_lane_specs()
     candidate_map = {candidate.candidate_label: candidate for candidate in candidates}
-    requested = set(str(value) for value in lane_ids) if lane_ids is not None else None
+    requested = _requested_lane_ids(lane_ids, available_ids=(spec.lane_id for spec in specs))
     resolved: list[ResolvedAllocationLane] = []
-    for spec in default_allocation_lane_specs():
+    for spec in specs:
         if requested is not None and spec.lane_id not in requested:
             continue
         candidate = candidate_map[spec.candidate_label]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/dataset_role_registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/dataset_role_registry.py
@@ -130,7 +130,14 @@ def resolve_dataset_roles(
     *,
     dataset_ids: Iterable[str] | None = None,
 ) -> list[ResolvedDatasetRole]:
-    requested = set(str(value) for value in dataset_ids) if dataset_ids is not None else None
+    if dataset_ids is None:
+        requested = None
+    else:
+        requested = {str(value) for value in dataset_ids}
+        available_ids = {dataset.dataset_id for dataset in registry.datasets}
+        unknown_ids = sorted(requested.difference(available_ids))
+        if unknown_ids:
+            raise ValueError(f"Unknown dataset ids requested: {', '.join(unknown_ids)}")
     resolved: list[ResolvedDatasetRole] = []
     for dataset in registry.datasets:
         if requested is not None and dataset.dataset_id not in requested:

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/harvest_profile_registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/harvest_profile_registry.py
@@ -29,6 +29,15 @@ class HarvestProfileSpec:
     selected_family_is_proxy: bool
 
 
+KNOWN_HARVEST_PROFILE_IDS = frozenset(
+    {
+        "incumbent_harvest_profile",
+        "locked_research_selected_harvest_profile",
+        "diagnostic_factorial_harvest_profile",
+    }
+)
+
+
 def _selected_payload_path(*, repo_root: Path, selected_payload_path: str | Path | None = None) -> Path:
     if selected_payload_path is not None:
         candidate = Path(selected_payload_path)
@@ -38,13 +47,23 @@ def _selected_payload_path(*, repo_root: Path, selected_payload_path: str | Path
     return (repo_root / "out" / "tomics_knu_harvest_family_factorial" / "selected_harvest_family.json").resolve()
 
 
+def _requested_profile_ids(requested_ids: list[str] | None) -> set[str] | None:
+    if not requested_ids:
+        return None
+    requested = {str(value) for value in requested_ids}
+    unknown_ids = sorted(requested.difference(KNOWN_HARVEST_PROFILE_IDS))
+    if unknown_ids:
+        raise ValueError(f"Unknown harvest profile ids requested: {', '.join(unknown_ids)}")
+    return requested
+
+
 def resolve_harvest_profiles(
     *,
     repo_root: Path,
     requested_ids: list[str] | None = None,
     selected_payload_path: str | Path | None = None,
 ) -> list[HarvestProfileSpec]:
-    requested = set(requested_ids) if requested_ids else None
+    requested = _requested_profile_ids(requested_ids)
     profiles: list[HarvestProfileSpec] = [
         HarvestProfileSpec(
             harvest_profile_id="incumbent_harvest_profile",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_gate.py
@@ -38,10 +38,63 @@ def _gate_config(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def _gate_score(row: pd.Series) -> float:
-    rmse_cumulative = float(pd.to_numeric(pd.Series([row.get("rmse_cumulative_offset", math.inf)]), errors="coerce").fillna(math.inf).iloc[0])
-    rmse_daily = float(pd.to_numeric(pd.Series([row.get("rmse_daily_increment", math.inf)]), errors="coerce").fillna(math.inf).iloc[0])
-    fruit_anchor_error = float(pd.to_numeric(pd.Series([row.get("fruit_anchor_error", math.inf)]), errors="coerce").fillna(math.inf).iloc[0])
-    canopy_collapse_days = float(pd.to_numeric(pd.Series([row.get("canopy_collapse_days", math.inf)]), errors="coerce").fillna(math.inf).iloc[0])
+    rmse_cumulative = float(
+        pd.to_numeric(pd.Series([row.get("rmse_cumulative_offset", math.inf)]), errors="coerce")
+        .fillna(math.inf)
+        .iloc[0]
+    )
+    rmse_daily = float(
+        pd.to_numeric(pd.Series([row.get("rmse_daily_increment", math.inf)]), errors="coerce")
+        .fillna(math.inf)
+        .iloc[0]
+    )
+    fruit_anchor_error = float(
+        pd.to_numeric(pd.Series([row.get("fruit_anchor_error", math.inf)]), errors="coerce")
+        .fillna(math.inf)
+        .iloc[0]
+    )
+    canopy_collapse_days = float(
+        pd.to_numeric(pd.Series([row.get("canopy_collapse_days", math.inf)]), errors="coerce")
+        .fillna(math.inf)
+        .iloc[0]
+    )
+    if math.isfinite(rmse_cumulative) or math.isfinite(rmse_daily):
+        return -rmse_cumulative - 0.5 * rmse_daily - 0.25 * fruit_anchor_error - 0.1 * canopy_collapse_days
+
+    native_state_coverage = float(
+        pd.to_numeric(pd.Series([row.get("native_state_coverage", math.nan)]), errors="coerce")
+        .fillna(math.nan)
+        .iloc[0]
+    )
+    shared_tdvs_proxy_fraction = float(
+        pd.to_numeric(pd.Series([row.get("shared_tdvs_proxy_fraction", math.nan)]), errors="coerce")
+        .fillna(math.nan)
+        .iloc[0]
+    )
+    family_separability_score = float(
+        pd.to_numeric(pd.Series([row.get("family_separability_score", math.nan)]), errors="coerce")
+        .fillna(math.nan)
+        .iloc[0]
+    )
+    if (
+        math.isfinite(native_state_coverage)
+        or math.isfinite(shared_tdvs_proxy_fraction)
+        or math.isfinite(family_separability_score)
+    ):
+        native_term = native_state_coverage if math.isfinite(native_state_coverage) else 0.0
+        proxy_term = shared_tdvs_proxy_fraction if math.isfinite(shared_tdvs_proxy_fraction) else 1.0
+        separability_term = family_separability_score if math.isfinite(family_separability_score) else 0.0
+        canopy_term = canopy_collapse_days if math.isfinite(canopy_collapse_days) else 0.0
+        all_zero_penalty = 1.0 if bool(row.get("any_all_zero_harvest_series", False)) else 0.0
+        offplant_penalty = 1.0 if bool(row.get("offplant_with_positive_mass_flag", False)) else 0.0
+        return (
+            separability_term
+            + native_term
+            - 0.5 * proxy_term
+            - 0.1 * canopy_term
+            - all_zero_penalty
+            - offplant_penalty
+        )
     return -rmse_cumulative - 0.5 * rmse_daily - 0.25 * fruit_anchor_error - 0.1 * canopy_collapse_days
 
 
@@ -87,6 +140,20 @@ def _lane_audit_summary(promotion_rows: pd.DataFrame) -> pd.DataFrame:
             }
         )
     return pd.DataFrame(summary_rows)
+
+
+def _select_diagnostic_record(diagnostic_surface_df: pd.DataFrame) -> dict[str, object]:
+    if diagnostic_surface_df.empty:
+        return {}
+    selected_row = (
+        diagnostic_surface_df.sort_values(
+            ["diagnostic_score", "dataset_id", "allocation_lane_id", "harvest_profile_id"],
+            ascending=[False, True, True, True],
+        )
+        .reset_index(drop=True)
+        .iloc[0]
+    )
+    return selected_row.to_dict()
 
 
 def run_lane_matrix_gate(
@@ -282,7 +349,7 @@ def run_lane_matrix_gate(
             selected_promotion = promotion_surface_df.iloc[0].to_dict()
     promotion_surface_df.to_csv(paths.promotion_surface_path, index=False)
 
-    diagnostic_selected = diagnostic_surface_df.iloc[0].to_dict() if not diagnostic_surface_df.empty else {}
+    diagnostic_selected = _select_diagnostic_record(diagnostic_surface_df)
     decision_payload = {
         "matrix_root": str(matrix_root),
         "promotion_surface_path": str(paths.promotion_surface_path),
@@ -296,6 +363,7 @@ def run_lane_matrix_gate(
         },
         "promotion_selected": selected_promotion,
         "promotion_blocked": (not bool(selected_promotion)) or (not bool(selected_promotion.get("passes", False))),
+        "diagnostic_selection_basis": "highest_diagnostic_score" if diagnostic_selected else None,
         "diagnostic_selected": diagnostic_selected,
     }
     write_json(paths.lane_gate_decision_path, decision_payload)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py
@@ -154,6 +154,28 @@ def build_lane_scorecard_row(
     }
 
 
+def build_diagnostic_runtime_lane_scorecard_row(
+    scenario: ComparisonScenario,
+    *,
+    validation_df: pd.DataFrame,
+    run_df: pd.DataFrame,
+    metrics: dict[str, object],
+    basis_normalization_resolved: bool | None = None,
+) -> dict[str, object]:
+    row = build_lane_scorecard_row(
+        scenario,
+        validation_df=validation_df,
+        run_df=run_df,
+        metrics=metrics,
+        basis_normalization_resolved=basis_normalization_resolved,
+    )
+    row["execution_status"] = "diagnostic_runtime_scored"
+    row["rmse_cumulative_offset"] = math.nan
+    row["rmse_daily_increment"] = math.nan
+    row["winner_stability_score"] = math.nan
+    return row
+
+
 def build_split_score_rows(
     scenario: ComparisonScenario,
     *,
@@ -261,6 +283,7 @@ __all__ = [
     "RUNTIME_COMPLETE_SEMANTICS",
     "RUNTIME_UNRESOLVED",
     "build_context_only_lane_scorecard_row",
+    "build_diagnostic_runtime_lane_scorecard_row",
     "build_lane_scorecard_row",
     "build_split_score_rows",
     "finalize_lane_scorecard",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py
@@ -14,6 +14,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.regis
     load_dataset_registry,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.runtime import (
+    prepare_dataset_runtime_bundle,
     prepare_measured_harvest_bundle,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_calibration_bridge import (
@@ -37,6 +38,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.ha
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.lane_scorecard import (
     build_context_only_lane_scorecard_row,
+    build_diagnostic_runtime_lane_scorecard_row,
     build_lane_scorecard_row,
     build_split_score_rows,
     finalize_lane_scorecard,
@@ -111,6 +113,54 @@ def _write_scenario_sidecars(
             "dataset_id": scenario.dataset_role_assignment.dataset_id,
             "metrics": dict(metrics),
         },
+    )
+
+
+def _write_scenario_error_sidecar(
+    scenario: ComparisonScenario,
+    *,
+    scenario_root: Path,
+    error: Exception,
+) -> None:
+    write_json(
+        scenario_root / "audit.json",
+        {
+            "scenario_id": scenario.scenario_id,
+            "allocation_lane_id": scenario.allocation_lane.lane_id,
+            "harvest_profile_id": scenario.harvest_profile.harvest_profile_id,
+            "dataset_id": scenario.dataset_role_assignment.dataset_id,
+            "error": {
+                "type": type(error).__name__,
+                "message": str(error),
+            },
+        },
+    )
+
+
+def _build_diagnostic_observed_df(*, validation_start: pd.Timestamp, validation_end: pd.Timestamp) -> pd.DataFrame:
+    dates = pd.date_range(validation_start.normalize(), validation_end.normalize(), freq="D")
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "measured_cumulative_harvested_fruit_dry_weight_floor_area": pd.Series(
+                [pd.NA] * len(dates),
+                dtype="Float64",
+            ),
+            "estimated_cumulative_harvested_fruit_dry_weight_floor_area": pd.Series(
+                [pd.NA] * len(dates),
+                dtype="Float64",
+            ),
+            "measured_cumulative_total_fruit_dry_weight_floor_area": pd.Series(
+                [pd.NA] * len(dates),
+                dtype="Float64",
+            ),
+            "estimated_cumulative_total_fruit_dry_weight_floor_area": pd.Series(
+                [pd.NA] * len(dates),
+                dtype="Float64",
+            ),
+            "measured_daily_increment_floor_area": pd.Series([pd.NA] * len(dates), dtype="Float64"),
+            "estimated_daily_increment_floor_area": pd.Series([pd.NA] * len(dates), dtype="Float64"),
+        }
     )
 
 
@@ -211,7 +261,8 @@ def run_lane_matrix(
 
     base_config = load_harvest_base_config(reference_meta)
     theta_scenario_id = str(lane_cfg.get("theta_proxy_scenario", "moderate"))
-    bundle_cache: dict[str, Any] = {}
+    measured_bundle_cache: dict[str, Any] = {}
+    runtime_bundle_cache: dict[str, Any] = {}
     reconstruction_cache: dict[tuple[str, str], dict[str, object]] = {}
     scorecard_rows: list[dict[str, object]] = []
     split_rows: list[dict[str, object]] = []
@@ -230,14 +281,72 @@ def run_lane_matrix(
             )
             continue
         if dataset_assignment.dataset_role != "measured_harvest":
-            scorecard_rows.append(
-                build_context_only_lane_scorecard_row(
-                    scenario,
-                    execution_status="dataset_role_not_harvest_scoreable",
+            try:
+                runtime_bundle = runtime_bundle_cache.get(dataset_assignment.dataset_id)
+                if runtime_bundle is None:
+                    prepared_root = ensure_dir(output_root / "_prepared" / dataset_assignment.dataset_id)
+                    runtime_bundle = prepare_dataset_runtime_bundle(
+                        dataset_assignment.dataset,
+                        validation_cfg=validation_cfg,
+                        prepared_root=prepared_root,
+                    )
+                    runtime_bundle_cache[dataset_assignment.dataset_id] = runtime_bundle
+                forcing_scenario = runtime_bundle.scenarios[theta_scenario_id]
+                diagnostic_observed_df = _build_diagnostic_observed_df(
+                    validation_start=runtime_bundle.validation_start,
+                    validation_end=runtime_bundle.validation_end,
                 )
-            )
+                run_cfg = configure_candidate_run(
+                    base_config=copy.deepcopy(base_config),
+                    forcing_csv_path=forcing_scenario.forcing_csv_path,
+                    theta_center=float(forcing_scenario.summary.get("theta_mean", 0.65)),
+                    row=scenario.allocation_lane.candidate_row,
+                    initial_state_overrides={},
+                )
+                result = run_harvest_family_simulation(
+                    run_config=run_cfg,
+                    observed_df=diagnostic_observed_df,
+                    unit_label=runtime_bundle.source_unit_label,
+                    repo_root=repo_root,
+                    fruit_harvest_family=scenario.harvest_profile.fruit_harvest_family,
+                    leaf_harvest_family=scenario.harvest_profile.leaf_harvest_family,
+                    fdmc_mode=scenario.harvest_profile.fdmc_mode,
+                    fruit_params=scenario.harvest_profile.fruit_params,
+                    leaf_params=scenario.harvest_profile.leaf_params,
+                )
+                diagnostic_metrics = dict(result.metrics)
+                diagnostic_metrics["diagnostic_hidden_state_mode"] = "no_observed_harvest_default_init"
+                diagnostic_metrics["diagnostic_dataset_role"] = dataset_assignment.dataset_role
+                scorecard_rows.append(
+                    build_diagnostic_runtime_lane_scorecard_row(
+                        scenario,
+                        validation_df=result.validation_df,
+                        run_df=result.run_df,
+                        metrics=diagnostic_metrics,
+                        basis_normalization_resolved=runtime_bundle.basis_normalization_resolved,
+                    )
+                )
+                _write_scenario_sidecars(
+                    scenario,
+                    scenario_root=scenario_root,
+                    validation_df=result.validation_df,
+                    harvest_mass_balance_df=result.harvest_mass_balance_df,
+                    metrics=diagnostic_metrics,
+                )
+            except (FileNotFoundError, KeyError, ValueError) as error:
+                scorecard_rows.append(
+                    build_context_only_lane_scorecard_row(
+                        scenario,
+                        execution_status="diagnostic_runtime_unavailable",
+                    )
+                )
+                _write_scenario_error_sidecar(
+                    scenario,
+                    scenario_root=scenario_root,
+                    error=error,
+                )
             continue
-        bundle = bundle_cache.get(dataset_assignment.dataset_id)
+        bundle = measured_bundle_cache.get(dataset_assignment.dataset_id)
         if bundle is None:
             prepared_root = ensure_dir(output_root / "_prepared" / dataset_assignment.dataset_id)
             bundle = prepare_measured_harvest_bundle(
@@ -245,7 +354,7 @@ def run_lane_matrix(
                 validation_cfg=validation_cfg,
                 prepared_root=prepared_root,
             )
-            bundle_cache[dataset_assignment.dataset_id] = bundle
+            measured_bundle_cache[dataset_assignment.dataset_id] = bundle
         forcing_scenario = bundle.scenarios[theta_scenario_id]
         cache_key = (dataset_assignment.dataset_id, scenario.allocation_lane.lane_id)
         initial_state_overrides = reconstruction_cache.get(cache_key)

--- a/tests/test_multidataset_runtime.py
+++ b/tests/test_multidataset_runtime.py
@@ -7,12 +7,14 @@ import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
+    DatasetCapability,
     DatasetManagementMetadata,
     DatasetMetadataContract,
     DatasetObservationContract,
     DatasetSanitizedFixtureContract,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.runtime import (
+    prepare_dataset_runtime_bundle,
     prepare_measured_harvest_bundle,
 )
 
@@ -67,6 +69,48 @@ def _write_rootzone_ec_fixture(path: Path) -> None:
             "depth_cm": [10, 10, 10, 10],
         }
     ).to_csv(path, index=False)
+
+
+def test_prepare_dataset_runtime_bundle_does_not_require_observed_harvest(tmp_path: Path) -> None:
+    forcing_path = tmp_path / "forcing.csv"
+    _write_forcing_fixture(forcing_path)
+    dataset = DatasetMetadataContract(
+        dataset_id="context_only",
+        dataset_kind="traitenv_bundle",
+        display_name="Context-only forcing",
+        forcing_path=forcing_path,
+        observed_harvest_path=None,
+        validation_start="2025-01-01",
+        validation_end="2025-01-03",
+        cultivar="cv",
+        greenhouse="gh",
+        season="winter",
+        capability=DatasetCapability.CONTEXT_ONLY,
+        basis=DatasetBasisContract(reporting_basis="floor_area_g_m2"),
+        observation=DatasetObservationContract(),
+        management=DatasetManagementMetadata(),
+        sanitized_fixture=DatasetSanitizedFixtureContract(forcing_fixture_path=forcing_path),
+        notes={"dataset_role_hint": "trait_plus_env_no_harvest"},
+    )
+
+    bundle = prepare_dataset_runtime_bundle(
+        dataset,
+        validation_cfg={
+            "resample_rule": "1D",
+            "theta_proxy_mode": "bucket_irrigated",
+            "theta_proxy_scenarios": ["moderate"],
+        },
+        prepared_root=tmp_path / "prepared-runtime",
+    )
+
+    manifest_path = bundle.prepared_root / "runtime_contract_manifest.json"
+    assert bundle.dataset_id == "context_only"
+    assert bundle.scenarios["moderate"].forcing_csv_path.exists()
+    assert manifest_path.exists()
+    assert not (bundle.prepared_root / "observation_contract_manifest.json").exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["forcing_path"] == str(forcing_path)
+    assert manifest["sanitized_fixture"]["observed_harvest_fixture_path"] is None
 
 
 def test_prepare_measured_harvest_bundle_honors_contract_columns_and_basis_conversion(tmp_path: Path) -> None:

--- a/tests/test_tomics_lane_matrix_gate.py
+++ b/tests/test_tomics_lane_matrix_gate.py
@@ -432,3 +432,131 @@ def test_lane_matrix_gate_measured_dataset_count_uses_only_promotion_passing_row
     assert not incumbent_row.empty
     assert float(incumbent_row.iloc[0]["cross_dataset_stability_score"]) == 1.0
     assert bool(incumbent_row.iloc[0]["passes"]) is True
+
+
+def _diagnostic_context_scorecard_row(
+    *,
+    dataset_id: str,
+    allocation_lane_id: str,
+    native_state_coverage: float,
+    shared_tdvs_proxy_fraction: float,
+    family_separability_score: float,
+    any_all_zero_harvest_series: bool = False,
+    offplant_with_positive_mass_flag: bool = False,
+    canopy_collapse_days: float = 0.0,
+) -> dict[str, object]:
+    return {
+        "scenario_id": f"{allocation_lane_id}__incumbent_harvest_profile__{dataset_id}",
+        "allocation_lane_id": allocation_lane_id,
+        "harvest_profile_id": "incumbent_harvest_profile",
+        "dataset_id": dataset_id,
+        "dataset_role": "trait_plus_env_no_harvest",
+        "promotion_eligible": False,
+        "reference_only": False,
+        "reporting_basis_in": "floor_area_g_m2",
+        "reporting_basis_canonical": "floor_area_g_m2",
+        "basis_normalization_resolved": True,
+        "rmse_cumulative_offset": float("nan"),
+        "rmse_daily_increment": float("nan"),
+        "fruit_anchor_error": 0.0,
+        "canopy_collapse_days": canopy_collapse_days,
+        "winner_stability_score": float("nan"),
+        "native_state_coverage": native_state_coverage,
+        "shared_tdvs_proxy_fraction": shared_tdvs_proxy_fraction,
+        "family_separability_score": family_separability_score,
+        "any_all_zero_harvest_series": any_all_zero_harvest_series,
+        "dropped_nonharvested_mass_g_m2": 0.0,
+        "offplant_with_positive_mass_flag": offplant_with_positive_mass_flag,
+        "runtime_complete_semantics": "explicit_harvested_cumulative_writeback_audited",
+        "selected_family_label": "incumbent",
+        "selected_family_is_native": True,
+        "selected_family_is_proxy": False,
+        "execution_status": "diagnostic_runtime_scored",
+        "candidate_label": "shipped_tomics",
+        "architecture_id": f"{allocation_lane_id}_architecture",
+        "partition_policy": "tomics",
+        "mean_alloc_frac_fruit": 0.45,
+        "mean_proxy_family_state_fraction": shared_tdvs_proxy_fraction,
+    }
+
+
+def test_lane_matrix_gate_ranks_context_only_runtime_rows_by_diagnostic_score(tmp_path: Path) -> None:
+    matrix_root = tmp_path / "out" / "tomics" / "validation" / "lane-matrix"
+    matrix_root.mkdir(parents=True, exist_ok=True)
+    scorecard_df = pd.DataFrame(
+        [
+            _diagnostic_context_scorecard_row(
+                dataset_id="ctx",
+                allocation_lane_id="incumbent_current",
+                native_state_coverage=0.9,
+                shared_tdvs_proxy_fraction=0.1,
+                family_separability_score=0.8,
+            ),
+            _diagnostic_context_scorecard_row(
+                dataset_id="ctx",
+                allocation_lane_id="research_promoted",
+                native_state_coverage=0.3,
+                shared_tdvs_proxy_fraction=0.6,
+                family_separability_score=0.0,
+                any_all_zero_harvest_series=True,
+                offplant_with_positive_mass_flag=True,
+                canopy_collapse_days=4.0,
+            ),
+        ]
+    )
+    scorecard_df.to_csv(matrix_root / "lane_scorecard.csv", index=False)
+    config = {
+        "validation": {
+            "lane_matrix_gate": {
+                "matrix_root": str(matrix_root),
+                "output_root": str(matrix_root),
+                "min_dataset_count": 2,
+            }
+        }
+    }
+
+    run_lane_matrix_gate(config, repo_root=tmp_path, config_path=tmp_path / "gate.yaml")
+
+    diagnostic_df = pd.read_csv(matrix_root / "diagnostic_surface.csv")
+    assert diagnostic_df.iloc[0]["allocation_lane_id"] == "incumbent_current"
+    assert float(diagnostic_df.iloc[0]["diagnostic_score"]) > float(diagnostic_df.iloc[1]["diagnostic_score"])
+
+
+def test_lane_matrix_gate_selects_highest_scoring_diagnostic_record_in_decision_payload(tmp_path: Path) -> None:
+    matrix_root = tmp_path / "out" / "tomics" / "validation" / "lane-matrix"
+    matrix_root.mkdir(parents=True, exist_ok=True)
+    scorecard_df = pd.DataFrame(
+        [
+            _diagnostic_context_scorecard_row(
+                dataset_id="a_ctx",
+                allocation_lane_id="incumbent_current",
+                native_state_coverage=0.1,
+                shared_tdvs_proxy_fraction=0.8,
+                family_separability_score=0.1,
+            ),
+            _diagnostic_context_scorecard_row(
+                dataset_id="z_ctx",
+                allocation_lane_id="research_current",
+                native_state_coverage=0.95,
+                shared_tdvs_proxy_fraction=0.05,
+                family_separability_score=0.9,
+            ),
+        ]
+    )
+    scorecard_df.to_csv(matrix_root / "lane_scorecard.csv", index=False)
+    config = {
+        "validation": {
+            "lane_matrix_gate": {
+                "matrix_root": str(matrix_root),
+                "output_root": str(matrix_root),
+                "min_dataset_count": 2,
+            }
+        }
+    }
+
+    run_lane_matrix_gate(config, repo_root=tmp_path, config_path=tmp_path / "gate.yaml")
+
+    decision = json.loads((matrix_root / "lane_gate_decision.json").read_text(encoding="utf-8"))
+    assert decision["diagnostic_selection_basis"] == "highest_diagnostic_score"
+    assert decision["diagnostic_selected"]["dataset_id"] == "z_ctx"
+    assert decision["diagnostic_selected"]["allocation_lane_id"] == "research_current"

--- a/tests/test_tomics_lane_matrix_registry.py
+++ b/tests/test_tomics_lane_matrix_registry.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
     DatasetManagementMetadata,
@@ -111,6 +113,11 @@ def test_allocation_lane_registry_resolves_required_policies() -> None:
     assert lane_map["raw_reference_thorp"].promotion_eligible is False
 
 
+def test_allocation_lane_registry_rejects_unknown_requested_lane() -> None:
+    with pytest.raises(ValueError, match="Unknown allocation lane ids requested: missing_lane"):
+        resolve_allocation_lanes(_calibration_candidates(), lane_ids=["incumbent_current", "missing_lane"])
+
+
 def test_dataset_roles_do_not_auto_promote_yield_environment() -> None:
     registry = DatasetRegistry(
         datasets=(
@@ -133,6 +140,17 @@ def test_dataset_roles_do_not_auto_promote_yield_environment() -> None:
     assert role_map["traitenv_context"].dataset_role == "trait_plus_env_no_harvest"
     assert role_map["yield_env_only"].dataset_role == "yield_environment_only"
     assert role_map["yield_env_only"].promotion_denominator_eligible is False
+
+
+def test_dataset_role_registry_rejects_unknown_requested_dataset() -> None:
+    registry = DatasetRegistry(
+        datasets=(
+            _dataset(dataset_id="knu_actual", dataset_kind="knu_measured_harvest"),
+        ),
+        default_dataset_ids=("knu_actual",),
+    )
+    with pytest.raises(ValueError, match="Unknown dataset ids requested: missing_dataset"):
+        resolve_dataset_roles(registry, dataset_ids=["knu_actual", "missing_dataset"])
 
 
 def test_measured_harvest_contract_requires_sanitized_fixture_metadata() -> None:
@@ -197,3 +215,8 @@ def test_harvest_profile_registry_reads_locked_selected_family(tmp_path: Path) -
     assert profile_map["locked_research_selected_harvest_profile"].fruit_harvest_family == "dekoning_fds"
     assert profile_map["locked_research_selected_harvest_profile"].selected_family_is_native is True
     assert profile_map["locked_research_selected_harvest_profile"].selected_family_is_proxy is True
+
+
+def test_harvest_profile_registry_rejects_unknown_requested_profile(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unknown harvest profile ids requested: missing_profile"):
+        resolve_harvest_profiles(repo_root=tmp_path, requested_ids=["incumbent_harvest_profile", "missing_profile"])

--- a/tests/test_tomics_lane_matrix_smoke.py
+++ b/tests/test_tomics_lane_matrix_smoke.py
@@ -21,6 +21,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_family
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.lane_gate import (
     run_lane_matrix_gate,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.lane_scorecard import (
+    RUNTIME_COMPLETE_SEMANTICS,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.matrix_runner import (
     run_lane_matrix,
 )
@@ -469,8 +472,11 @@ def test_lane_matrix_keeps_context_only_dataset_diagnostic_only(tmp_path: Path, 
     context_rows = scorecard_df.loc[scorecard_df["dataset_id"].eq("trait_context")].copy()
     assert not context_rows.empty
     assert set(context_rows["dataset_role"]) == {"trait_plus_env_no_harvest"}
-    assert set(context_rows["execution_status"]) == {"dataset_role_not_harvest_scoreable"}
-    assert not context_rows["execution_status"].eq("scored").any()
+    assert set(context_rows["execution_status"]) == {"diagnostic_runtime_scored"}
+    assert context_rows["runtime_complete_semantics"].eq(RUNTIME_COMPLETE_SEMANTICS).all()
+    assert context_rows["native_state_coverage"].notna().all()
+    assert context_rows["mean_alloc_frac_fruit"].notna().all()
+    assert context_rows["rmse_cumulative_offset"].isna().all()
 
     gate_config = {
         "validation": {
@@ -485,6 +491,7 @@ def test_lane_matrix_keeps_context_only_dataset_diagnostic_only(tmp_path: Path, 
     diagnostic_df = pd.read_csv(output_root / "diagnostic_surface.csv")
     decision = json.loads((output_root / "lane_gate_decision.json").read_text(encoding="utf-8"))
     assert "trait_context" in set(diagnostic_df["dataset_id"])
+    assert diagnostic_df.loc[diagnostic_df["dataset_id"].eq("trait_context"), "diagnostic_score"].notna().all()
     assert decision["measured_dataset_count"] == 1
 
 


### PR DESCRIPTION
## Summary
- Reconciles the preserved stale #288 lane-matrix delta onto fresh main without cherry-picking the old branch wholesale.
- Adds a forcing-only `PreparedDatasetRuntimeBundle` path so context-only datasets can run diagnostic harvest-family runtime when a forcing fixture and basis contract are available.
- Keeps context-only diagnostic rows out of RMSE/promotion scoring while preserving promotion denominator semantics for measured-harvest datasets only.
- Adds explicit unknown-id validation for requested lane/profile/dataset selections.

## Scope hygiene
- No raw/private data added.
- No KNU/private fixture changes.
- No cross-dataset promotion semantics widened.
- No dataset contract/blocker downgrade from the stale branch was carried over.

## Validation
- `poetry run pytest -q tests/test_multidataset_runtime.py tests/test_tomics_lane_matrix_smoke.py tests/test_tomics_lane_matrix_gate.py tests/test_tomics_lane_matrix_registry.py tests/test_cross_dataset_gate.py` -> 29 passed
- `poetry run pytest -q tests/test_tomics_lane_matrix.py` -> 6 passed
- `poetry run pytest -q tests/test_multidataset_contracts.py tests/test_multidataset_registry.py` -> 21 passed
- `poetry run ruff check .` -> passed
- `poetry run pytest --collect-only -q` -> 602 tests collected
- Full `poetry run pytest -q` did not finish within 15 minutes in this environment; no assertion failure was observed before timeout.
- `tests/test_tomics_public_current_factorial_runner.py` also exceeded the 3 minute local timeout and is not used as a blocker for this narrow #288 cleanup PR.

Closes #288