### PR TITLE
[Bug] Restore TOMICS lane matrix harvest writeback diagnostics

### DIFF
--- a/configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml
+++ b/configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml
@@ -73,7 +73,7 @@ validation:
     output_root: out/tomics_a1_a4_multidataset_lane_matrix
     theta_proxy_scenario: moderate
     allow_state_reconstruction_fallback: true
-    state_reconstruction_fallback_policy: smoke_only_default_init_when_reconstruction_fails
+    state_reconstruction_fallback_policy: smoke_only_observed_seed_init_when_reconstruction_fails
     dataset_ids:
       - knu_actual
       - public_rda__yield

--- a/docs/architecture/review/tomics-a1-a4-allocation-factorial-selection.md
+++ b/docs/architecture/review/tomics-a1-a4-allocation-factorial-selection.md
@@ -225,6 +225,14 @@ The lane gate therefore keeps `primary_measured_score.json` separate from
 `review_only_public_score.json` and does not pool those values into one promotion score.
 No raw/private KNU data are committed by this follow-up.
 
+Issue #306 tightens the same lane matrix without changing allocation behavior.
+Dataset forcing is clipped to each declared validation window before the measured-harvest runtime is prepared,
+so public RDA no longer injects observed-window initial state at the earlier crop-start forcing date.
+If reconstruction fails on a short review-only smoke lane, the fallback now uses observed-harvest seeded
+cohort initialization instead of an empty default state. The `any_all_zero_harvest_series` guard now means
+both the model cumulative harvested series and the model increment series are all-zero; zero increment-only
+cases remain visible in `all_zero_model_daily_increment_series`.
+
 ## Next minimal issue
 
 After #304 lands, use the generated multi-dataset bundle to choose the next narrow validation dependency rather

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/runtime.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/datasets/runtime.py
@@ -297,9 +297,18 @@ def prepare_dataset_runtime_bundle(
 
     if dataset.forcing_path is None:
         raise ValueError(f"Dataset {dataset.dataset_id!r} does not define a forcing_path.")
-    forcing_df = read_knu_forcing_csv(dataset.forcing_path)
     validation_start = pd.Timestamp(dataset.validation_start).normalize()
     validation_end = pd.Timestamp(dataset.validation_end).normalize()
+    forcing_df = _filter_by_validation_window(
+        read_knu_forcing_csv(dataset.forcing_path),
+        validation_start=validation_start,
+        validation_end=validation_end,
+    )
+    if forcing_df.empty:
+        raise ValueError(
+            f"Dataset {dataset.dataset_id!r} did not retain any forcing rows inside "
+            f"{dataset.validation_start}..{dataset.validation_end}."
+        )
     normalization_factor = _normalization_factor(dataset)
     rootzone_path = dataset.management.rootzone_path
     rootzone_ec_path = dataset.management.ec_path

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/init_search.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/init_search.py
@@ -63,14 +63,17 @@ def _fruit_cohorts(
         return []
     weights = [float(idx + 1) for idx in range(active_trusses)]
     total_weight = sum(weights)
-    tdvs_values = [0.35 + 0.55 * idx / max(active_trusses - 1, 1) for idx in range(active_trusses)]
+    # Seed the oldest reconstructed truss at TOMSIM harvest readiness so short
+    # validation windows can exercise harvested writeback without lowering the
+    # incumbent harvest threshold.
+    tdvs_values = [0.35 + 0.65 * idx / max(active_trusses - 1, 1) for idx in range(active_trusses)]
     cohorts: list[dict[str, object]] = []
     for idx in range(active_trusses):
         runtime_seed = _runtime_seed(tdvs=tdvs_values[idx], cohort_index=idx)
         cohorts.append(
             {
                 "entity_id": f"truss_{idx + 1:04d}",
-                "tdvs": min(tdvs_values[idx], 0.98),
+                "tdvs": min(tdvs_values[idx], 1.0),
                 "n_fruits": n_fruits_per_truss,
                 "w_fr_cohort": fruit_mass_g_m2 * weights[idx] / total_weight,
                 "active": bool(runtime_seed["sink_active_flag"]),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py
@@ -29,6 +29,19 @@ def _all_zero_series(frame: pd.DataFrame, column: str) -> bool:
     return bool((series.abs() <= 1e-12).all())
 
 
+def _harvest_series_diagnostics(validation_df: pd.DataFrame) -> dict[str, bool]:
+    zero_increment = _all_zero_series(validation_df, "model_daily_increment_floor_area")
+    zero_cumulative = _all_zero_series(
+        validation_df,
+        "model_cumulative_harvested_fruit_dry_weight_floor_area",
+    )
+    return {
+        "all_zero_model_daily_increment_series": zero_increment,
+        "all_zero_model_cumulative_harvest_series": zero_cumulative,
+        "any_all_zero_harvest_series": bool(zero_increment and zero_cumulative),
+    }
+
+
 def _runtime_complete(validation_df: pd.DataFrame, metrics: dict[str, object]) -> str:
     required_columns = {
         "model_cumulative_harvested_fruit_dry_weight_floor_area",
@@ -86,6 +99,8 @@ def build_context_only_lane_scorecard_row(
         "shared_tdvs_proxy_fraction": math.nan,
         "family_separability_score": math.nan,
         "any_all_zero_harvest_series": False,
+        "all_zero_model_daily_increment_series": False,
+        "all_zero_model_cumulative_harvest_series": False,
         "dropped_nonharvested_mass_g_m2": 0.0,
         "offplant_with_positive_mass_flag": False,
         "runtime_complete_semantics": RUNTIME_UNRESOLVED,
@@ -121,6 +136,7 @@ def build_lane_scorecard_row(
     native_state_coverage = float(metrics.get("native_family_state_fraction", 0.0))
     shared_tdvs_proxy_fraction = float(metrics.get("shared_tdvs_proxy_fraction", 0.0))
     proxy_fraction = float(metrics.get("proxy_family_state_fraction", 0.0))
+    harvest_series = _harvest_series_diagnostics(validation_df)
     return {
         "scenario_id": scenario.scenario_id,
         "allocation_lane_id": scenario.allocation_lane.lane_id,
@@ -147,10 +163,7 @@ def build_lane_scorecard_row(
         "native_state_coverage": native_state_coverage,
         "shared_tdvs_proxy_fraction": shared_tdvs_proxy_fraction,
         "family_separability_score": max(native_state_coverage - shared_tdvs_proxy_fraction, 0.0),
-        "any_all_zero_harvest_series": bool(
-            _all_zero_series(validation_df, "model_daily_increment_floor_area")
-            or _all_zero_series(validation_df, "model_cumulative_harvested_fruit_dry_weight_floor_area")
-        ),
+        **harvest_series,
         "dropped_nonharvested_mass_g_m2": float(metrics.get("post_writeback_dropped_nonharvested_mass_g_m2", 0.0)),
         "offplant_with_positive_mass_flag": bool(metrics.get("offplant_with_positive_mass_flag", False)),
         "runtime_complete_semantics": _runtime_complete(validation_df, metrics),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py
@@ -24,6 +24,9 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_calibr
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.harvest_family_eval import (
     run_harvest_family_simulation,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.init_search import (
+    build_reconstruction_candidates,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.allocation_lane_registry import (
     resolve_allocation_lanes,
 )
@@ -168,6 +171,19 @@ def _build_diagnostic_observed_df(*, validation_start: pd.Timestamp, validation_
             "estimated_daily_increment_floor_area": pd.Series([pd.NA] * len(dates), dtype="Float64"),
         }
     )
+
+
+def _fallback_initial_state_overrides(observed_df: pd.DataFrame) -> dict[str, object]:
+    candidates = build_reconstruction_candidates(
+        observed_df,
+        modes=("cohort_aware_init", "buffer_aware_init", "minimal_scalar_init"),
+    )
+    if not candidates:
+        return {}
+    for candidate in candidates:
+        if candidate.mode == "cohort_aware_init":
+            return dict(candidate.initial_state_overrides)
+    return dict(candidates[0].initial_state_overrides)
 
 
 def run_lane_matrix(
@@ -394,8 +410,8 @@ def run_lane_matrix(
             except (RuntimeError, ValueError) as error:
                 if not allow_reconstruction_fallback:
                     raise
-                initial_state_overrides = {}
-                reconstruction_status = "fallback_default_init"
+                initial_state_overrides = _fallback_initial_state_overrides(bundle.observed_df)
+                reconstruction_status = "fallback_observed_seed_init"
                 reconstruction_error = f"{type(error).__name__}: {error}"
             else:
                 initial_state_overrides = dict(reconstruction.initial_state_overrides)

--- a/tests/test_multidataset_runtime.py
+++ b/tests/test_multidataset_runtime.py
@@ -161,6 +161,8 @@ def test_prepare_measured_harvest_bundle_honors_contract_columns_and_basis_conve
     assert list(bundle.observed_df["date"].dt.strftime("%Y-%m-%d")) == ["2025-01-02", "2025-01-03"]
     assert list(bundle.observed_df["measured_cumulative_total_fruit_dry_weight_floor_area"]) == [4.0, 6.0]
     assert list(bundle.observed_df["estimated_cumulative_total_fruit_dry_weight_floor_area"]) == [4.2, 6.2]
+    forcing_df = pd.read_csv(bundle.scenarios["moderate"].forcing_csv_path)
+    assert list(pd.to_datetime(forcing_df["datetime"]).dt.strftime("%Y-%m-%d")) == ["2025-01-02", "2025-01-03"]
     assert bundle.reporting_basis_in == "g_per_plant"
     assert bundle.reporting_basis_canonical == "floor_area_g_m2"
     assert bundle.basis_normalization_resolved is True

--- a/tests/test_tomics_knu_state_reconstruction.py
+++ b/tests/test_tomics_knu_state_reconstruction.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
+
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import load_config
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.current_vs_promoted import (
     prepare_knu_bundle,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.init_search import (
+    build_reconstruction_candidates,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.state_reconstruction import (
     reconstruct_hidden_state,
@@ -45,3 +50,22 @@ def test_state_reconstruction_returns_supported_mode_and_initial_state(tmp_path:
     assert "W_fr_harvested" in result.initial_state_overrides
     assert "W_lv" in result.initial_state_overrides
     assert result.metrics["init_fit_score"] == result.metrics["init_fit_score"]
+
+
+def test_cohort_reconstruction_seeds_harvest_ready_oldest_truss() -> None:
+    observed_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-01-01", "2025-01-02"]),
+            "measured_cumulative_total_fruit_dry_weight_floor_area": [5.0, 8.0],
+            "measured_daily_increment_floor_area": [pd.NA, 3.0],
+        }
+    )
+
+    candidates = build_reconstruction_candidates(observed_df, modes=("cohort_aware_init",))
+    cohort_candidates = [candidate for candidate in candidates if candidate.mode == "cohort_aware_init"]
+    assert cohort_candidates
+
+    truss_cohorts = cohort_candidates[0].initial_state_overrides["truss_cohorts"]
+    oldest = max(truss_cohorts, key=lambda row: float(row["tdvs"]))
+    assert float(oldest["tdvs"]) >= 1.0
+    assert oldest["harvest_ready_flag"] is True

--- a/tests/test_tomics_lane_matrix.py
+++ b/tests/test_tomics_lane_matrix.py
@@ -38,6 +38,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.da
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.lane_matrix.lane_scorecard import (
     RUNTIME_COMPLETE_SEMANTICS,
+    _harvest_series_diagnostics,
     promotion_audit_passes,
 )
 
@@ -246,6 +247,21 @@ def test_promotion_audit_exclusions_cover_basis_and_writeback_flags() -> None:
     assert not promotion_audit_passes(pd.Series({**clean_payload, "dropped_nonharvested_mass_g_m2": 0.1}))
     assert not promotion_audit_passes(pd.Series({**clean_payload, "offplant_with_positive_mass_flag": True}))
     assert not promotion_audit_passes(pd.Series({**clean_payload, "basis_normalization_resolved": False}))
+
+
+def test_harvest_series_diagnostic_all_zero_requires_missing_cumulative_and_increment() -> None:
+    frame = pd.DataFrame(
+        {
+            "model_cumulative_harvested_fruit_dry_weight_floor_area": [2.4, 2.4, 2.4],
+            "model_daily_increment_floor_area": [pd.NA, 0.0, 0.0],
+        }
+    )
+
+    diagnostics = _harvest_series_diagnostics(frame)
+
+    assert diagnostics["all_zero_model_daily_increment_series"] is True
+    assert diagnostics["all_zero_model_cumulative_harvest_series"] is False
+    assert diagnostics["any_all_zero_harvest_series"] is False
 
 
 def test_lane_gate_keeps_raw_reference_only_in_diagnostics(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary
- Closes #306.
- Clips dataset forcing to the declared validation window before TOMICS measured-harvest runtime preparation.
- Replaces empty lane-matrix reconstruction fallback with observed-harvest seeded cohort initialization for short smoke lanes.
- Narrows `any_all_zero_harvest_series` to mean both cumulative harvested and increment series are all-zero, while preserving zero-increment diagnostics separately.

## Validation
- `poetry run python scripts/run_tomics_lane_matrix.py --config configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml`
- `poetry run python scripts/run_tomics_lane_matrix_gate.py --config configs/exp/tomics_a1_a4_multidataset_lane_matrix.yaml`
- `poetry run pytest tests/test_tomics_lane_matrix_registry.py tests/test_tomics_lane_matrix_gate.py tests/test_cross_dataset_scorecard.py tests/test_cross_dataset_gate.py tests/test_tomics_multidataset_harvest_factorial_runner.py tests/test_multidataset_runtime.py tests/test_tomics_knu_state_reconstruction.py tests/test_tomics_lane_matrix.py::test_harvest_series_diagnostic_all_zero_requires_missing_cumulative_and_increment -q`
- `poetry run ruff check .`

## Result
- `any_all_zero_harvest_series = false` for KNU, public RDA, and public AI competition lanes.
- Public RDA now has nonzero cumulative and interval harvest movement inside its validation window.
- KNU and public AI still expose `all_zero_model_daily_increment_series = true`, so the caveat is visible rather than hidden.
- A3 remains shipped incumbent; A4 remains research-only.
