### PR TITLE
[Bug] Split TOMICS lane registry fast contract from slow smoke

### DIFF
--- a/tests/test_tomics_lane_matrix.py
+++ b/tests/test_tomics_lane_matrix.py
@@ -29,7 +29,6 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_factor
     run_harvest_family_factorial,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix import (
-    resolve_allocation_lanes,
     resolve_dataset_roles,
     run_lane_matrix,
     run_lane_matrix_gate,
@@ -199,23 +198,6 @@ def _write_lane_matrix_gate_config(tmp_path: Path, *, repo_root: Path, matrix_ro
     out_path = tmp_path / "tomics_lane_matrix_gate_test.yaml"
     out_path.write_text(yaml.safe_dump(config, sort_keys=False, allow_unicode=False), encoding="utf-8")
     return out_path
-
-
-def test_allocation_lane_registry_resolves_expected_partition_policies(tmp_path: Path) -> None:
-    repo_root = _repo_root()
-    config_path = write_minimal_knu_config(tmp_path, repo_root=repo_root, mode="both")
-    load_config(config_path)
-    run_current_vs_promoted_factorial(config_path=config_path, mode="both")
-    config = load_config(config_path)
-    candidates, _ = load_harvest_candidates(config=config, repo_root=repo_root, config_path=config_path)
-    lanes = {lane.lane_id: lane for lane in resolve_allocation_lanes(candidates)}
-
-    assert lanes["legacy_sink_baseline"].partition_policy == "legacy"
-    assert lanes["incumbent_current"].partition_policy == "tomics"
-    assert lanes["research_current"].partition_policy == "tomics_alloc_research"
-    assert lanes["research_promoted"].partition_policy == "tomics_promoted_research"
-    assert lanes["raw_reference_thorp"].partition_policy == "thorp_fruit_veg"
-    assert lanes["legacy_sink_baseline"].architecture_id != lanes["incumbent_current"].architecture_id
 
 
 def test_dataset_roles_separate_measured_context_and_yield_environment(tmp_path: Path) -> None:

--- a/tests/test_tomics_lane_matrix_registry_smoke.py
+++ b/tests/test_tomics_lane_matrix_registry_smoke.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import load_config
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_promoted import (
+    run_current_vs_promoted_factorial,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_calibration_bridge import (
+    load_harvest_candidates,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix import (
+    resolve_allocation_lanes,
+)
+
+from .tomics_knu_test_helpers import write_minimal_knu_config
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.slow
+def test_allocation_lane_registry_resolves_current_vs_promoted_candidates_smoke(tmp_path: Path) -> None:
+    repo_root = _repo_root()
+    config_path = write_minimal_knu_config(tmp_path, repo_root=repo_root, mode="both")
+    run_current_vs_promoted_factorial(config_path=config_path, mode="both")
+    config = load_config(config_path)
+    candidates, _ = load_harvest_candidates(config=config, repo_root=repo_root, config_path=config_path)
+    lanes = {lane.lane_id: lane for lane in resolve_allocation_lanes(candidates)}
+
+    assert lanes["legacy_sink_baseline"].partition_policy == "legacy"
+    assert lanes["incumbent_current"].partition_policy == "tomics"
+    assert lanes["research_current"].partition_policy == "tomics_alloc_research"
+    assert lanes["research_promoted"].partition_policy == "tomics_promoted_research"
+    assert lanes["raw_reference_thorp"].partition_policy == "thorp_fruit_veg"
+    assert lanes["legacy_sink_baseline"].architecture_id != lanes["incumbent_current"].architecture_id


### PR DESCRIPTION
## Summary
- remove the duplicated default-suite current-vs-promoted lane-registry test from `tests/test_tomics_lane_matrix.py`
- preserve the same current-vs-promoted-backed coverage as an opt-in slow smoke in `tests/test_tomics_lane_matrix_registry_smoke.py`
- keep the fast synthetic lane registry contract in `tests/test_tomics_lane_matrix_registry.py` as the default guardrail

## Validation
- `poetry run pytest -q tests/test_tomics_lane_matrix_registry.py tests/test_tomics_lane_matrix.py -m "not slow" --durations=10`
- `poetry run pytest -q -o "addopts=" -m slow tests/test_tomics_lane_matrix_registry_smoke.py --durations=5`
- `poetry run pytest --durations=15`
- `poetry run ruff check .`

Closes #296