### PR TITLE
[Bug] Bound default pytest validation and document slow suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ poetry run python scripts/run_tomics_factorial.py --config configs/exp/tomics_fa
 poetry run python scripts/run_tomics_lane_matrix.py --config configs/exp/tomics_lane_matrix.yaml
 poetry run python scripts/run_tomics_lane_matrix_gate.py --config configs/exp/tomics_lane_matrix_gate.yaml
 poetry run pytest
+poetry run pytest -o addopts= -m slow
+poetry run pytest -o addopts=
 poetry run ruff check .
 ```
+
+The default `poetry run pytest` suite excludes tests marked `slow`. Use `poetry run pytest -o addopts= -m slow`
+for opt-in slow validation, or `poetry run pytest -o addopts=` for the complete test suite.
 
 `THORP` and `TDGM` full-series control rerenders are long-running. On the current workstation, the canonical full rerender completed in about 52 minutes for `THORP` and 56 minutes for `TDGM`.
 
@@ -160,7 +165,7 @@ poetry run ruff check .
 - Slice 108 vectorizes the THORP/TDGM root-uptake bottleneck so the canonical full-series control rerenders finish in practical time, regenerates the live Plotkit comparison bundles, and records that root `TDGM` still shows long-horizon full-series drift against the legacy MATLAB control payload.
 
 ## Next validation
-- Keep `pytest`, `ruff`, and the root rerun parity renderers green while the architecture remains in monitor mode.
+- Keep the default fast `pytest`, opt-in slow `pytest`, `ruff`, and the root rerun parity renderers green while the architecture remains in monitor mode.
 - Keep the fast root `GOSM` rerun tests warning-free and run the opt-in slow `imag` branch whenever root `gosm` hydraulics or stomatal logic changes.
 - Run the opt-in slow `GOSM` `imag` conductance-loss parity branch when root `gosm` hydraulics or stomatal logic changes.
 - Re-render `scripts/render_root_rerun_parity_figures.py` whenever root `THORP`, `GOSM`, or `TDGM` rerun kernels change.

--- a/docs/architecture/implementation/implementation_gate_checklist.md
+++ b/docs/architecture/implementation/implementation_gate_checklist.md
@@ -15,7 +15,8 @@ Broad implementation is blocked until all required items are checked.
 
 ## Slice 001 Validation Commands
 
-- `poetry run pytest`
+- `poetry run pytest` (default fast suite; slow tests are opt-in through `pyproject.toml`)
+- `poetry run pytest -o addopts= -m slow` when long-running parity or TOMICS integration smoke surfaces are in scope
 - `poetry run ruff check .`
 
 ## Artifact Retention Rule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ pytest = "^9.0.2"
 ruff = "^0.15.5"
 
 [tool.pytest.ini_options]
+addopts = "-m 'not slow'"
 markers = [
-    "slow: long-running legacy parity regressions",
+    "slow: long-running legacy parity or TOMICS integration regressions",
 ]
 

--- a/tests/test_tomics_knu_harvest_family_factorial_runner.py
+++ b/tests/test_tomics_knu_harvest_family_factorial_runner.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
 from .test_tomics_knu_harvest_runner_smoke import (
     assert_harvest_family_factorial_runner_writes_required_outputs_from_sanitized_fixture,
 )
 
 
+@pytest.mark.slow
 def test_harvest_family_factorial_runner_writes_required_outputs_from_sanitized_fixture(tmp_path) -> None:
     assert_harvest_family_factorial_runner_writes_required_outputs_from_sanitized_fixture(tmp_path)

--- a/tests/test_tomics_knu_harvest_promotion_gate.py
+++ b/tests/test_tomics_knu_harvest_promotion_gate.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
 from .test_tomics_knu_harvest_runner_smoke import (
     assert_harvest_promotion_gate_runner_writes_scorecard_outputs_from_sanitized_fixture,
 )
 
 
+@pytest.mark.slow
 def test_harvest_promotion_gate_runner_writes_scorecard_outputs_from_sanitized_fixture(tmp_path, monkeypatch) -> None:
     assert_harvest_promotion_gate_runner_writes_scorecard_outputs_from_sanitized_fixture(tmp_path, monkeypatch)

--- a/tests/test_tomics_lane_matrix.py
+++ b/tests/test_tomics_lane_matrix.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pandas as pd
+import pytest
 import yaml
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import load_config
@@ -426,6 +427,7 @@ def test_lane_gate_keeps_raw_reference_only_in_diagnostics(tmp_path: Path) -> No
     assert decision["diagnostic_surface_path"].endswith("diagnostic_surface.csv")
 
 
+@pytest.mark.slow
 def test_lane_matrix_runner_current_knu_smoke(tmp_path: Path) -> None:
     repo_root = _repo_root()
     current_vs_promoted_config = write_minimal_knu_config(tmp_path, repo_root=repo_root, mode="both")
@@ -498,6 +500,7 @@ def test_lane_matrix_runner_current_knu_smoke(tmp_path: Path) -> None:
     assert (gate_root / "lane_gate_decision.json").exists()
 
 
+@pytest.mark.slow
 def test_lane_matrix_runner_supports_multidataset_mode(tmp_path: Path) -> None:
     repo_root = _repo_root()
     current_vs_promoted_config = write_minimal_knu_config(tmp_path, repo_root=repo_root, mode="both")

--- a/tests/test_tomics_public_current_factorial_runner.py
+++ b/tests/test_tomics_public_current_factorial_runner.py
@@ -9,6 +9,8 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation import (
     run_current_vs_promoted_factorial,
 )
 
+pytestmark = pytest.mark.slow
+
 
 def _write_public_config(tmp_path: Path, *, repo_root: Path, source_config: str) -> Path:
     source_path = repo_root / source_config


### PR DESCRIPTION
## Summary
- Make the default `poetry run pytest` suite exclude `slow` tests through `pyproject.toml`.
- Mark long-running TOMICS public, lane-matrix, and KNU harvest runner smoke tests as opt-in `slow`.
- Document fast, slow, and complete pytest validation commands in README and the implementation gate checklist.

## Validation
- `poetry run pytest -q tests/test_tomics_lane_matrix.py --durations=10` -> 4 passed, 2 deselected
- `poetry run pytest -q -o "addopts=" -m slow tests/test_tomics_public_current_factorial_runner.py --collect-only` -> 2 slow tests collected
- `poetry run pytest -q -o "addopts=" -m slow tests/test_tomics_lane_matrix.py --collect-only` -> 2 slow tests collected
- `poetry run pytest -q -o "addopts=" -m slow tests/test_tomics_knu_harvest_family_factorial_runner.py tests/test_tomics_knu_harvest_promotion_gate.py --collect-only` -> 2 slow tests collected
- `poetry run pytest -q --durations=20` -> 569 passed, 26 skipped, 7 deselected in 48.79s
- `poetry run ruff check .` -> passed

Closes #290