### PR TITLE
[Validation] Multi-dataset A1-A4 TOMICS allocation lane matrix

### DIFF
--- a/configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml
+++ b/configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml
@@ -1,0 +1,99 @@
+exp:
+  name: tomics_a1_a4_multidataset_lane_matrix
+
+paths:
+  repo_root: ../..
+
+validation:
+  resample_rule: 1h
+  theta_proxy_mode: bucket_irrigated
+  theta_proxy_scenarios: [moderate]
+  datasets:
+    registry_snapshot_path: configs/data/tomics_multidataset_candidates/traitenv_candidate_registry.json
+    default_dataset_ids:
+      - knu_actual
+      - public_rda__yield
+      - public_ai_competition__yield
+    items:
+      - dataset_id: knu_actual
+        dataset_kind: knu_measured_harvest
+        display_name: KNU measured harvest sanitized smoke fixture
+        dataset_family: knu_actual
+        observation_family: yield
+        capability: measured_harvest
+        ingestion_status: runnable
+        source_refs:
+          - tests/fixtures/knu_sanitized/KNU_Tomato_Env_fixture.csv
+          - tests/fixtures/knu_sanitized/tomato_validation_data_yield_fixture.csv
+        forcing_path: tests/fixtures/knu_sanitized/KNU_Tomato_Env_fixture.csv
+        observed_harvest_path: tests/fixtures/knu_sanitized/tomato_validation_data_yield_fixture.csv
+        validation_start: "2024-08-08"
+        validation_end: "2024-08-11"
+        cultivar: unknown
+        greenhouse: KNU
+        season: sanitized_smoke_window
+        basis:
+          reporting_basis: floor_area_g_m2
+          plants_per_m2: 1.836091
+        observation:
+          date_column: Date
+          measured_cumulative_column: Measured_Cumulative_Total_Fruit_DW (g/m^2)
+          estimated_cumulative_column: Estimated_Cumulative_Total_Fruit_DW (g/m^2)
+          measured_semantics: cumulative_harvested_fruit_dry_weight_floor_area
+        sanitized_fixture:
+          fixture_kind: sanitized_csv_fixture
+          forcing_fixture_path: tests/fixtures/knu_sanitized/KNU_Tomato_Env_fixture.csv
+          observed_harvest_fixture_path: tests/fixtures/knu_sanitized/tomato_validation_data_yield_fixture.csv
+        priority_tags:
+          - baseline_window
+          - sanitized_fixture_smoke
+        provenance_tags:
+          - actual_data_contract
+          - knu
+          - measured_harvest
+        notes:
+          dataset_role_hint: measured_harvest
+          evidence_grade: direct_measured_harvest
+          decision_weight: promotion_gate
+          dataset_source_kind: sanitized_fixture_smoke
+          reporting_basis: floor_area_g_m2
+      - dataset_id: public_rda__yield
+        notes:
+          dataset_role_hint: measured_harvest
+          evidence_grade: review_only_derived_dw
+          decision_weight: review_only_robustness
+          proxy_caveat: measured fresh shipment mass converted to derived fruit DW with 0.065 dry matter ratio; not direct fruit DW.
+      - dataset_id: public_ai_competition__yield
+        notes:
+          dataset_role_hint: measured_harvest
+          evidence_grade: review_only_derived_dw
+          decision_weight: review_only_robustness
+          proxy_caveat: public competition fresh harvest proxy converted to derived fruit DW with 0.065 dry matter ratio; not direct fruit DW.
+  lane_matrix:
+    output_root: out/tomics_a1_a4_multidataset_lane_matrix
+    theta_proxy_scenario: moderate
+    allow_state_reconstruction_fallback: true
+    state_reconstruction_fallback_policy: smoke_only_default_init_when_reconstruction_fails
+    dataset_ids:
+      - knu_actual
+      - public_rda__yield
+      - public_ai_competition__yield
+    allocation_lane_ids:
+      - legacy_sink_baseline
+      - raw_reference_thorp
+      - incumbent_current
+      - research_promoted
+    harvest_profile_ids:
+      - incumbent_harvest_profile
+  lane_matrix_gate:
+    matrix_root: out/tomics_a1_a4_multidataset_lane_matrix
+    output_root: out/tomics_a1_a4_multidataset_lane_matrix
+    native_state_coverage_min: 0.5
+    shared_tdvs_proxy_fraction_max: 0.5
+    cross_dataset_stability_score_min: 0.5
+    min_dataset_count: 2
+
+reference:
+  current_vs_promoted_config: configs/exp/tomics_current_vs_promoted_factorial_knu.yaml
+  current_output_root: out/tomics/validation/knu/architecture/current-factorial
+  promoted_output_root: out/tomics/validation/knu/architecture/promoted-factorial

--- a/docs/architecture/review/tomics-a1-a4-allocation-factorial-selection.md
+++ b/docs/architecture/review/tomics-a1-a4-allocation-factorial-selection.md
@@ -200,6 +200,32 @@ Current evidence does not meet that bar.
 - Do not promote on public RDA or public AI alone because both are review-only derived-DW lanes.
 - Do not include `school_trait_bundle__yield` until its raw/sanitized observed-harvest blockers are resolved.
 
+## Multi-dataset reproducibility follow-up
+
+Issue #304 adds a reproducible A1-A4 lane-matrix config for `knu_actual`, `public_rda__yield`, and
+`public_ai_competition__yield` under `configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml`.
+This follow-up does not reopen the architecture decision from Issue #302 / PR #303.
+The original decision remains unchanged unless a future measured-harvest promotion gate is explicitly reopened:
+A3 remains the shipped incumbent and A4 remains research-only.
+
+The config uses repo-relative sanitized fixtures and writes the review bundle to
+`out/tomics_a1_a4_multidataset_lane_matrix/`.
+It separates direct measured evidence from review-only public evidence:
+
+| Dataset | Evidence grade | Decision weight | Promotion use |
+|---|---|---|---|
+| `knu_actual` | `direct_measured_harvest` | `promotion_gate` | Primary measured-harvest score only |
+| `public_rda__yield` | `review_only_derived_dw` | `review_only_robustness` | Robustness / contradiction check only |
+| `public_ai_competition__yield` | `review_only_derived_dw` | `review_only_robustness` | Public smoke / contradiction check only |
+
+The public RDA and public AI competition lanes are useful for robustness, overfitting detection, and
+directionality checks, but they are not promotion evidence because their observed harvest targets are
+derived dry-weight estimates from public fresh-harvest or shipment measurements.
+The lane gate therefore keeps `primary_measured_score.json` separate from
+`review_only_public_score.json` and does not pool those values into one promotion score.
+No raw/private KNU data are committed by this follow-up.
+
 ## Next minimal issue
 
-Create one follow-up issue to make the A1-A4 lane-matrix run reproducible on repo-relative fixtures, including `knu_actual`, `public_rda__yield`, and `public_ai_competition__yield`, without requiring the missing KNU longrun xlsx file.
+After #304 lands, use the generated multi-dataset bundle to choose the next narrow validation dependency rather
+than treating a KNU-only run as the final reproducibility claim.

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/artifact_schema.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/artifact_schema.py
@@ -13,6 +13,14 @@ ARTIFACT_FILENAMES = {
     "diagnostic_surface": "diagnostic_surface.csv",
     "promotion_surface": "promotion_surface.csv",
     "dataset_role_summary": "dataset_role_summary.csv",
+    "architecture_matrix": "architecture_matrix.csv",
+    "per_dataset_metric_summary": "per_dataset_metric_summary.csv",
+    "dataset_role_matrix": "dataset_role_matrix.csv",
+    "primary_measured_score": "primary_measured_score.json",
+    "review_only_public_score": "review_only_public_score.json",
+    "all_runnable_smoke_score": "all_runnable_smoke_score.json",
+    "promotion_gate_decision": "promotion_gate_decision.json",
+    "readme": "README.md",
 }
 
 
@@ -55,6 +63,38 @@ class LaneMatrixArtifactPaths:
     @property
     def dataset_role_summary_path(self) -> Path:
         return self.root / ARTIFACT_FILENAMES["dataset_role_summary"]
+
+    @property
+    def architecture_matrix_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["architecture_matrix"]
+
+    @property
+    def per_dataset_metric_summary_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["per_dataset_metric_summary"]
+
+    @property
+    def dataset_role_matrix_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["dataset_role_matrix"]
+
+    @property
+    def primary_measured_score_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["primary_measured_score"]
+
+    @property
+    def review_only_public_score_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["review_only_public_score"]
+
+    @property
+    def all_runnable_smoke_score_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["all_runnable_smoke_score"]
+
+    @property
+    def promotion_gate_decision_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["promotion_gate_decision"]
+
+    @property
+    def readme_path(self) -> Path:
+        return self.root / ARTIFACT_FILENAMES["readme"]
 
     def scenario_root(self, scenario_id: str) -> Path:
         return self.scenarios_root / scenario_id

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/dataset_role_registry.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/dataset_role_registry.py
@@ -6,6 +6,8 @@ from typing import Iterable
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetCapability,
     DatasetMetadataContract,
+    accepted_review_only_dry_matter_runtime,
+    dataset_review_flags,
     is_measured_harvest_runnable,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.registry import (
@@ -31,6 +33,12 @@ class ResolvedDatasetRole:
     has_measured_harvest_contract: bool
     reporting_basis: str
     plants_per_m2: float
+    evidence_grade: str
+    decision_weight: str
+    proxy_caveat: str
+    review_flags: tuple[str, ...]
+    is_direct_dry_weight: bool | None
+    observed_harvest_derivation: str
     dataset: DatasetMetadataContract
 
 
@@ -85,6 +93,74 @@ def _explicit_role_hint(dataset: DatasetMetadataContract) -> str | None:
 
 def measured_harvest_contract_satisfied(dataset: DatasetMetadataContract) -> bool:
     return is_measured_harvest_runnable(dataset)
+
+
+def _normalize_note_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    key = str(value).strip().lower()
+    if key in {"true", "1", "yes"}:
+        return True
+    if key in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def _note_text(dataset: DatasetMetadataContract, key: str) -> str:
+    return str(dataset.notes.get(key) or "").strip()
+
+
+def _is_review_only_derived_dw(dataset: DatasetMetadataContract) -> bool:
+    return accepted_review_only_dry_matter_runtime(dataset)
+
+
+def infer_dataset_evidence_grade(dataset: DatasetMetadataContract, *, dataset_role: str) -> str:
+    if _is_review_only_derived_dw(dataset):
+        return "review_only_derived_dw"
+    raw = _note_text(dataset, "evidence_grade").lower()
+    if raw:
+        return raw
+    if dataset_role == "measured_harvest" and measured_harvest_contract_satisfied(dataset):
+        return "direct_measured_harvest"
+    if dataset_role == "trait_plus_env_no_harvest":
+        return "trait_env_context"
+    if dataset_role == "yield_environment_only":
+        return "yield_environment_context"
+    if dataset_role == "env_only":
+        return "environment_context"
+    return "metadata_only"
+
+
+def infer_dataset_decision_weight(
+    dataset: DatasetMetadataContract,
+    *,
+    dataset_role: str,
+    evidence_grade: str,
+) -> str:
+    del dataset_role
+    if evidence_grade == "review_only_derived_dw":
+        return "review_only_robustness"
+    raw = _note_text(dataset, "decision_weight").lower()
+    if raw:
+        return raw
+    if evidence_grade == "direct_measured_harvest":
+        return "promotion_gate"
+    return "diagnostic_context"
+
+
+def infer_dataset_proxy_caveat(dataset: DatasetMetadataContract, *, evidence_grade: str) -> str:
+    raw = _note_text(dataset, "proxy_caveat")
+    if raw:
+        return raw
+    if evidence_grade == "review_only_derived_dw":
+        derivation = _note_text(dataset, "observed_harvest_derivation") or dataset.dry_matter_conversion.mode
+        return (
+            f"{derivation}; source fresh harvest/shipment is converted to dry weight with a documented "
+            "dry-matter ratio and is not direct measured fruit dry weight."
+        )
+    return ""
 
 
 def infer_dataset_role(dataset: DatasetMetadataContract) -> str:
@@ -144,17 +220,35 @@ def resolve_dataset_roles(
             continue
         dataset_role = infer_dataset_role(dataset)
         spec = ROLE_SPECS[dataset_role]
+        evidence_grade = infer_dataset_evidence_grade(dataset, dataset_role=dataset_role)
+        decision_weight = infer_dataset_decision_weight(
+            dataset,
+            dataset_role=dataset_role,
+            evidence_grade=evidence_grade,
+        )
+        review_flags = dataset_review_flags(dataset)
+        promotion_denominator_eligible = (
+            spec.promotion_denominator_eligible
+            and evidence_grade == "direct_measured_harvest"
+            and decision_weight == "promotion_gate"
+        )
         resolved.append(
             ResolvedDatasetRole(
                 dataset_id=dataset.dataset_id,
                 dataset_kind=dataset.dataset_kind,
                 display_name=dataset.display_name,
                 dataset_role=dataset_role,
-                promotion_denominator_eligible=spec.promotion_denominator_eligible,
+                promotion_denominator_eligible=promotion_denominator_eligible,
                 scorecard_included=spec.scorecard_included,
                 has_measured_harvest_contract=measured_harvest_contract_satisfied(dataset),
                 reporting_basis=dataset.basis.reporting_basis,
                 plants_per_m2=float(dataset.basis.plants_per_m2 or 0.0),
+                evidence_grade=evidence_grade,
+                decision_weight=decision_weight,
+                proxy_caveat=infer_dataset_proxy_caveat(dataset, evidence_grade=evidence_grade),
+                review_flags=review_flags,
+                is_direct_dry_weight=_normalize_note_bool(dataset.notes.get("is_direct_dry_weight")),
+                observed_harvest_derivation=_note_text(dataset, "observed_harvest_derivation"),
                 dataset=dataset,
             )
         )
@@ -165,6 +259,8 @@ __all__ = [
     "DatasetRoleSpec",
     "ResolvedDatasetRole",
     "ROLE_SPECS",
+    "infer_dataset_decision_weight",
+    "infer_dataset_evidence_grade",
     "infer_dataset_role",
     "measured_harvest_contract_satisfied",
     "resolve_dataset_roles",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_gate.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_gate.py
@@ -17,6 +17,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.ar
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.lane_scorecard import (
     promotion_audit_passes,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.summary_artifacts import (
+    write_promotion_gate_decision_artifact,
+)
 
 
 def _as_dict(raw: object) -> dict[str, Any]:
@@ -99,11 +102,16 @@ def _gate_score(row: pd.Series) -> float:
 
 
 def _base_promotion_mask(scorecard_df: pd.DataFrame) -> pd.Series:
-    return (
+    mask = (
         scorecard_df["promotion_eligible"].fillna(False).astype(bool)
         & ~scorecard_df["reference_only"].fillna(False).astype(bool)
         & scorecard_df["dataset_role"].eq("measured_harvest")
     )
+    if "decision_weight" in scorecard_df:
+        mask &= scorecard_df["decision_weight"].fillna("").astype(str).eq("promotion_gate")
+    if "evidence_grade" in scorecard_df:
+        mask &= scorecard_df["evidence_grade"].fillna("").astype(str).eq("direct_measured_harvest")
+    return mask
 
 
 def _lane_audit_summary(promotion_rows: pd.DataFrame) -> pd.DataFrame:
@@ -367,6 +375,11 @@ def run_lane_matrix_gate(
         "diagnostic_selected": diagnostic_selected,
     }
     write_json(paths.lane_gate_decision_path, decision_payload)
+    write_promotion_gate_decision_artifact(
+        paths=paths,
+        scorecard_df=scorecard_df,
+        decision_payload=decision_payload,
+    )
     return {
         "output_root": str(output_root),
         "promotion_rows": int(promotion_surface_df.shape[0]),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py
@@ -65,12 +65,19 @@ def build_context_only_lane_scorecard_row(
         "harvest_profile_id": scenario.harvest_profile.harvest_profile_id,
         "dataset_id": dataset_assignment.dataset_id,
         "dataset_role": dataset_assignment.dataset_role,
+        "evidence_grade": dataset_assignment.evidence_grade,
+        "decision_weight": dataset_assignment.decision_weight,
+        "proxy_caveat": dataset_assignment.proxy_caveat,
+        "review_flags": ";".join(dataset_assignment.review_flags),
+        "is_direct_dry_weight": dataset_assignment.is_direct_dry_weight,
+        "observed_harvest_derivation": dataset_assignment.observed_harvest_derivation,
         "promotion_eligible": bool(scenario.promotion_surface_eligible),
         "reference_only": bool(scenario.allocation_lane.reference_only),
         "reporting_basis_in": dataset_assignment.reporting_basis,
         "reporting_basis_canonical": "floor_area_g_m2",
         "basis_normalization_resolved": bool(resolved_basis),
         "rmse_cumulative_offset": math.nan,
+        "r2_cumulative_offset": math.nan,
         "rmse_daily_increment": math.nan,
         "fruit_anchor_error": math.nan,
         "canopy_collapse_days": math.nan,
@@ -86,6 +93,8 @@ def build_context_only_lane_scorecard_row(
         "selected_family_is_native": bool(scenario.harvest_profile.selected_family_is_native),
         "selected_family_is_proxy": bool(scenario.harvest_profile.selected_family_is_proxy),
         "execution_status": execution_status,
+        "state_reconstruction_status": "not_attempted",
+        "state_reconstruction_error": "",
         "candidate_label": scenario.allocation_lane.candidate_label,
         "architecture_id": scenario.allocation_lane.architecture_id,
         "partition_policy": scenario.allocation_lane.partition_policy,
@@ -118,12 +127,19 @@ def build_lane_scorecard_row(
         "harvest_profile_id": scenario.harvest_profile.harvest_profile_id,
         "dataset_id": dataset_assignment.dataset_id,
         "dataset_role": dataset_assignment.dataset_role,
+        "evidence_grade": dataset_assignment.evidence_grade,
+        "decision_weight": dataset_assignment.decision_weight,
+        "proxy_caveat": dataset_assignment.proxy_caveat,
+        "review_flags": ";".join(dataset_assignment.review_flags),
+        "is_direct_dry_weight": dataset_assignment.is_direct_dry_weight,
+        "observed_harvest_derivation": dataset_assignment.observed_harvest_derivation,
         "promotion_eligible": bool(scenario.promotion_surface_eligible),
         "reference_only": bool(scenario.allocation_lane.reference_only),
         "reporting_basis_in": reporting_basis_in,
         "reporting_basis_canonical": "floor_area_g_m2",
         "basis_normalization_resolved": bool(resolved_basis),
         "rmse_cumulative_offset": float(metrics.get("rmse_cumulative_offset", math.nan)),
+        "r2_cumulative_offset": float(metrics.get("r2_cumulative_offset", math.nan)),
         "rmse_daily_increment": float(metrics.get("rmse_daily_increment", math.nan)),
         "fruit_anchor_error": math.nan,
         "canopy_collapse_days": float(metrics.get("canopy_collapse_days", math.nan)),
@@ -142,6 +158,8 @@ def build_lane_scorecard_row(
         "selected_family_is_native": bool(scenario.harvest_profile.selected_family_is_native),
         "selected_family_is_proxy": bool(scenario.harvest_profile.selected_family_is_proxy),
         "execution_status": "scored",
+        "state_reconstruction_status": str(metrics.get("state_reconstruction_status", "reconstructed")),
+        "state_reconstruction_error": str(metrics.get("state_reconstruction_error", "")),
         "candidate_label": scenario.allocation_lane.candidate_label,
         "architecture_id": scenario.allocation_lane.architecture_id,
         "partition_policy": scenario.allocation_lane.partition_policy,
@@ -183,7 +201,11 @@ def build_split_score_rows(
     validation_df: pd.DataFrame,
 ) -> list[dict[str, object]]:
     split_rows: list[dict[str, object]] = []
-    for split in build_split_windows(observed_df):
+    try:
+        split_windows = build_split_windows(observed_df)
+    except ValueError:
+        return split_rows
+    for split in split_windows:
         dates = pd.to_datetime(validation_df["date"], errors="coerce").dt.normalize()
         mask = (dates >= split.calibration_start) & (dates <= split.holdout_end)
         window = validation_df.loc[mask].copy()

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py
@@ -47,6 +47,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.sc
     ComparisonScenario,
     compose_scenarios,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.summary_artifacts import (
+    write_lane_matrix_reproducibility_artifacts,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.state_reconstruction import (
     reconstruct_hidden_state,
 )
@@ -89,6 +92,9 @@ def _scenario_index_row(scenario: ComparisonScenario) -> dict[str, object]:
         "harvest_profile_id": scenario.harvest_profile.harvest_profile_id,
         "dataset_id": dataset_assignment.dataset_id,
         "dataset_role": dataset_assignment.dataset_role,
+        "evidence_grade": dataset_assignment.evidence_grade,
+        "decision_weight": dataset_assignment.decision_weight,
+        "proxy_caveat": dataset_assignment.proxy_caveat,
         "promotion_surface_eligible": bool(scenario.promotion_surface_eligible),
         "scorecard_included": bool(dataset_assignment.scorecard_included),
     }
@@ -235,6 +241,12 @@ def run_lane_matrix(
                     "dataset_role": dataset.dataset_role,
                     "reporting_basis": dataset.reporting_basis,
                     "promotion_denominator_eligible": dataset.promotion_denominator_eligible,
+                    "evidence_grade": dataset.evidence_grade,
+                    "decision_weight": dataset.decision_weight,
+                    "proxy_caveat": dataset.proxy_caveat,
+                    "review_flags": list(dataset.review_flags),
+                    "is_direct_dry_weight": dataset.is_direct_dry_weight,
+                    "observed_harvest_derivation": dataset.observed_harvest_derivation,
                 }
                 for dataset in dataset_roles
             ],
@@ -253,6 +265,12 @@ def run_lane_matrix(
                 "has_measured_harvest_contract": dataset.has_measured_harvest_contract,
                 "reporting_basis": dataset.reporting_basis,
                 "plants_per_m2": dataset.plants_per_m2,
+                "evidence_grade": dataset.evidence_grade,
+                "decision_weight": dataset.decision_weight,
+                "proxy_caveat": dataset.proxy_caveat,
+                "review_flags": ";".join(dataset.review_flags),
+                "is_direct_dry_weight": dataset.is_direct_dry_weight,
+                "observed_harvest_derivation": dataset.observed_harvest_derivation,
             }
             for dataset in dataset_roles
         ]
@@ -261,9 +279,10 @@ def run_lane_matrix(
 
     base_config = load_harvest_base_config(reference_meta)
     theta_scenario_id = str(lane_cfg.get("theta_proxy_scenario", "moderate"))
+    allow_reconstruction_fallback = bool(lane_cfg.get("allow_state_reconstruction_fallback", False))
     measured_bundle_cache: dict[str, Any] = {}
     runtime_bundle_cache: dict[str, Any] = {}
-    reconstruction_cache: dict[tuple[str, str], dict[str, object]] = {}
+    reconstruction_cache: dict[tuple[str, str], tuple[dict[str, object], str, str]] = {}
     scorecard_rows: list[dict[str, object]] = []
     split_rows: list[dict[str, object]] = []
     scenario_index_rows: list[dict[str, object]] = []
@@ -317,6 +336,8 @@ def run_lane_matrix(
                 diagnostic_metrics = dict(result.metrics)
                 diagnostic_metrics["diagnostic_hidden_state_mode"] = "no_observed_harvest_default_init"
                 diagnostic_metrics["diagnostic_dataset_role"] = dataset_assignment.dataset_role
+                diagnostic_metrics["state_reconstruction_status"] = "not_attempted_context_runtime"
+                diagnostic_metrics["state_reconstruction_error"] = ""
                 scorecard_rows.append(
                     build_diagnostic_runtime_lane_scorecard_row(
                         scenario,
@@ -357,20 +378,36 @@ def run_lane_matrix(
             measured_bundle_cache[dataset_assignment.dataset_id] = bundle
         forcing_scenario = bundle.scenarios[theta_scenario_id]
         cache_key = (dataset_assignment.dataset_id, scenario.allocation_lane.lane_id)
-        initial_state_overrides = reconstruction_cache.get(cache_key)
-        if initial_state_overrides is None:
-            reconstruction = reconstruct_hidden_state(
-                architecture_row=scenario.allocation_lane.candidate_row,
-                base_config=copy.deepcopy(base_config),
-                forcing_csv_path=forcing_scenario.forcing_csv_path,
-                theta_center=float(forcing_scenario.summary.get("theta_mean", 0.65)),
-                observed_df=bundle.observed_df,
-                calibration_end=bundle.calibration_end,
-                repo_root=repo_root,
-                unit_label=bundle.source_unit_label,
+        cached_reconstruction = reconstruction_cache.get(cache_key)
+        if cached_reconstruction is None:
+            try:
+                reconstruction = reconstruct_hidden_state(
+                    architecture_row=scenario.allocation_lane.candidate_row,
+                    base_config=copy.deepcopy(base_config),
+                    forcing_csv_path=forcing_scenario.forcing_csv_path,
+                    theta_center=float(forcing_scenario.summary.get("theta_mean", 0.65)),
+                    observed_df=bundle.observed_df,
+                    calibration_end=bundle.calibration_end,
+                    repo_root=repo_root,
+                    unit_label=bundle.source_unit_label,
+                )
+            except (RuntimeError, ValueError) as error:
+                if not allow_reconstruction_fallback:
+                    raise
+                initial_state_overrides = {}
+                reconstruction_status = "fallback_default_init"
+                reconstruction_error = f"{type(error).__name__}: {error}"
+            else:
+                initial_state_overrides = dict(reconstruction.initial_state_overrides)
+                reconstruction_status = "reconstructed"
+                reconstruction_error = ""
+            reconstruction_cache[cache_key] = (
+                initial_state_overrides,
+                reconstruction_status,
+                reconstruction_error,
             )
-            initial_state_overrides = dict(reconstruction.initial_state_overrides)
-            reconstruction_cache[cache_key] = initial_state_overrides
+        else:
+            initial_state_overrides, reconstruction_status, reconstruction_error = cached_reconstruction
         run_cfg = configure_candidate_run(
             base_config=copy.deepcopy(base_config),
             forcing_csv_path=forcing_scenario.forcing_csv_path,
@@ -389,12 +426,15 @@ def run_lane_matrix(
             fruit_params=scenario.harvest_profile.fruit_params,
             leaf_params=scenario.harvest_profile.leaf_params,
         )
+        scored_metrics = dict(result.metrics)
+        scored_metrics["state_reconstruction_status"] = reconstruction_status
+        scored_metrics["state_reconstruction_error"] = reconstruction_error
         scorecard_rows.append(
             build_lane_scorecard_row(
                 scenario,
                 validation_df=result.validation_df,
                 run_df=result.run_df,
-                metrics=result.metrics,
+                metrics=scored_metrics,
                 basis_normalization_resolved=bundle.basis_normalization_resolved,
             )
         )
@@ -410,7 +450,7 @@ def run_lane_matrix(
             scenario_root=scenario_root,
             validation_df=result.validation_df,
             harvest_mass_balance_df=result.harvest_mass_balance_df,
-            metrics=result.metrics,
+            metrics=scored_metrics,
         )
 
     scenario_index_df = pd.DataFrame(scenario_index_rows)
@@ -420,6 +460,12 @@ def run_lane_matrix(
         split_score_df=pd.DataFrame(split_rows),
     )
     scorecard_df.to_csv(paths.lane_scorecard_path, index=False)
+    write_lane_matrix_reproducibility_artifacts(
+        paths=paths,
+        allocation_lanes=allocation_lanes,
+        dataset_roles=dataset_roles,
+        scorecard_df=scorecard_df,
+    )
     return {
         "output_root": str(output_root),
         "scenario_count": len(scenarios),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/summary_artifacts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/summary_artifacts.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import write_json
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.allocation_lane_registry import (
+    ResolvedAllocationLane,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.artifact_schema import (
+    LaneMatrixArtifactPaths,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.dataset_role_registry import (
+    ResolvedDatasetRole,
+)
+
+
+ARCHITECTURE_CODE_BY_LANE = {
+    "legacy_sink_baseline": "A1",
+    "raw_reference_thorp": "A2",
+    "incumbent_current": "A3",
+    "research_promoted": "A4",
+}
+
+ARCHITECTURE_FAMILY_BY_LANE = {
+    "legacy_sink_baseline": "legacy_sink_baseline",
+    "raw_reference_thorp": "raw_thorp_direct_negative_control",
+    "incumbent_current": "shipped_tomics_bounded_incumbent",
+    "research_promoted": "research_promoted_marginal_allocator",
+}
+
+
+def architecture_code(lane_id: str) -> str:
+    return ARCHITECTURE_CODE_BY_LANE.get(lane_id, "unmapped")
+
+
+def architecture_family_id(lane_id: str) -> str:
+    return ARCHITECTURE_FAMILY_BY_LANE.get(lane_id, lane_id)
+
+
+def _json_ready(value: object) -> object:
+    if value is pd.NA:
+        return None
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return None
+    if isinstance(value, (pd.Timestamp,)):
+        return value.isoformat()
+    if hasattr(value, "item"):
+        try:
+            return _json_ready(value.item())
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+def _json_tree(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_tree(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_tree(item) for item in value]
+    return _json_ready(value)
+
+
+def _numeric(row: pd.Series, column: str, default: float = math.nan) -> float:
+    value = pd.to_numeric(pd.Series([row.get(column, default)]), errors="coerce").iloc[0]
+    return float(value) if pd.notna(value) else math.nan
+
+
+def _bool(row: pd.Series, column: str) -> bool:
+    value = row.get(column, False)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def _column_equals(frame: pd.DataFrame, column: str, expected: str) -> pd.Series:
+    if column not in frame:
+        return pd.Series([False] * len(frame), index=frame.index)
+    return frame[column].fillna("").astype(str).eq(expected)
+
+
+def _direct_measured_mask(frame: pd.DataFrame) -> pd.Series:
+    base = _column_equals(frame, "dataset_role", "measured_harvest")
+    if "evidence_grade" in frame:
+        base &= _column_equals(frame, "evidence_grade", "direct_measured_harvest")
+    if "decision_weight" in frame:
+        base &= _column_equals(frame, "decision_weight", "promotion_gate")
+    return base
+
+
+def _review_only_derived_dw_mask(frame: pd.DataFrame) -> pd.Series:
+    return _column_equals(frame, "evidence_grade", "review_only_derived_dw")
+
+
+def _guardrail_failures(row: pd.Series) -> list[str]:
+    failures: list[str] = []
+    if _bool(row, "any_all_zero_harvest_series"):
+        failures.append("all_zero_harvest_series")
+    if _bool(row, "offplant_with_positive_mass_flag"):
+        failures.append("offplant_with_positive_mass")
+    if not _bool(row, "basis_normalization_resolved"):
+        failures.append("basis_normalization_unresolved")
+    if str(row.get("runtime_complete_semantics", "")) != "explicit_harvested_cumulative_writeback_audited":
+        failures.append("runtime_semantics_unresolved")
+    dropped_mass = abs(_numeric(row, "dropped_nonharvested_mass_g_m2", default=0.0))
+    if math.isfinite(dropped_mass) and dropped_mass > 1e-9:
+        failures.append("dropped_nonharvested_mass")
+    collapse_days = _numeric(row, "canopy_collapse_days")
+    if math.isfinite(collapse_days) and collapse_days > 0.0:
+        failures.append("canopy_collapse_days")
+    return failures
+
+
+def _metric_columns() -> list[str]:
+    return [
+        "rmse_cumulative_offset",
+        "r2_cumulative_offset",
+        "rmse_daily_increment",
+        "fruit_anchor_error",
+        "canopy_collapse_days",
+        "native_state_coverage",
+        "shared_tdvs_proxy_fraction",
+        "mean_proxy_family_state_fraction",
+    ]
+
+
+def _score_rows(scorecard_df: pd.DataFrame) -> list[dict[str, object]]:
+    if scorecard_df.empty:
+        return []
+    rows: list[dict[str, object]] = []
+    for _, row in scorecard_df.sort_values(["dataset_id", "allocation_lane_id"]).iterrows():
+        payload: dict[str, object] = {
+            "dataset_id": row.get("dataset_id"),
+            "dataset_role": row.get("dataset_role"),
+            "evidence_grade": row.get("evidence_grade"),
+            "decision_weight": row.get("decision_weight"),
+            "architecture_code": architecture_code(str(row.get("allocation_lane_id", ""))),
+            "architecture_id": architecture_family_id(str(row.get("allocation_lane_id", ""))),
+            "repo_lane_alias": row.get("allocation_lane_id"),
+            "harvest_profile_id": row.get("harvest_profile_id"),
+            "execution_status": row.get("execution_status"),
+            "state_reconstruction_status": row.get("state_reconstruction_status"),
+            "state_reconstruction_error": row.get("state_reconstruction_error"),
+            "physiological_guardrail_failures": _guardrail_failures(row),
+        }
+        for column in _metric_columns():
+            payload[column] = _json_ready(row.get(column))
+        rows.append({key: _json_ready(value) for key, value in payload.items()})
+    return rows
+
+
+def _winner_by_dataset(scorecard_df: pd.DataFrame) -> list[dict[str, object]]:
+    if scorecard_df.empty:
+        return []
+    work = scorecard_df.copy()
+    work["rmse_cumulative_offset"] = pd.to_numeric(work["rmse_cumulative_offset"], errors="coerce")
+    work["rmse_daily_increment"] = pd.to_numeric(work["rmse_daily_increment"], errors="coerce")
+    work = work.loc[work["rmse_cumulative_offset"].notna()].copy()
+    if work.empty:
+        return []
+    winners = (
+        work.sort_values(["dataset_id", "rmse_cumulative_offset", "rmse_daily_increment", "allocation_lane_id"])
+        .groupby("dataset_id", as_index=False)
+        .first()
+    )
+    return _score_rows(winners)
+
+
+def _winner_by_mean_rmse(scorecard_df: pd.DataFrame) -> dict[str, object]:
+    if scorecard_df.empty:
+        return {}
+    work = scorecard_df.copy()
+    work["rmse_cumulative_offset"] = pd.to_numeric(work["rmse_cumulative_offset"], errors="coerce")
+    work["rmse_daily_increment"] = pd.to_numeric(work["rmse_daily_increment"], errors="coerce")
+    work = work.loc[work["rmse_cumulative_offset"].notna()].copy()
+    if work.empty:
+        return {}
+    summary = (
+        work.groupby("allocation_lane_id", as_index=False)
+        .agg(
+            mean_rmse_cumulative_offset=("rmse_cumulative_offset", "mean"),
+            mean_rmse_daily_increment=("rmse_daily_increment", "mean"),
+            dataset_count=("dataset_id", "nunique"),
+        )
+        .sort_values(["mean_rmse_cumulative_offset", "mean_rmse_daily_increment", "allocation_lane_id"])
+    )
+    row = summary.iloc[0]
+    tied = summary.loc[
+        summary["mean_rmse_cumulative_offset"].sub(float(row["mean_rmse_cumulative_offset"])).abs() <= 1e-9
+    ].copy()
+    return {
+        "architecture_code": architecture_code(str(row["allocation_lane_id"])),
+        "architecture_id": architecture_family_id(str(row["allocation_lane_id"])),
+        "repo_lane_alias": str(row["allocation_lane_id"]),
+        "mean_rmse_cumulative_offset": _json_ready(float(row["mean_rmse_cumulative_offset"])),
+        "mean_rmse_daily_increment": _json_ready(float(row["mean_rmse_daily_increment"])),
+        "dataset_count": int(row["dataset_count"]),
+        "tie_detected": int(tied.shape[0]) > 1,
+        "tied_repo_lane_aliases": sorted(str(value) for value in tied["allocation_lane_id"]),
+    }
+
+
+def _score_payload(
+    *,
+    score_name: str,
+    purpose: str,
+    scorecard_df: pd.DataFrame,
+    promotion_use: str,
+) -> dict[str, object]:
+    return {
+        "score_name": score_name,
+        "purpose": purpose,
+        "promotion_use": promotion_use,
+        "dataset_ids": sorted({str(value) for value in scorecard_df.get("dataset_id", [])}),
+        "dataset_count": int(scorecard_df["dataset_id"].nunique()) if "dataset_id" in scorecard_df else 0,
+        "architecture_scores": _score_rows(scorecard_df),
+        "winner_by_dataset": _winner_by_dataset(scorecard_df),
+        "winner_by_mean_rmse": _winner_by_mean_rmse(scorecard_df),
+    }
+
+
+def _architecture_matrix(allocation_lanes: list[ResolvedAllocationLane]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "architecture_code": architecture_code(lane.lane_id),
+                "architecture_id": architecture_family_id(lane.lane_id),
+                "repo_lane_alias": lane.lane_id,
+                "repo_architecture_id": lane.architecture_id,
+                "candidate_label": lane.candidate_label,
+                "partition_policy": lane.partition_policy,
+                "promotion_eligible_in_code": bool(lane.promotion_eligible),
+                "reference_only": bool(lane.reference_only),
+                "diagnostic_only": bool(lane.diagnostic_only),
+                "production_default_changed": False,
+            }
+            for lane in allocation_lanes
+        ]
+    )
+
+
+def _dataset_role_matrix(dataset_roles: list[ResolvedDatasetRole]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "dataset_id": dataset.dataset_id,
+                "dataset_kind": dataset.dataset_kind,
+                "display_name": dataset.display_name,
+                "dataset_role": dataset.dataset_role,
+                "evidence_grade": dataset.evidence_grade,
+                "decision_weight": dataset.decision_weight,
+                "proxy_caveat": dataset.proxy_caveat,
+                "promotion_denominator_eligible": bool(dataset.promotion_denominator_eligible),
+                "scorecard_included": bool(dataset.scorecard_included),
+                "has_measured_harvest_contract": bool(dataset.has_measured_harvest_contract),
+                "reporting_basis": dataset.reporting_basis,
+                "plants_per_m2": dataset.plants_per_m2,
+                "review_flags": ";".join(dataset.review_flags),
+                "is_direct_dry_weight": dataset.is_direct_dry_weight,
+                "observed_harvest_derivation": dataset.observed_harvest_derivation,
+            }
+            for dataset in dataset_roles
+        ]
+    )
+
+
+def _per_dataset_metric_summary(scorecard_df: pd.DataFrame) -> pd.DataFrame:
+    if scorecard_df.empty:
+        return pd.DataFrame()
+    rows: list[dict[str, object]] = []
+    for _, row in scorecard_df.iterrows():
+        payload = {
+            "dataset_id": row.get("dataset_id"),
+            "dataset_role": row.get("dataset_role"),
+            "evidence_grade": row.get("evidence_grade"),
+            "decision_weight": row.get("decision_weight"),
+            "proxy_caveat": row.get("proxy_caveat"),
+            "architecture_code": architecture_code(str(row.get("allocation_lane_id", ""))),
+            "architecture_id": architecture_family_id(str(row.get("allocation_lane_id", ""))),
+            "repo_lane_alias": row.get("allocation_lane_id"),
+            "harvest_profile_id": row.get("harvest_profile_id"),
+            "execution_status": row.get("execution_status"),
+            "state_reconstruction_status": row.get("state_reconstruction_status"),
+            "state_reconstruction_error": row.get("state_reconstruction_error"),
+            "physiological_guardrail_failures": ";".join(_guardrail_failures(row)),
+        }
+        for column in _metric_columns():
+            payload[column] = row.get(column)
+        rows.append(payload)
+    return pd.DataFrame(rows).sort_values(["dataset_id", "architecture_code", "harvest_profile_id"])
+
+
+def write_lane_matrix_reproducibility_artifacts(
+    *,
+    paths: LaneMatrixArtifactPaths,
+    allocation_lanes: list[ResolvedAllocationLane],
+    dataset_roles: list[ResolvedDatasetRole],
+    scorecard_df: pd.DataFrame,
+) -> None:
+    architecture_df = _architecture_matrix(allocation_lanes)
+    dataset_role_df = _dataset_role_matrix(dataset_roles)
+    metric_summary_df = _per_dataset_metric_summary(scorecard_df)
+
+    architecture_df.to_csv(paths.architecture_matrix_path, index=False)
+    dataset_role_df.to_csv(paths.dataset_role_matrix_path, index=False)
+    metric_summary_df.to_csv(paths.per_dataset_metric_summary_path, index=False)
+
+    direct_mask = _direct_measured_mask(scorecard_df)
+    review_mask = _review_only_derived_dw_mask(scorecard_df)
+    runnable_mask = _column_equals(scorecard_df, "dataset_role", "measured_harvest")
+
+    write_json(
+        paths.primary_measured_score_path,
+        _json_tree(
+            _score_payload(
+                score_name="primary_measured_score",
+                purpose="Direct measured-harvest promotion-gate evidence only.",
+                scorecard_df=scorecard_df.loc[direct_mask].copy(),
+                promotion_use="promotion_gate_only",
+            )
+        ),
+    )
+    write_json(
+        paths.review_only_public_score_path,
+        _json_tree(
+            _score_payload(
+                score_name="review_only_public_score",
+                purpose="Review-only public derived-DW robustness and contradiction check.",
+                scorecard_df=scorecard_df.loc[review_mask].copy(),
+                promotion_use="not_allowed_for_promotion",
+            )
+        ),
+    )
+    write_json(
+        paths.all_runnable_smoke_score_path,
+        _json_tree(
+            _score_payload(
+                score_name="all_runnable_smoke_score",
+                purpose="All runnable measured-harvest-compatible lanes for reproducibility smoke only.",
+                scorecard_df=scorecard_df.loc[runnable_mask].copy(),
+                promotion_use="smoke_only_not_a_pooled_promotion_score",
+            )
+        ),
+    )
+    paths.readme_path.write_text(
+        "\n".join(
+            [
+                "# TOMICS A1-A4 multidataset lane matrix",
+                "",
+                "This output bundle compares A1-A4 TOMICS allocation lanes across the currently runnable ",
+                "harvest-validation datasets.",
+                "",
+                "Datasets:",
+                "- `knu_actual`: direct measured harvest, promotion-gate evidence.",
+                "- `public_rda__yield`: review-only derived dry-weight lane, not promotion evidence.",
+                "- `public_ai_competition__yield`: review-only derived dry-weight lane, not promotion evidence.",
+                "",
+                "Decision policy:",
+                "- `primary_measured_score.json` uses only direct measured harvest evidence.",
+                "- `review_only_public_score.json` keeps public derived-DW lanes separate.",
+                "- `all_runnable_smoke_score.json` is a reproducibility smoke summary, not a promotion score.",
+                "- A3 remains the shipped incumbent and A4 remains research-only in this follow-up.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_promotion_gate_decision_artifact(
+    *,
+    paths: LaneMatrixArtifactPaths,
+    scorecard_df: pd.DataFrame,
+    decision_payload: dict[str, object],
+) -> None:
+    direct_mask = _direct_measured_mask(scorecard_df)
+    review_mask = _review_only_derived_dw_mask(scorecard_df)
+    payload: dict[str, object] = {
+        "decision_scope": "multi_dataset_a1_a4_reproducibility_followup",
+        "promotion_score_policy": "primary_measured_direct_harvest_only",
+        "primary_measured_dataset_ids": sorted(
+            {str(value) for value in scorecard_df.loc[direct_mask, "dataset_id"]}
+        ),
+        "review_only_dataset_ids": sorted({str(value) for value in scorecard_df.loc[review_mask, "dataset_id"]}),
+        "a3_decision": "keep_shipped_incumbent",
+        "a4_decision": "keep_research_only",
+        "public_proxy_lanes_can_promote_a4": False,
+        "lane_gate_decision": decision_payload,
+    }
+    write_json(paths.promotion_gate_decision_path, _json_tree(payload))
+
+
+__all__ = [
+    "ARCHITECTURE_CODE_BY_LANE",
+    "ARCHITECTURE_FAMILY_BY_LANE",
+    "architecture_code",
+    "architecture_family_id",
+    "write_lane_matrix_reproducibility_artifacts",
+    "write_promotion_gate_decision_artifact",
+]

--- a/tests/test_tomics_lane_matrix_gate.py
+++ b/tests/test_tomics_lane_matrix_gate.py
@@ -337,6 +337,140 @@ def test_lane_matrix_gate_counts_only_audit_passing_measured_datasets_in_denomin
     assert bool(promotion_df.loc[0, "passes"]) is False
 
 
+def test_lane_matrix_gate_excludes_review_only_derived_dw_from_promotion_denominator(tmp_path: Path) -> None:
+    matrix_root = tmp_path / "out" / "tomics" / "validation" / "lane-matrix"
+    matrix_root.mkdir(parents=True, exist_ok=True)
+    base_row = {
+        "scenario_id": "incumbent_current__incumbent_harvest_profile__knu_actual",
+        "allocation_lane_id": "incumbent_current",
+        "harvest_profile_id": "incumbent_harvest_profile",
+        "dataset_id": "knu_actual",
+        "dataset_role": "measured_harvest",
+        "evidence_grade": "direct_measured_harvest",
+        "decision_weight": "promotion_gate",
+        "proxy_caveat": "",
+        "promotion_eligible": True,
+        "reference_only": False,
+        "reporting_basis_in": "floor_area_g_m2",
+        "reporting_basis_canonical": "floor_area_g_m2",
+        "basis_normalization_resolved": True,
+        "rmse_cumulative_offset": 1.0,
+        "r2_cumulative_offset": 0.8,
+        "rmse_daily_increment": 0.5,
+        "fruit_anchor_error": 0.0,
+        "canopy_collapse_days": 0.0,
+        "winner_stability_score": 1.0,
+        "native_state_coverage": 0.9,
+        "shared_tdvs_proxy_fraction": 0.1,
+        "family_separability_score": 0.8,
+        "any_all_zero_harvest_series": False,
+        "dropped_nonharvested_mass_g_m2": 0.0,
+        "offplant_with_positive_mass_flag": False,
+        "runtime_complete_semantics": "explicit_harvested_cumulative_writeback_audited",
+        "selected_family_label": "incumbent",
+        "selected_family_is_native": True,
+        "selected_family_is_proxy": False,
+        "execution_status": "scored",
+        "candidate_label": "shipped_tomics",
+        "architecture_id": "shipped_tomics_control",
+        "partition_policy": "tomics",
+        "mean_alloc_frac_fruit": 0.45,
+        "mean_proxy_family_state_fraction": 0.1,
+    }
+    public_row = {
+        **base_row,
+        "scenario_id": "incumbent_current__incumbent_harvest_profile__public_rda__yield",
+        "dataset_id": "public_rda__yield",
+        "evidence_grade": "review_only_derived_dw",
+        "decision_weight": "review_only_robustness",
+        "proxy_caveat": "derived DW from measured fresh shipment",
+        "rmse_cumulative_offset": 0.2,
+        "r2_cumulative_offset": 0.95,
+    }
+    pd.DataFrame([base_row, public_row]).to_csv(matrix_root / "lane_scorecard.csv", index=False)
+    config = {
+        "validation": {
+            "lane_matrix_gate": {
+                "matrix_root": str(matrix_root),
+                "output_root": str(matrix_root),
+                "min_dataset_count": 2,
+            }
+        }
+    }
+
+    run_lane_matrix_gate(config, repo_root=tmp_path, config_path=tmp_path / "gate.yaml")
+
+    promotion_df = pd.read_csv(matrix_root / "promotion_surface.csv")
+    decision = json.loads((matrix_root / "lane_gate_decision.json").read_text(encoding="utf-8"))
+    promotion_decision = json.loads((matrix_root / "promotion_gate_decision.json").read_text(encoding="utf-8"))
+
+    assert int(decision["measured_dataset_count"]) == 1
+    assert json.loads(promotion_df.loc[0, "dataset_ids"]) == ["knu_actual"]
+    assert "public_rda__yield" not in promotion_df.loc[0, "dataset_ids"]
+    assert promotion_decision["primary_measured_dataset_ids"] == ["knu_actual"]
+    assert promotion_decision["review_only_dataset_ids"] == ["public_rda__yield"]
+    assert promotion_decision["public_proxy_lanes_can_promote_a4"] is False
+
+
+def test_lane_matrix_gate_promotion_decision_matches_legacy_scorecard_denominator(tmp_path: Path) -> None:
+    matrix_root = tmp_path / "out" / "tomics" / "validation" / "lane-matrix"
+    matrix_root.mkdir(parents=True, exist_ok=True)
+    scorecard_df = pd.DataFrame(
+        [
+            {
+                "scenario_id": "incumbent_current__incumbent_harvest_profile__ds1",
+                "allocation_lane_id": "incumbent_current",
+                "harvest_profile_id": "incumbent_harvest_profile",
+                "dataset_id": "ds1",
+                "dataset_role": "measured_harvest",
+                "promotion_eligible": True,
+                "reference_only": False,
+                "reporting_basis_in": "floor_area_g_m2",
+                "reporting_basis_canonical": "floor_area_g_m2",
+                "basis_normalization_resolved": True,
+                "rmse_cumulative_offset": 1.0,
+                "rmse_daily_increment": 0.5,
+                "fruit_anchor_error": 0.0,
+                "canopy_collapse_days": 0.0,
+                "winner_stability_score": 1.0,
+                "native_state_coverage": 0.9,
+                "shared_tdvs_proxy_fraction": 0.1,
+                "family_separability_score": 0.8,
+                "any_all_zero_harvest_series": False,
+                "dropped_nonharvested_mass_g_m2": 0.0,
+                "offplant_with_positive_mass_flag": False,
+                "runtime_complete_semantics": "explicit_harvested_cumulative_writeback_audited",
+                "selected_family_label": "incumbent",
+                "selected_family_is_native": True,
+                "selected_family_is_proxy": False,
+                "execution_status": "scored",
+                "candidate_label": "shipped_tomics",
+                "architecture_id": "shipped_tomics_control",
+                "partition_policy": "tomics",
+                "mean_alloc_frac_fruit": 0.45,
+                "mean_proxy_family_state_fraction": 0.1,
+            }
+        ]
+    )
+    scorecard_df.to_csv(matrix_root / "lane_scorecard.csv", index=False)
+    config = {
+        "validation": {
+            "lane_matrix_gate": {
+                "matrix_root": str(matrix_root),
+                "output_root": str(matrix_root),
+                "min_dataset_count": 1,
+            }
+        }
+    }
+
+    run_lane_matrix_gate(config, repo_root=tmp_path, config_path=tmp_path / "gate.yaml")
+
+    lane_decision = json.loads((matrix_root / "lane_gate_decision.json").read_text(encoding="utf-8"))
+    promotion_decision = json.loads((matrix_root / "promotion_gate_decision.json").read_text(encoding="utf-8"))
+    assert lane_decision["measured_dataset_count"] == 1
+    assert promotion_decision["primary_measured_dataset_ids"] == ["ds1"]
+
+
 def test_lane_matrix_gate_measured_dataset_count_uses_only_promotion_passing_rows(tmp_path: Path) -> None:
     matrix_root = tmp_path / "out" / "tomics" / "validation" / "lane-matrix"
     matrix_root.mkdir(parents=True, exist_ok=True)

--- a/tests/test_tomics_lane_matrix_registry.py
+++ b/tests/test_tomics_lane_matrix_registry.py
@@ -7,6 +7,7 @@ import pytest
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.datasets.contracts import (
     DatasetBasisContract,
+    DatasetDryMatterConversionContract,
     DatasetManagementMetadata,
     DatasetMetadataContract,
     DatasetObservationContract,
@@ -140,6 +141,62 @@ def test_dataset_roles_do_not_auto_promote_yield_environment() -> None:
     assert role_map["traitenv_context"].dataset_role == "trait_plus_env_no_harvest"
     assert role_map["yield_env_only"].dataset_role == "yield_environment_only"
     assert role_map["yield_env_only"].promotion_denominator_eligible is False
+
+
+def test_review_only_derived_dw_harvest_stays_out_of_promotion_denominator() -> None:
+    fixture_root = Path("data") / "fixtures" / "public_rda_sanitized" / "slice"
+    dataset = DatasetMetadataContract(
+        dataset_id="public_rda__yield",
+        dataset_kind="traitenv_candidate",
+        display_name="Public RDA yield",
+        dataset_family="public_rda",
+        observation_family="yield",
+        capability="measured_harvest",
+        ingestion_status="runnable",
+        forcing_path=fixture_root / "forcing_fixture.csv",
+        observed_harvest_path=fixture_root / "observed_harvest_fixture.csv",
+        validation_start="2019-01-17",
+        validation_end="2019-06-30",
+        cultivar="deirose",
+        greenhouse="vinyl",
+        season="season1",
+        basis=DatasetBasisContract(reporting_basis="floor_area_g_m2", plants_per_m2=4.0),
+        observation=DatasetObservationContract(
+            date_column="Date",
+            measured_cumulative_column="Measured_Cumulative_Total_Fruit_DW (g/m^2)",
+            measured_semantics="cumulative_harvested_fruit_dry_weight_floor_area",
+        ),
+        dry_matter_conversion=DatasetDryMatterConversionContract(
+            mode="derived_dw_from_measured_fresh_shipment",
+            fresh_weight_column="raw_total_shipment_kg",
+            dry_matter_ratio=0.065,
+            citations=("fixture provenance",),
+            review_only=True,
+        ),
+        management=DatasetManagementMetadata(),
+        sanitized_fixture=DatasetSanitizedFixtureContract(
+            forcing_fixture_path=fixture_root / "forcing_fixture.csv",
+            observed_harvest_fixture_path=fixture_root / "observed_harvest_fixture.csv",
+        ),
+        notes={
+            "dataset_role_hint": "measured_harvest",
+            "observed_harvest_derivation": "derived_dw_from_measured_fresh_shipment",
+            "is_direct_dry_weight": False,
+            "uses_literature_dry_matter_fraction": True,
+            "review_flags": ["review_only_dry_matter_conversion"],
+            "floor_area_basis_source": "fixture provenance floor area",
+            "dry_matter_conversion_method": "fresh shipment * 0.065 / floor area",
+            "dry_matter_conversion_provenance": "fixture provenance",
+        },
+    )
+    role = resolve_dataset_roles(DatasetRegistry(datasets=(dataset,), default_dataset_ids=("public_rda__yield",)))[0]
+
+    assert role.dataset_role == "measured_harvest"
+    assert role.evidence_grade == "review_only_derived_dw"
+    assert role.decision_weight == "review_only_robustness"
+    assert role.promotion_denominator_eligible is False
+    assert role.is_direct_dry_weight is False
+    assert role.observed_harvest_derivation == "derived_dw_from_measured_fresh_shipment"
 
 
 def test_dataset_role_registry_rejects_unknown_requested_dataset() -> None:


### PR DESCRIPTION
## Summary
- Add `configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml` for A1-A4 validation across `knu_actual`, `public_rda__yield`, and `public_ai_competition__yield`.
- Add lane-matrix summary artifacts that separate direct measured evidence from review-only derived-DW public lanes.
- Keep public RDA and public AI competition out of the promotion denominator while preserving them as reproducibility/robustness lanes.
- Document the multi-dataset follow-up in the A1-A4 architecture review.

## Dataset roles
- `knu_actual`: `direct_measured_harvest`, `promotion_gate`
- `public_rda__yield`: `review_only_derived_dw`, `review_only_robustness`
- `public_ai_competition__yield`: `review_only_derived_dw`, `review_only_robustness`

## Validation
- `poetry run python scripts/run_tomics_lane_matrix.py --config configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml`
- `poetry run python scripts/run_tomics_lane_matrix_gate.py --config configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml`
- `poetry run pytest tests/test_tomics_lane_matrix_registry.py tests/test_tomics_lane_matrix_gate.py tests/test_cross_dataset_scorecard.py tests/test_cross_dataset_gate.py tests/test_tomics_multidataset_harvest_factorial_runner.py -q`
- `poetry run ruff check .`
- `poetry run pytest -q`

## Notes
The generated output bundle is under `out/tomics_a1_a4_multidataset_lane_matrix/` and is intentionally not committed because `out/` is ignored. The smoke run produced all required artifacts, but the promotion gate remains blocked by harvested-writeback guardrails in the current sanitized smoke surface. A3 remains the shipped incumbent and A4 remains research-only.

Closes #304