### PR TITLE
[TOMICS] Add HAF 2025-2C observer pipeline

### DIFF
--- a/configs/exp/tomics_haf_2025_2c_input_schema_audit.yaml
+++ b/configs/exp/tomics_haf_2025_2c_input_schema_audit.yaml
@@ -1,0 +1,16 @@
+exp:
+  name: tomics_haf_2025_2c_input_schema_audit
+
+paths:
+  repo_root: ../..
+
+tomics_haf:
+  season_id: "2025_2C"
+  raw_filename_note: "some raw filenames contain 2026_2; evaluation season is user-defined as 2025 second cropping cycle."
+  raw_data_root: artifacts/tomato_integrated_radiation_architecture_v1_3/input_raw
+  output_root: out/tomics/analysis/haf_2025_2c
+  input_files:
+    fruit_leaf_temperature_solar_raw_dat: "2026_2작기_토마토_엽온_과실직경.dat"
+    dataset1: dataset1_loadcell_1_6_daily_ec_moisture_yield_env.parquet
+    dataset2: dataset2_loadcell_4_5_daily_ec_moisture_tensiometer.parquet
+    dataset3: dataset3_individual_stem_diameter_flower_height_flowering_date.parquet

--- a/configs/exp/tomics_haf_2025_2c_observer_pipeline.yaml
+++ b/configs/exp/tomics_haf_2025_2c_observer_pipeline.yaml
@@ -1,0 +1,27 @@
+exp:
+  name: tomics_haf_2025_2c_observer_pipeline
+
+paths:
+  repo_root: ../..
+
+tomics_haf:
+  season_id: "2025_2C"
+  raw_filename_note: "Some raw filenames contain 2026_2; biological evaluation season is user-defined as 2025 second cropping cycle."
+  raw_data_root: artifacts/tomato_integrated_radiation_architecture_v1_3/input_raw
+  output_root: out/tomics/analysis/haf_2025_2c
+  sensor_mapping_path: configs/sensor_mapping/2025_2c_fruit_leaf_loadcell.yaml
+  input_files:
+    fruit_leaf_temperature_solar_raw_dat: "2026_2작기_토마토_엽온_과실직경.dat"
+    dataset1: dataset1_loadcell_1_6_daily_ec_moisture_yield_env.parquet
+    dataset2: dataset2_loadcell_4_5_daily_ec_moisture_tensiometer.parquet
+    dataset3: dataset3_individual_stem_diameter_flower_height_flowering_date.parquet
+
+observer_pipeline:
+  parquet_batch_size: 250000
+  max_full_rows_without_limit: 2000000
+  # Local smoke caps keep the private run bounded. Remove or raise these caps for a full production observer export.
+  max_rows:
+    dataset1: 1000000
+    dataset2: 500000
+    dataset3:
+

--- a/configs/exp/tomics_haf_2025_2c_observer_pipeline.yaml
+++ b/configs/exp/tomics_haf_2025_2c_observer_pipeline.yaml
@@ -26,3 +26,10 @@ observer_pipeline:
     dataset1: 1000000
     dataset2: 500000
     dataset3:
+
+dmc:
+  canonical_fruit_DMC_fraction: 0.056
+  DMC_fixed_for_2025_2C: true
+  DMC_sensitivity_enabled: false
+  DMC_sensitivity_values: []
+  deprecated_previous_default_fruit_DMC_fraction: 0.065

--- a/configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml
+++ b/configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml
@@ -31,3 +31,19 @@ observer_pipeline:
   write_intermediate_chunk_manifests: true
   fail_on_full_in_memory_large_dataset: true
 
+legacy_v1_3:
+  enabled: true
+  archive_root: artifacts/tomato_integrated_radiation_architecture_v1_3
+  event_bridge_daily_candidates:
+    - previous_outputs/event_bridge_outputs/daily_event_bridged_transpiration.csv
+    - outputs/derived/legacy_daily_event_bridged_transpiration.csv
+  integrated_daily_master: outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv
+  fresh_dry_loadcell_summary: outputs/tables/fresh_dry_weight_loadcell_final_summary.csv
+  fresh_dry_treatment_summary: outputs/tables/fresh_dry_weight_treatment_summary.csv
+  dataset3_traits_plus_yield: outputs/derived/dataset3_traits_plus_fresh_dry_yield.csv
+  provenance_label: legacy_v1_3_derived_output
+  allow_legacy_event_bridge_calibration: true
+  allow_legacy_event_bridge_qc_false: true
+  event_bridge_min_valid_coverage_fraction: 0.0
+  allow_legacy_yield_bridge: true
+  direct_dry_yield_measured: false

--- a/configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml
+++ b/configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml
@@ -1,5 +1,5 @@
 exp:
-  name: tomics_haf_2025_2c_observer_pipeline
+  name: tomics_haf_2025_2c_observer_pipeline_production
 
 paths:
   repo_root: ../..
@@ -17,12 +17,17 @@ tomics_haf:
     dataset3: dataset3_individual_stem_diameter_flower_height_flowering_date.parquet
 
 observer_pipeline:
-  mode: smoke
+  mode: production
   parquet_batch_size: 250000
   max_full_rows_without_limit: 2000000
-  fail_on_full_in_memory_large_dataset: true
-  # Local smoke caps keep the private run bounded. Remove or raise these caps for a full production observer export.
   max_rows:
-    dataset1: 1000000
-    dataset2: 500000
+    dataset1:
+    dataset2:
     dataset3:
+  require_chunk_aggregation: true
+  require_row_cap_absent_for_production: true
+  require_dataset1_full_processed: true
+  require_dataset2_full_processed: true
+  write_intermediate_chunk_manifests: true
+  fail_on_full_in_memory_large_dataset: true
+

--- a/configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml
+++ b/configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml
@@ -31,6 +31,13 @@ observer_pipeline:
   write_intermediate_chunk_manifests: true
   fail_on_full_in_memory_large_dataset: true
 
+dmc:
+  canonical_fruit_DMC_fraction: 0.056
+  DMC_fixed_for_2025_2C: true
+  DMC_sensitivity_enabled: false
+  DMC_sensitivity_values: []
+  deprecated_previous_default_fruit_DMC_fraction: 0.065
+
 legacy_v1_3:
   enabled: true
   archive_root: artifacts/tomato_integrated_radiation_architecture_v1_3

--- a/configs/sensor_mapping/2025_2c_fruit_leaf_loadcell.yaml
+++ b/configs/sensor_mapping/2025_2c_fruit_leaf_loadcell.yaml
@@ -1,0 +1,60 @@
+season_id: "2025_2C"
+
+raw_filename_note: "Some raw filenames contain 2026_2; biological evaluation season is user-defined as 2025 second cropping cycle."
+
+timestamp_col: "TIMESTAMP"
+record_col: "RECORD"
+cadence_minutes: 10
+
+raw_columns:
+  leaf_temperature_1: "LeafTemp1_Avg"
+  leaf_temperature_2: "LeafTemp2_Avg"
+  fruit_diameter_1: "Fruit1Diameter_Avg"
+  fruit_diameter_2: "Fruit2Diameter_Avg"
+  solar_radiation: "SolarRad_Avg"
+
+loadcell_treatment_map:
+  1: "Control"
+  2: "Control"
+  3: "Control"
+  4: "Drought"
+  5: "Drought"
+  6: "Drought"
+
+leaf_sensor_map:
+  LeafTemp1_Avg:
+    loadcell_id: 4
+    treatment: "Drought"
+    mapping_status: "confirmed_by_user"
+  LeafTemp2_Avg:
+    loadcell_id: 1
+    treatment: "Control"
+    mapping_status: "confirmed_by_user"
+
+fruit_sensor_map:
+  Fruit1Diameter_Avg:
+    loadcell_id: 4
+    treatment: "Drought"
+    mapping_status: "provisional"
+  Fruit2Diameter_Avg:
+    loadcell_id: 1
+    treatment: "Control"
+    mapping_status: "provisional"
+
+metadata:
+  biological_replication: false
+  sensor_level_only: true
+  fruit_diameter_inference_level: "sensor_level_descriptive_only"
+  fruit_diameter_allowed_use: "apparent_growth_observer"
+  fruit_diameter_disallowed_use:
+    - "replicated_treatment_effect_test"
+    - "p_value_for_treatment_effect"
+    - "allocation_parameter_calibration"
+    - "hydraulic_growth_gate_calibration"
+    - "model_promotion_gate"
+  leaf_temperature_allowed_use: "paired_leaf_thermal_observer"
+  leaf_mapping_status: "confirmed_by_user"
+  fruit_mapping_status: "provisional"
+  fruit_diameter_p_values_allowed: false
+  fruit_diameter_allocation_calibration_target: false
+

--- a/configs/sensor_mapping/2025_2c_fruit_leaf_loadcell.yaml
+++ b/configs/sensor_mapping/2025_2c_fruit_leaf_loadcell.yaml
@@ -57,4 +57,3 @@ metadata:
   fruit_mapping_status: "provisional"
   fruit_diameter_p_values_allowed: false
   fruit_diameter_allocation_calibration_target: false
-

--- a/docs/architecture/review/tomics-lane-matrix-daily-increment-diagnostics.md
+++ b/docs/architecture/review/tomics-lane-matrix-daily-increment-diagnostics.md
@@ -123,4 +123,3 @@ series is all zero.
 
 For short review-only public smoke lanes, keep the resulting warning explicit
 instead of using the lane for promotion.
-

--- a/docs/architecture/review/tomics-lane-matrix-daily-increment-diagnostics.md
+++ b/docs/architecture/review/tomics-lane-matrix-daily-increment-diagnostics.md
@@ -1,0 +1,126 @@
+# TOMICS Lane-Matrix Daily Increment Diagnostics
+
+Issue: #308
+
+## Executive Summary
+
+The remaining `all_zero_model_daily_increment_series=true` rows in the A1-A4
+multi-dataset lane matrix are not a recurrence of the broader harvested
+writeback bug fixed in #307. The cumulative model harvest series is nonzero,
+so `any_all_zero_harvest_series=false` is correct.
+
+The residual daily-increment flag has two dataset-specific causes:
+
+- `knu_actual`: the four-row sanitized smoke window seeds the first cumulative
+  harvested value but does not generate a harvest event inside the scored
+  window.
+- `public_ai_competition__yield`: the fallback seeded cohort harvests on the
+  first observed date, so the event is present in the mass-balance trace but
+  invisible to a `.diff()`-based observed-row daily increment comparison.
+
+`public_rda__yield` is not the blocker for this diagnostic pass.
+
+## Scope
+
+This diagnostic does not change the shipped `partition_policy: tomics`
+behavior, does not promote A4, and does not alter production allocation logic.
+Public derived-DW datasets remain review-only robustness lanes and are not
+promotion evidence.
+
+## Code Path Inspected
+
+- `scripts/run_tomics_lane_matrix.py`
+- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/matrix_runner.py`
+- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/lane_matrix/lane_scorecard.py`
+- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_family_eval.py`
+- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/harvest_operator.py`
+- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/init_search.py`
+- `src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/state_reconstruction.py`
+
+The scorecard flag is computed from the validation overlay's
+`model_daily_increment_floor_area` column. The model daily increment is derived
+from daily-last cumulative `harvested_fruit_g_m2` using `.diff()`, and the
+first observed row has no increment by construction.
+
+## Artifact Evidence
+
+Primary artifact root:
+
+- `out/tomics_a1_a4_multidataset_lane_matrix/`
+
+Representative incumbent lane:
+
+- `scenarios/incumbent_current__incumbent_harvest_profile__knu_actual/`
+- `scenarios/incumbent_current__incumbent_harvest_profile__public_ai_competition__yield/`
+
+### KNU
+
+Validation overlay:
+
+| date | measured cumulative | measured increment | model cumulative | model increment |
+| --- | ---: | ---: | ---: | ---: |
+| 2024-08-08 | 2.4 | n/a | 2.4 | n/a |
+| 2024-08-09 | 4.1 | 1.7 | 2.4 | 0.0 |
+| 2024-08-10 | 6.9 | 2.8 | 2.4 | 0.0 |
+| 2024-08-11 | 10.2 | 3.3 | 2.4 | 0.0 |
+
+Harvest mass-balance evidence:
+
+- `fruit_harvest_flux_g_m2_d=0.0` for all four scored days.
+- `eligible_harvest_mass_g_m2=0.0` for all four scored days.
+- `mature_onplant_mass_g_m2=0.0` for all four scored days.
+- `family_state_mode=shared_tdvs_proxy`.
+- `native_family_state_fraction=0.0`.
+
+Diagnosis: the nonzero cumulative model series is the initial harvested seed,
+not generated harvest during the four-day smoke window. The daily-zero flag is
+therefore scientifically meaningful for KNU.
+
+### Public AI Competition
+
+Validation overlay:
+
+| date | measured cumulative | measured increment | model cumulative | model increment |
+| --- | ---: | ---: | ---: | ---: |
+| 2024-01-19 | 7.1487 | n/a | 16.5282 | n/a |
+| 2024-01-26 | 16.5282 | 9.3795 | 16.5282 | 0.0 |
+
+Harvest mass-balance evidence:
+
+- `fruit_harvest_flux_g_m2_d=9.3795` on 2024-01-19.
+- `eligible_harvest_mass_g_m2=16.414125` on 2024-01-19.
+- `mature_onplant_mass_g_m2=16.414125` on 2024-01-19.
+- Later scored interval increment is 0.0.
+- `family_state_mode=native_payload`.
+- `native_family_state_fraction=1.0`.
+
+Diagnosis: public AI does generate a model harvest event, but it lands on the
+first observed date. Because daily increments are scored by differencing
+observed-row cumulative values, the first-day event is not represented as a
+finite increment, and the only finite observed-row model increment is 0.0.
+
+## Decision
+
+This is not a production allocator bug and not a scorecard false positive.
+The scorecard is correctly reporting that the finite observed-row model daily
+increment series is all zero.
+
+The issue is a validation-surface mismatch:
+
+- KNU needs either a longer/direct measured validation fixture window or a
+  reconstruction objective that rejects seeded-only fits when measured
+  increments are positive.
+- Public AI needs either pre-roll alignment or a fallback seeding policy that
+  prevents the only harvest event from landing on the first unscored increment
+  row.
+
+## Next Minimal Fix Candidate
+
+Add a reconstruction/fallback guard in a follow-up patch: when the observed
+finite daily increments contain positive values, penalize or reject
+reconstruction candidates whose finite scored `model_daily_increment_floor_area`
+series is all zero.
+
+For short review-only public smoke lanes, keep the resulting warning explicit
+instead of using the lane for promotion.
+

--- a/docs/architecture/tomics/event_bridge_calibration_contract.md
+++ b/docs/architecture/tomics/event_bridge_calibration_contract.md
@@ -1,0 +1,14 @@
+# Event Bridge Calibration Contract
+
+The production observer export derives 10-minute loadcell water-loss intervals from current Dataset1 rows. Legacy v1.3 daily event-bridged totals may be used only as a provenance-tagged calibration target.
+
+Calibration is allowed only when:
+
+- `date`, `loadcell_id`, and `treatment` match.
+- The legacy daily total is finite.
+- `valid_coverage_fraction` passes the configured threshold.
+- `primary_event_bridge_qc` is acceptable or explicitly allowed.
+
+If no legacy source is available or no rows match, calibrated interval values remain unavailable and metadata reports an uncalibrated status. The pipeline must not fake calibrated ET.
+
+Day/night phases remain radiation-defined from Dataset1 `env_inside_radiation_wm2`, not fixed 06:00-18:00.

--- a/docs/architecture/tomics/fresh_dry_yield_bridge_contract.md
+++ b/docs/architecture/tomics/fresh_dry_yield_bridge_contract.md
@@ -1,0 +1,15 @@
+# Fresh/Dry Yield Bridge Contract
+
+Goal 3A.5 may bridge fresh/dry yield values from legacy v1.3 derived outputs with explicit provenance. These outputs are not raw observations.
+
+Fresh yield fields such as `loadcell_daily_yield_g`, `loadcell_cumulative_yield_g`, and `final_fresh_yield_g` are treated as measured-or-legacy fresh-yield bridge values when their source passes schema checks.
+
+Dry yield fields with DMC labels are estimated dry-yield bases:
+
+- `default_5p6pct`
+- `lower_5p2pct`
+- `upper_6p0pct`
+- `broad_low_4pct`
+- `broad_high_8pct`
+
+DMC-derived dry yield is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified. The legacy default DMC is `0.056`; the configured TOMICS default remains `0.065`. Harvest-family validation must run DMC sensitivity later.

--- a/docs/architecture/tomics/fresh_dry_yield_bridge_contract.md
+++ b/docs/architecture/tomics/fresh_dry_yield_bridge_contract.md
@@ -4,12 +4,24 @@ Goal 3A.5 may bridge fresh/dry yield values from legacy v1.3 derived outputs wit
 
 Fresh yield fields such as `loadcell_daily_yield_g`, `loadcell_cumulative_yield_g`, and `final_fresh_yield_g` are treated as measured-or-legacy fresh-yield bridge values when their source passes schema checks.
 
-Dry yield fields with DMC labels are estimated dry-yield bases:
+For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`.
+
+Dry yield fields with 5.6% DMC labels are mapped to the canonical 2025-2C dry-yield basis:
 
 - `default_5p6pct`
+- `final_dry_yield_g_est_5p6pct`
+- `dry_yield_5p6pct`
+
+Other legacy DMC-labeled columns may be audited as provenance-only sensitivity columns, not current 2025-2C primary metrics:
+
 - `lower_5p2pct`
 - `upper_6p0pct`
 - `broad_low_4pct`
 - `broad_high_8pct`
+- historical or deprecated previous-default `0.065` / 6.5% columns
 
-DMC-derived dry yield is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified. The legacy default DMC is `0.056`; the configured TOMICS default remains `0.065`. Harvest-family validation must run DMC sensitivity later.
+Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
+
+DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics.
+
+Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.

--- a/docs/architecture/tomics/fruit_leaf_loadcell_observer_integration.md
+++ b/docs/architecture/tomics/fruit_leaf_loadcell_observer_integration.md
@@ -1,0 +1,20 @@
+# TOMICS-HAF 2025-2C Fruit/Leaf Loadcell Observer Integration
+
+The fruit and leaf raw `.dat` sensors are integrated as observer diagnostics around existing TOMICS machinery.
+
+Confirmed leaf-temperature mapping:
+
+- `LeafTemp1_Avg` maps to loadcell `4`, treatment `Drought`.
+- `LeafTemp2_Avg` maps to loadcell `1`, treatment `Control`.
+
+Provisional fruit-diameter mapping:
+
+- `Fruit1Diameter_Avg` maps provisionally to loadcell `4`, treatment `Drought`.
+- `Fruit2Diameter_Avg` maps provisionally to loadcell `1`, treatment `Control`.
+
+Fruit diameter is sensor-level apparent expansion diagnostics only. It may be used as a descriptive observer, posterior diagnostic, or hydraulic-realization readout.
+
+Fruit diameter must not be used for treatment p-values, allocation calibration, hydraulic gate calibration, model promotion, or harvest-family promotion targets.
+
+The observer layer writes radiation-phase and fixed-clock compatibility summaries, but day/night phases for downstream observer features are radiation-defined from Dataset1 `env_inside_radiation_wm2`.
+

--- a/docs/architecture/tomics/fruit_leaf_loadcell_observer_integration.md
+++ b/docs/architecture/tomics/fruit_leaf_loadcell_observer_integration.md
@@ -17,4 +17,3 @@ Fruit diameter is sensor-level apparent expansion diagnostics only. It may be us
 Fruit diameter must not be used for treatment p-values, allocation calibration, hydraulic gate calibration, model promotion, or harvest-family promotion targets.
 
 The observer layer writes radiation-phase and fixed-clock compatibility summaries, but day/night phases for downstream observer features are radiation-defined from Dataset1 `env_inside_radiation_wm2`.
-

--- a/docs/architecture/tomics/harvest_aware_promotion_gate.md
+++ b/docs/architecture/tomics/harvest_aware_promotion_gate.md
@@ -1,0 +1,13 @@
+# TOMICS Harvest-Aware Promotion Gate
+
+The harvest-aware promotion gate is not run in Goal 3A.6.
+
+For the later 2025-2C TOMICS-HAF promotion workflow, fruit DMC is fixed at `0.056`. Promotion-gate observation operators must use DMC `0.056` for fresh-to-dry and dry-to-fresh conversions.
+
+Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
+
+DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. DMC sensitivity outputs are not required for the current 2025-2C promotion precondition.
+
+Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C promotion metrics.
+
+Latent allocation remains observer-supported inference, not direct allocation validation.

--- a/docs/architecture/tomics/harvest_family_architecture.md
+++ b/docs/architecture/tomics/harvest_family_architecture.md
@@ -1,0 +1,13 @@
+# TOMICS Harvest-Family Architecture
+
+The shipped TOMICS incumbent remains unchanged.
+
+For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`. This is an analysis-layer decision for the 2025-2C observer and later harvest-family evaluation inputs; it does not silently change generic TOMICS or public-dataset defaults.
+
+Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
+
+DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal.
+
+Any prior `0.065` DMC references are deprecated previous-default notes for the 2025-2C HAF analysis and must not drive current 2025-2C ranking, scoring, promotion, or paper-primary metrics.
+
+Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.

--- a/docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md
+++ b/docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md
@@ -1,0 +1,23 @@
+# TOMICS-HAF 2025-2C Harvest-Family Factorial Design
+
+Goal 3B remains blocked until it is explicitly started. This document records the DMC precondition for that later goal.
+
+For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`.
+
+The 2025-2C observation operator family must include:
+
+- `fresh_to_dry_dmc_0p056`
+- `dry_to_fresh_dmc_0p056`
+
+Goal 3B acceptance criteria:
+
+- DMC default = `0.056`.
+- DMC fixed output exists.
+- Fresh and DMC-estimated dry yield bases are both reported.
+- DMC sensitivity outputs are not required for the current 2025-2C run.
+
+DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics.
+
+Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
+
+Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.

--- a/docs/architecture/tomics/legacy_v1_3_bridge_contract.md
+++ b/docs/architecture/tomics/legacy_v1_3_bridge_contract.md
@@ -1,0 +1,16 @@
+# Legacy v1.3 Bridge Contract
+
+Goal 3A.5 may read selected TOMICS v1.3 derived outputs as provenance-tagged bridge inputs for observer hardening. These files are legacy derived outputs, not raw observations.
+
+Allowed bridge surfaces:
+
+- `previous_outputs/event_bridge_outputs/daily_event_bridged_transpiration.csv`
+- `outputs/derived/legacy_daily_event_bridged_transpiration.csv`
+- `outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv`
+- `outputs/tables/fresh_dry_weight_loadcell_final_summary.csv`
+- `outputs/tables/fresh_dry_weight_treatment_summary.csv`
+- `outputs/derived/dataset3_traits_plus_fresh_dry_yield.csv`
+
+Every imported value must keep `legacy_v1_3_derived_output` provenance. The bridge may calibrate current production event-bridged ET only when date, loadcell, treatment, finite daily total, coverage, and QC checks pass.
+
+The bridge must not change shipped TOMICS defaults, promote any allocator, or convert latent allocation inference into direct validation.

--- a/docs/architecture/tomics/legacy_v1_3_bridge_contract.md
+++ b/docs/architecture/tomics/legacy_v1_3_bridge_contract.md
@@ -13,4 +13,8 @@ Allowed bridge surfaces:
 
 Every imported value must keep `legacy_v1_3_derived_output` provenance. The bridge may calibrate current production event-bridged ET only when date, loadcell, treatment, finite daily total, coverage, and QC checks pass.
 
+For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`. Legacy v1.3 fresh/dry yield outputs are provenance-tagged derived outputs, not raw observations. Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
+
+DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. Prior `0.065` DMC references are deprecated previous-default notes only.
+
 The bridge must not change shipped TOMICS defaults, promote any allocator, or convert latent allocation inference into direct validation.

--- a/docs/architecture/tomics/new_phytologist_readiness_checklist.md
+++ b/docs/architecture/tomics/new_phytologist_readiness_checklist.md
@@ -1,0 +1,19 @@
+# New Phytologist Readiness Checklist
+
+For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`.
+
+Readiness items for yield provenance:
+
+- Fresh yield basis is reported.
+- DMC-estimated dry yield basis is reported with DMC `0.056`.
+- Dry yield derived from fresh yield using DMC `0.056` is explicitly described as estimated, not direct destructive dry-mass measurement unless separately verified.
+- DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal.
+- Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics.
+- Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.
+
+Observer constraints remain:
+
+- Day/night phases remain radiation-defined from Dataset1 `env_inside_radiation_wm2`, not fixed `06:00-18:00`.
+- Fruit diameter remains sensor-level apparent expansion diagnostics.
+- Latent allocation remains observer-supported inference, not direct allocation validation.
+- Shipped TOMICS incumbent remains unchanged.

--- a/docs/architecture/tomics/observer_metadata_contract.md
+++ b/docs/architecture/tomics/observer_metadata_contract.md
@@ -1,0 +1,15 @@
+# Observer Metadata Contract
+
+TOMICS-HAF observer metadata is written with stable top-level canonical keys and no case-insensitive duplicates. This avoids PowerShell-style collisions such as `LAI_available` versus `lai_available` and `VPD_available` versus `vpd_available`.
+
+Canonical top-level keys include:
+
+- `LAI_available`
+- `VPD_available`
+- `Dataset3_mapping_confidence`
+- `fruit_diameter_p_values_allowed`
+- `fruit_diameter_allocation_calibration_target`
+- `fruit_diameter_model_promotion_target`
+- `shipped_TOMICS_incumbent_changed`
+
+Legacy or superseded keys may be retained only under `legacy_metadata`. Stage snapshots are written separately for schema/radiation, observer, and production observer stages so one stage does not silently overwrite another.

--- a/docs/architecture/tomics/pr_309_goal2_5_summary.md
+++ b/docs/architecture/tomics/pr_309_goal2_5_summary.md
@@ -1,0 +1,55 @@
+# PR 309 Goal 2.5 Summary
+
+Suggested PR title:
+
+`[TOMICS] Add HAF 2025-2C observer pipeline`
+
+## Summary
+
+Closes #308
+
+- Preserves the original #308 daily-harvest diagnostic commit.
+- Adds the TOMICS-HAF 2025-2C observer pipeline.
+- Adds production-ready chunk aggregation for full Dataset1/Dataset2 observer export.
+- Keeps Dataset1 `env_inside_radiation_wm2` radiation-defined day/night as primary.
+- Keeps fixed `06:00-18:00` windows compatibility-only.
+- Keeps raw `.dat` `SolarRad_Avg` fallback-only for 2025-2C.
+- Keeps fruit diameter sensor-level apparent expansion diagnostics only.
+- Keeps shipped TOMICS incumbent unchanged.
+- Does not run latent allocation, harvest-family factorial, cross-dataset gate, or promotion gate.
+
+## Validation
+
+- Targeted Goal 2.5 + Goal 2 observer tests: `16 passed`.
+- Ruff: `All checks passed`.
+- Full pytest: `600 passed, 26 skipped, 12 deselected`.
+- Smoke observer run: succeeded with row caps and `production_ready_for_latent_allocation = false`.
+- Production observer run: succeeded with Dataset1 `139,713,462 / 139,713,462` rows and Dataset2 `46,571,154 / 46,571,154` rows processed.
+
+## Production Export
+
+- `observer_pipeline_mode = production`.
+- `chunk_aggregation_used = true`.
+- `full_in_memory_large_dataset_used = false`.
+- `row_cap_applied = false`.
+- `production_export_completed = true`.
+- `production_ready_for_latent_allocation = true`.
+
+## Unresolved Assumptions
+
+- Fruit1/Fruit2 mapping remains provisional.
+- Dataset3 remains `direct_loadcell_no_date` unless verified otherwise.
+- Event-bridged ET remains uncalibrated where existing daily totals are unavailable.
+- LAI and harvest yield remain unavailable unless separately verified.
+- Latent allocation inference is blocked until a later explicit goal.
+
+## Safe Interpretation
+
+Goal 2.5 makes the observer feature frame production-ready for later latent allocation; it does not infer allocation.
+
+Day/night phases remain radiation-defined from Dataset1 `env_inside_radiation_wm2`, not fixed `06:00-18:00`.
+
+Fruit diameter remains sensor-level apparent expansion diagnostics.
+
+Shipped TOMICS incumbent remains unchanged.
+

--- a/docs/architecture/tomics/pr_309_goal2_5_summary.md
+++ b/docs/architecture/tomics/pr_309_goal2_5_summary.md
@@ -35,6 +35,14 @@ Closes #308
 - `production_export_completed = true`.
 - `production_ready_for_latent_allocation = true`.
 
+## Goal 3A.6 DMC Canonicalization
+
+- For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`.
+- Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
+- DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal.
+- Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics.
+- Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.
+
 ## Unresolved Assumptions
 
 - Fruit1/Fruit2 mapping remains provisional.

--- a/docs/architecture/tomics/pr_309_goal2_5_summary.md
+++ b/docs/architecture/tomics/pr_309_goal2_5_summary.md
@@ -52,4 +52,3 @@ Day/night phases remain radiation-defined from Dataset1 `env_inside_radiation_wm
 Fruit diameter remains sensor-level apparent expansion diagnostics.
 
 Shipped TOMICS incumbent remains unchanged.
-

--- a/docs/architecture/tomics/radiation_defined_daynight_contract.md
+++ b/docs/architecture/tomics/radiation_defined_daynight_contract.md
@@ -14,4 +14,3 @@ Fixed `06:00-18:00` windows are not primary. They are compatibility-only outputs
 The raw `.dat` `SolarRad_Avg` column is verified as a fallback candidate for this dataset, but Goal 1 established that Dataset1 radiation is high-frequency and directly usable. Therefore `SolarRad_Avg` remains fallback-only for the 2025-2C observer run.
 
 This contract does not change shipped TOMICS defaults and does not promote any allocator.
-

--- a/docs/architecture/tomics/radiation_defined_daynight_contract.md
+++ b/docs/architecture/tomics/radiation_defined_daynight_contract.md
@@ -1,0 +1,17 @@
+# TOMICS-HAF 2025-2C Radiation-Defined Day/Night Contract
+
+Dataset1 radiation defines day/night phases for the TOMICS-HAF 2025-2C observer layer.
+
+- Primary source: Dataset1.
+- Primary column: `env_inside_radiation_wm2`.
+- Main threshold: `0 W m-2`.
+- Sensitivity thresholds: `0`, `1`, `5`, and `10 W m-2`.
+- Main day: `env_inside_radiation_wm2 > 0`.
+- Main night: `env_inside_radiation_wm2 == 0`.
+
+Fixed `06:00-18:00` windows are not primary. They are compatibility-only outputs for legacy comparison and sensor-QC bookkeeping.
+
+The raw `.dat` `SolarRad_Avg` column is verified as a fallback candidate for this dataset, but Goal 1 established that Dataset1 radiation is high-frequency and directly usable. Therefore `SolarRad_Avg` remains fallback-only for the 2025-2C observer run.
+
+This contract does not change shipped TOMICS defaults and does not promote any allocator.
+

--- a/docs/architecture/tomics/rootzone_rzi_reference_contract.md
+++ b/docs/architecture/tomics/rootzone_rzi_reference_contract.md
@@ -1,0 +1,11 @@
+# Rootzone RZI Reference Contract
+
+Dataset2 contains LC4/LC5 drought-side moisture, EC, and tensiometer observations. It does not by itself provide a control reference for LC1-LC3.
+
+Goal 3A.5 therefore uses Dataset1 LC1-LC6 moisture as the primary control/drought reference when available:
+
+- `RZI_theta_paired = clip(1 - theta_lc4 / (theta_lc1 + eps), 0, 1)`
+- `RZI_theta_group = clip(1 - theta_drought_group / (theta_control_group + eps), 0, 1)`
+- `RZI_main` prefers paired LC4-vs-LC1, then group drought-vs-control, otherwise unavailable.
+
+Dataset2 tensiometer values remain drought-group diagnostics. They are not extrapolated to all loadcells.

--- a/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
+++ b/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
@@ -22,3 +22,4 @@ The observer feature frame is a prerequisite scaffold for later latent allocatio
 
 Shipped TOMICS incumbent behavior remains unchanged.
 
+Goal 2.5 hardens the observer export for production by adding chunk aggregation for full Dataset1 and Dataset2 processing. Smoke mode remains capped for fast local checks, while production mode is expected to process all projected parquet rows without full in-memory materialization. The production observer feature frame is a prerequisite input scaffold for later latent allocation inference; it does not infer allocation.

--- a/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
+++ b/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
@@ -23,3 +23,5 @@ The observer feature frame is a prerequisite scaffold for later latent allocatio
 Shipped TOMICS incumbent behavior remains unchanged.
 
 Goal 2.5 hardens the observer export for production by adding chunk aggregation for full Dataset1 and Dataset2 processing. Smoke mode remains capped for fast local checks, while production mode is expected to process all projected parquet rows without full in-memory materialization. The production observer feature frame is a prerequisite input scaffold for later latent allocation inference; it does not infer allocation.
+
+Goal 3A.6 fixes fruit DMC at `0.056` for the 2025-2C TOMICS-HAF analysis. Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified. DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics. Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.

--- a/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
+++ b/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
@@ -1,0 +1,24 @@
+# TOMICS-HAF 2025-2C Actual Data Observer Pipeline
+
+Goal 1 schema and radiation verification passed for the required 2025-2C raw inputs. Dataset1 `env_inside_radiation_wm2` is directly usable for radiation-defined day/night. The raw `.dat` `SolarRad_Avg` signal is fallback-only and is not required as the primary day/night source for this observer run.
+
+Goal 2 builds a thin TOMICS-HAF observer/profile layer. It produces:
+
+- radiation-defined 10-minute day/night intervals for thresholds `0`, `1`, `5`, and `10 W m-2`;
+- photoperiod tables;
+- event-bridged water-flux interval and daily summaries;
+- fruit/leaf QC and radiation-window observer summaries;
+- fixed `06:00-18:00` compatibility-only summaries;
+- Dataset2 root-zone moisture/EC/tensiometer indices;
+- apparent canopy conductance when VPD is available;
+- Dataset3 growth/phenology bridge outputs;
+- the TOMICS-HAF observer feature frame.
+
+Goal 1 established that VPD is available. LAI is unavailable and is not fabricated. Fresh/dry yield aliases are unavailable under the verified alias contract unless a later source is separately verified.
+
+Dataset3 is direct-loadcell mappable, but date/datetime and truss-position alias limitations remain. Without a safe date key, Dataset3 is emitted as direct-loadcell standalone structural/phenology summaries rather than causal allocation fitting data.
+
+The observer feature frame is a prerequisite scaffold for later latent allocation inference and harvest-family evaluation. Latent allocation inference, harvest-family factorial evaluation, cross-dataset gates, and promotion gates are not run in Goal 2.
+
+Shipped TOMICS incumbent behavior remains unchanged.
+

--- a/docs/architecture/tomics/tomics_haf_2025_2c_production_observer_export.md
+++ b/docs/architecture/tomics/tomics_haf_2025_2c_production_observer_export.md
@@ -11,4 +11,3 @@ Fruit diameter remains sensor-level apparent expansion diagnostics only. It is n
 Full production observer export is a prerequisite for latent allocation inference on actual 2025-2C data. Latent allocation inference, harvest-family factorials, cross-dataset gates, and promotion gates remain blocked until production observer export completes and metadata reports `production_ready_for_latent_allocation = true`.
 
 The production metadata contract records total rows, processed rows, processed fractions, batch counts, row-cap status, chunk aggregation status, water-flux carryover status, and whether full in-memory loading was avoided.
-

--- a/docs/architecture/tomics/tomics_haf_2025_2c_production_observer_export.md
+++ b/docs/architecture/tomics/tomics_haf_2025_2c_production_observer_export.md
@@ -1,0 +1,14 @@
+# TOMICS-HAF 2025-2C Production Observer Export
+
+Goal 2 smoke validation succeeded, but it used bounded row caps for private local runtime safety: Dataset1 was capped at `1,000,000 / 139,713,462` rows and Dataset2 was capped at `500,000 / 46,571,154` rows.
+
+Goal 2.5 adds production chunk aggregation so downstream latent allocation does not run on row-capped observer data. Production mode reads projected parquet batches and aggregates Dataset1 directly to 10-minute loadcell/treatment intervals, while aggregating Dataset2 to daily loadcell/treatment root-zone summaries. Production mode must not concatenate full Dataset1 or Dataset2 into memory.
+
+Dataset1 still defines day/night phases with `env_inside_radiation_wm2`. The main threshold is `0 W m-2`, and sensitivity thresholds remain `0`, `1`, `5`, and `10 W m-2`. Fixed `06:00-18:00` windows remain compatibility-only. raw `.dat` `SolarRad_Avg` remains fallback-only for this 2025-2C dataset.
+
+Fruit diameter remains sensor-level apparent expansion diagnostics only. It is not a treatment endpoint, p-value source, allocation calibration target, hydraulic gate calibration target, or model-promotion target.
+
+Full production observer export is a prerequisite for latent allocation inference on actual 2025-2C data. Latent allocation inference, harvest-family factorials, cross-dataset gates, and promotion gates remain blocked until production observer export completes and metadata reports `production_ready_for_latent_allocation = true`.
+
+The production metadata contract records total rows, processed rows, processed fractions, batch counts, row-cap status, chunk aggregation status, water-flux carryover status, and whether full in-memory loading was avoided.
+

--- a/scripts/run_tomics_haf_input_schema_audit.py
+++ b/scripts/run_tomics_haf_input_schema_audit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import load_config
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_repo_root
+from stomatal_optimiaztion.domains.tomato.tomics.observers import run_tomics_haf_input_schema_audit
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run TOMICS-HAF 2025-2C input schema audit.")
+    parser.add_argument("--config", required=True, help="Path to input schema audit YAML config.")
+    args = parser.parse_args()
+
+    config_path = Path(args.config).resolve()
+    config = load_config(config_path)
+    repo_root = resolve_repo_root(config, config_path=config_path)
+    result = run_tomics_haf_input_schema_audit(config, repo_root=repo_root, config_path=config_path)
+    print(result["output_root"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tomics_haf_observer_pipeline.py
+++ b/scripts/run_tomics_haf_observer_pipeline.py
@@ -29,4 +29,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/run_tomics_haf_observer_pipeline.py
+++ b/scripts/run_tomics_haf_observer_pipeline.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import (
+    run_tomics_haf_observer_pipeline,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the TOMICS-HAF 2025-2C observer pipeline.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/exp/tomics_haf_2025_2c_observer_pipeline.yaml"),
+        help="Path to the observer pipeline config.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = run_tomics_haf_observer_pipeline(args.config)
+    print(json.dumps(result["outputs"], indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/__init__.py
@@ -1,0 +1,33 @@
+"""TOMICS observer/profile utilities.
+
+This package hosts thin observer layers that feed existing TOMICS machinery.
+It does not change shipped TOMICS allocation or harvest-family defaults.
+"""
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.input_schema_audit import (
+    DEFAULT_INPUT_FILE_SPECS,
+    DEFAULT_ROLE_ALIASES,
+    SENSOR_MAPPING_METADATA,
+    audit_input_file,
+    match_semantic_roles,
+    run_tomics_haf_input_schema_audit,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source import (
+    RADIATION_THRESHOLDS_TO_TEST,
+    build_radiation_source_verification,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import (
+    run_tomics_haf_observer_pipeline,
+)
+
+__all__ = [
+    "DEFAULT_INPUT_FILE_SPECS",
+    "DEFAULT_ROLE_ALIASES",
+    "RADIATION_THRESHOLDS_TO_TEST",
+    "SENSOR_MAPPING_METADATA",
+    "audit_input_file",
+    "build_radiation_source_verification",
+    "match_semantic_roles",
+    "run_tomics_haf_observer_pipeline",
+    "run_tomics_haf_input_schema_audit",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/__init__.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/__init__.py
@@ -19,6 +19,10 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source impo
 from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import (
     run_tomics_haf_observer_pipeline,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.observers.production_export import (
+    aggregate_dataset1_streaming,
+    aggregate_dataset2_daily_streaming,
+)
 
 __all__ = [
     "DEFAULT_INPUT_FILE_SPECS",
@@ -26,6 +30,8 @@ __all__ = [
     "RADIATION_THRESHOLDS_TO_TEST",
     "SENSOR_MAPPING_METADATA",
     "audit_input_file",
+    "aggregate_dataset1_streaming",
+    "aggregate_dataset2_daily_streaming",
     "build_radiation_source_verification",
     "match_semantic_roles",
     "run_tomics_haf_observer_pipeline",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
@@ -82,6 +82,8 @@ OUTPUT_FILENAMES = {
     "dataset3_bridge": "2025_2c_dataset3_growth_phenology_bridge.csv",
     "observer_feature_frame": "2025_2c_tomics_haf_observer_feature_frame.csv",
     "metadata": "2025_2c_tomics_haf_metadata.json",
+    "chunk_manifest": "observer_production_chunk_manifest.csv",
+    "production_export_summary": "observer_production_export_summary.md",
 }
 
 
@@ -128,4 +130,3 @@ def base_metadata() -> dict[str, Any]:
         "harvest_family_factorial_run": False,
         "promotion_gate_run": False,
     }
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
@@ -84,6 +84,15 @@ OUTPUT_FILENAMES = {
     "metadata": "2025_2c_tomics_haf_metadata.json",
     "chunk_manifest": "observer_production_chunk_manifest.csv",
     "production_export_summary": "observer_production_export_summary.md",
+    "legacy_bridge_audit": "legacy_v1_3_bridge_audit.csv",
+    "legacy_bridge_audit_json": "legacy_v1_3_bridge_audit.json",
+    "event_bridge_calibration_audit": "event_bridge_calibration_audit.csv",
+    "fresh_dry_yield_bridge_audit": "fresh_dry_yield_bridge_audit.csv",
+    "metadata_contract_audit": "metadata_contract_audit.csv",
+    "rootzone_rzi_reference_audit": "rootzone_rzi_reference_audit.csv",
+    "metadata_goal1_schema_radiation": "metadata_goal1_schema_radiation.json",
+    "metadata_goal2_observer": "metadata_goal2_observer.json",
+    "metadata_goal2_5_production_observer": "metadata_goal2_5_production_observer.json",
 }
 
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
@@ -16,8 +16,11 @@ MAIN_RADIATION_THRESHOLD_W_M2 = 0
 RADIATION_COLUMN_USED = "env_inside_radiation_wm2"
 RADIATION_PRIMARY_SOURCE = "dataset1"
 
-DEFAULT_FRUIT_DRY_MATTER_CONTENT = 0.065
-DMC_SENSITIVITY: tuple[float, ...] = (0.040, 0.052, 0.056, 0.060, 0.065, 0.080)
+CANONICAL_2025_2C_FRUIT_DMC = 0.056
+DEFAULT_FRUIT_DRY_MATTER_CONTENT = CANONICAL_2025_2C_FRUIT_DMC
+DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC = 0.065
+DMC_SENSITIVITY: tuple[float, ...] = ()
+HAF_2025_2C_LOADCELL_FLOOR_AREA_M2 = 3.148672656
 
 RAW_INPUT_FILENAMES = {
     "fruit_leaf_temperature_solar_raw_dat": "2026_2작기_토마토_엽온_과실직경.dat",
@@ -125,8 +128,15 @@ def base_metadata() -> dict[str, Any]:
         "fresh_yield_available": False,
         "dry_yield_available": False,
         "DMC_conversion_performed": False,
+        "canonical_fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+        "fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
         "default_fruit_dry_matter_content": DEFAULT_FRUIT_DRY_MATTER_CONTENT,
-        "dmc_sensitivity": list(DMC_SENSITIVITY),
+        "DMC_fixed_for_2025_2C": True,
+        "DMC_sensitivity_enabled": False,
+        "DMC_sensitivity_values": list(DMC_SENSITIVITY),
+        "deprecated_previous_default_fruit_DMC_fraction": DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
+        "dry_yield_is_dmc_estimated": False,
+        "direct_dry_yield_measured": False,
         "biological_replication": False,
         "fruit_diameter_sensor_level_only": True,
         "fruit_diameter_treatment_endpoint": False,

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+SEASON_ID = "2025_2C"
+RAW_FILENAME_NOTE = (
+    "Some raw filenames contain 2026_2; biological evaluation season is "
+    "user-defined as 2025 second cropping cycle."
+)
+
+OBSERVER_PIPELINE_VERSION = "tomics-haf-2025-2c-observer-v1"
+
+RADIATION_THRESHOLDS_W_M2: tuple[int, ...] = (0, 1, 5, 10)
+MAIN_RADIATION_THRESHOLD_W_M2 = 0
+RADIATION_COLUMN_USED = "env_inside_radiation_wm2"
+RADIATION_PRIMARY_SOURCE = "dataset1"
+
+DEFAULT_FRUIT_DRY_MATTER_CONTENT = 0.065
+DMC_SENSITIVITY: tuple[float, ...] = (0.040, 0.052, 0.056, 0.060, 0.065, 0.080)
+
+RAW_INPUT_FILENAMES = {
+    "fruit_leaf_temperature_solar_raw_dat": "2026_2작기_토마토_엽온_과실직경.dat",
+    "dataset1": "dataset1_loadcell_1_6_daily_ec_moisture_yield_env.parquet",
+    "dataset2": "dataset2_loadcell_4_5_daily_ec_moisture_tensiometer.parquet",
+    "dataset3": "dataset3_individual_stem_diameter_flower_height_flowering_date.parquet",
+}
+
+DATASET1_COLUMN_CANDIDATES: tuple[str, ...] = (
+    "timestamp",
+    "date",
+    "loadcell_id",
+    "sample_id",
+    "treatment",
+    "loadcell_weight_kg",
+    "env_inside_radiation_wm2",
+    "env_vpd_kpa",
+    "env_air_temperature_c",
+    "env_co2_ppm",
+    "moisture_percent",
+    "ec_ds",
+)
+
+DATASET2_COLUMN_CANDIDATES: tuple[str, ...] = (
+    "timestamp",
+    "date",
+    "loadcell_id",
+    "sample_id",
+    "treatment",
+    "loadcell_weight_kg",
+    "moisture_percent",
+    "ec_ds",
+    "tensiometer_hp",
+)
+
+DATASET3_COLUMN_CANDIDATES: tuple[str, ...] = (
+    "season",
+    "sample_id",
+    "loadcell_id",
+    "treatment",
+    "flower_cluster_no",
+    "flowering_date",
+    "stem_diameter",
+    "flower_cluster_height",
+    "has_flowering_date",
+    "has_stem_diameter",
+    "has_flower_cluster_height",
+)
+
+OUTPUT_FILENAMES = {
+    "fruit_leaf_timeseries_qc": "2025_2c_fruit_leaf_timeseries_qc.csv",
+    "sensor_qc_report": "2025_2c_sensor_qc_report.csv",
+    "radiation_photoperiod": "radiation_photoperiod_by_date_all_thresholds.csv",
+    "event_intervals": "radiation_daynight_10min_event_bridged_intervals.csv",
+    "event_daily_all_thresholds": "radiation_daynight_event_bridged_daily_all_thresholds.csv",
+    "event_daily_main_0w": "radiation_daynight_event_bridged_daily_main_0W.csv",
+    "event_daily_wide_main_0w": "radiation_daynight_daily_wide_main_0W.csv",
+    "fruit_leaf_radiation_windows": "2025_2c_fruit_leaf_radiation_windows.csv",
+    "fruit_leaf_clock_windows": "2025_2c_fruit_leaf_clock_compat_windows.csv",
+    "fruit_leaf_loadcell_bridge": "2025_2c_fruit_leaf_loadcell_bridge.csv",
+    "rootzone_indices": "2025_2c_rootzone_indices.csv",
+    "dataset3_bridge": "2025_2c_dataset3_growth_phenology_bridge.csv",
+    "observer_feature_frame": "2025_2c_tomics_haf_observer_feature_frame.csv",
+    "metadata": "2025_2c_tomics_haf_metadata.json",
+}
+
+
+def resolve_repo_path(repo_root: Path, value: str | Path) -> Path:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        return candidate
+    return (repo_root / candidate).resolve()
+
+
+def base_metadata() -> dict[str, Any]:
+    return {
+        "season_id": SEASON_ID,
+        "raw_filename_note": RAW_FILENAME_NOTE,
+        "observer_pipeline_version": OBSERVER_PIPELINE_VERSION,
+        "radiation_daynight_primary_source": RADIATION_PRIMARY_SOURCE,
+        "radiation_column_used": RADIATION_COLUMN_USED,
+        "radiation_thresholds_tested": list(RADIATION_THRESHOLDS_W_M2),
+        "main_radiation_threshold_wm2": MAIN_RADIATION_THRESHOLD_W_M2,
+        "fixed_clock_daynight_primary": False,
+        "clock_06_18_used_only_for_compatibility": True,
+        "dataset1_radiation_directly_usable": True,
+        "dataset1_radiation_grain": "high_frequency_10min_or_finer",
+        "fallback_required": False,
+        "fallback_source_if_required": None,
+        "raw_dat_solar_rad_fallback_verified": True,
+        "VPD_available": True,
+        "apparent_canopy_conductance_available": True,
+        "LAI_available": False,
+        "fresh_yield_available": False,
+        "dry_yield_available": False,
+        "DMC_conversion_performed": False,
+        "default_fruit_dry_matter_content": DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+        "dmc_sensitivity": list(DMC_SENSITIVITY),
+        "biological_replication": False,
+        "fruit_diameter_sensor_level_only": True,
+        "fruit_diameter_treatment_endpoint": False,
+        "fruit_diameter_p_values_allowed": False,
+        "fruit_diameter_allocation_calibration_target": False,
+        "fruit_diameter_model_promotion_target": False,
+        "fixed_clock_outputs_compatibility_only": True,
+        "shipped_TOMICS_incumbent_changed": False,
+        "latent_allocation_inference_run": False,
+        "harvest_family_factorial_run": False,
+        "promotion_gate_run": False,
+    }
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/dataset3_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/dataset3_bridge.py
@@ -70,4 +70,3 @@ def build_dataset3_growth_phenology_bridge(frame: pd.DataFrame) -> tuple[pd.Data
         "Dataset3_mapping_confidence_counts": {str(key): int(value) for key, value in counts.items()},
     }
     return summary, metadata
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/dataset3_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/dataset3_bridge.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.input_schema_audit import match_semantic_roles
+
+
+def audit_dataset3_schema(frame: pd.DataFrame) -> dict[str, Any]:
+    roles = match_semantic_roles(frame.columns)
+    return {
+        "columns": list(map(str, frame.columns)),
+        "matched_roles": roles,
+        "datetime_or_date_available": "datetime" in roles or "date" in roles,
+        "truss_position_available": "truss_position" in roles,
+        "loadcell_available": "loadcell" in roles,
+        "treatment_available": "treatment" in roles,
+    }
+
+
+def build_dataset3_growth_phenology_bridge(frame: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, Any]]:
+    schema = audit_dataset3_schema(frame)
+    data = frame.copy()
+    has_date = bool(schema["datetime_or_date_available"])
+    has_loadcell = "loadcell_id" in data.columns or "loadcell" in data.columns
+    has_treatment = "treatment" in data.columns
+    if "date" in data.columns:
+        data["date"] = pd.to_datetime(data["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+
+    if has_loadcell and has_date:
+        confidence = "direct_loadcell"
+        group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in data.columns]
+    elif has_loadcell:
+        confidence = "direct_loadcell_no_date"
+        group_cols = [column for column in ("loadcell_id", "treatment") if column in data.columns]
+    elif has_treatment and has_date:
+        confidence = "treatment_level_only"
+        group_cols = [column for column in ("date", "treatment") if column in data.columns]
+    else:
+        confidence = "unlinked"
+        group_cols = [column for column in ("season",) if column in data.columns]
+
+    if not group_cols:
+        data["_standalone_dataset3"] = "all"
+        group_cols = ["_standalone_dataset3"]
+
+    aggregations: dict[str, tuple[str, str]] = {"dataset3_row_count": (group_cols[0], "size")}
+    if "stem_diameter" in data.columns:
+        aggregations["stem_diameter_mean"] = ("stem_diameter", "mean")
+    if "flower_cluster_height" in data.columns:
+        aggregations["flower_cluster_height_mean"] = ("flower_cluster_height", "mean")
+    if "flowering_date" in data.columns:
+        data["flowering_date"] = pd.to_datetime(data["flowering_date"], errors="coerce")
+        aggregations["flowering_date_min"] = ("flowering_date", "min")
+        aggregations["flowering_date_max"] = ("flowering_date", "max")
+    if "flower_cluster_no" in data.columns:
+        aggregations["flower_cluster_no_mean"] = ("flower_cluster_no", "mean")
+
+    summary = data.groupby(group_cols, dropna=False).agg(**aggregations).reset_index()
+    summary["Dataset3_mapping_confidence"] = confidence
+    summary["Dataset3_datetime_or_date_available"] = has_date
+    summary["Dataset3_truss_position_available"] = bool(schema["truss_position_available"])
+    summary["causal_allocation_fitting_run"] = False
+    summary["allocation_use"] = "growth_phenology_observer_only"
+    counts = summary["Dataset3_mapping_confidence"].value_counts().to_dict()
+    metadata = {
+        **schema,
+        "Dataset3_mapping_confidence": confidence,
+        "Dataset3_mapping_confidence_counts": {str(key): int(value) for key, value in counts.items()},
+    }
+    return summary, metadata
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/event_bridge_calibration.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/event_bridge_calibration.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+EVENT_TOTAL_COL = "event_bridged_loss_g_per_day"
+CALIBRATION_TOTAL_COL = "existing_daily_event_bridged_loss_g_per_day"
+
+
+def _normalize_keys(frame: pd.DataFrame) -> pd.DataFrame:
+    out = frame.copy()
+    if "date" in out.columns:
+        out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    if "loadcell_id" in out.columns:
+        out["loadcell_id"] = pd.to_numeric(out["loadcell_id"], errors="coerce").astype("Int64").astype(str)
+    if "treatment" in out.columns:
+        out["treatment"] = out["treatment"].astype(str)
+    return out
+
+
+def load_legacy_event_bridge_daily_totals(
+    config: Mapping[str, Any],
+    *,
+    min_valid_coverage_fraction: float = 0.0,
+    allow_qc_false: bool = True,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any]]:
+    min_valid_coverage_fraction = float(
+        config.get("event_bridge_min_valid_coverage_fraction", min_valid_coverage_fraction)
+    )
+    allow_qc_false = bool(config.get("allow_legacy_event_bridge_qc_false", allow_qc_false))
+    if not bool(config.get("enabled")) or not bool(config.get("allow_legacy_event_bridge_calibration")):
+        empty_audit = pd.DataFrame(
+            [
+                {
+                    "source_path": "",
+                    "status": "disabled",
+                    "rows_total": 0,
+                    "rows_usable": 0,
+                    "notes": "Legacy event bridge calibration is disabled.",
+                }
+            ]
+        )
+        return pd.DataFrame(), empty_audit, {
+            "existing_daily_event_bridged_total_available": False,
+            "event_bridged_ET_calibration_status": "uncalibrated_no_daily_total",
+            "event_bridged_ET_calibration_source": "",
+            "event_bridged_ET_calibration_provenance": config.get("provenance_label", "legacy_v1_3_derived_output"),
+            "event_bridged_ET_calibration_direct_raw_recomputed": False,
+            "event_bridged_ET_calibration_rows_matched": 0,
+            "event_bridged_ET_calibration_rows_unmatched": 0,
+        }
+
+    archive_root = Path(config["archive_root_path"])
+    candidates = [archive_root / str(path) for path in config.get("event_bridge_daily_candidates", [])]
+    audit_rows: list[dict[str, Any]] = []
+    for path in candidates:
+        row = {"source_path": str(path), "status": "missing_file", "rows_total": 0, "rows_usable": 0, "notes": ""}
+        if not path.exists():
+            audit_rows.append(row)
+            continue
+        frame = pd.read_csv(path)
+        row["rows_total"] = int(frame.shape[0])
+        required = {"date", "loadcell_id", "treatment", EVENT_TOTAL_COL}
+        missing = sorted(required.difference(frame.columns))
+        if missing:
+            row["status"] = "missing_required_columns"
+            row["notes"] = ";".join(missing)
+            audit_rows.append(row)
+            continue
+        work = _normalize_keys(frame)
+        work[EVENT_TOTAL_COL] = pd.to_numeric(work[EVENT_TOTAL_COL], errors="coerce")
+        work = work[np.isfinite(work[EVENT_TOTAL_COL])]
+        if "valid_coverage_fraction" in work.columns:
+            work["valid_coverage_fraction"] = pd.to_numeric(work["valid_coverage_fraction"], errors="coerce")
+            work = work[work["valid_coverage_fraction"].fillna(-np.inf).ge(min_valid_coverage_fraction)]
+        if "primary_event_bridge_qc" in work.columns and not allow_qc_false:
+            work = work[work["primary_event_bridge_qc"].astype(str).str.lower().eq("true")]
+        work = work[work[EVENT_TOTAL_COL].notna()]
+        work = work.rename(columns={EVENT_TOTAL_COL: CALIBRATION_TOTAL_COL})
+        keep = [
+            column
+            for column in (
+                "date",
+                "loadcell_id",
+                "treatment",
+                CALIBRATION_TOTAL_COL,
+                "primary_event_bridge_qc",
+                "valid_coverage_fraction",
+                "event_bridge_rate_source",
+                "bridge_to_quiet_scaled_ratio",
+            )
+            if column in work.columns
+        ]
+        usable = work[keep].drop_duplicates(["date", "loadcell_id", "treatment"])
+        row["rows_usable"] = int(usable.shape[0])
+        row["status"] = "ok" if not usable.empty else "no_usable_rows"
+        audit_rows.append(row)
+        if not usable.empty:
+            metadata = {
+                "existing_daily_event_bridged_total_available": True,
+                "event_bridged_ET_calibration_status": "legacy_daily_totals_available",
+                "event_bridged_ET_calibration_source": str(path),
+                "event_bridged_ET_calibration_provenance": config.get("provenance_label", "legacy_v1_3_derived_output"),
+                "event_bridged_ET_calibration_direct_raw_recomputed": False,
+                "event_bridged_ET_calibration_rows_matched": 0,
+                "event_bridged_ET_calibration_rows_unmatched": 0,
+            }
+            return usable, pd.DataFrame(audit_rows), metadata
+
+    return pd.DataFrame(), pd.DataFrame(audit_rows), {
+        "existing_daily_event_bridged_total_available": False,
+        "event_bridged_ET_calibration_status": "uncalibrated_no_daily_total",
+        "event_bridged_ET_calibration_source": "",
+        "event_bridged_ET_calibration_provenance": config.get("provenance_label", "legacy_v1_3_derived_output"),
+        "event_bridged_ET_calibration_direct_raw_recomputed": False,
+        "event_bridged_ET_calibration_rows_matched": 0,
+        "event_bridged_ET_calibration_rows_unmatched": 0,
+    }
+
+
+def calibration_match_metadata(intervals: pd.DataFrame, daily_totals: pd.DataFrame, metadata: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(metadata)
+    if daily_totals.empty or intervals.empty:
+        return out
+    interval_keys = _normalize_keys(intervals)[["date", "loadcell_id", "treatment"]].drop_duplicates()
+    total_keys = _normalize_keys(daily_totals)[["date", "loadcell_id", "treatment"]].drop_duplicates()
+    matched = interval_keys.merge(total_keys, on=["date", "loadcell_id", "treatment"], how="inner")
+    out["event_bridged_ET_calibration_rows_matched"] = int(matched.shape[0])
+    out["event_bridged_ET_calibration_rows_unmatched"] = int(interval_keys.shape[0] - matched.shape[0])
+    out["event_bridged_ET_calibration_status"] = (
+        "calibrated_to_legacy_daily_event_total" if out["event_bridged_ET_calibration_rows_matched"] else "uncalibrated_no_matching_daily_total"
+    )
+    return out

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
@@ -26,6 +26,8 @@ def build_observer_feature_frame(
     fruit_windows: pd.DataFrame | None = None,
     leaf_windows: pd.DataFrame | None = None,
     dataset3_bridge: pd.DataFrame | None = None,
+    radiation_source_used: str = "dataset1",
+    radiation_column_used: str = RADIATION_COLUMN_USED,
 ) -> pd.DataFrame:
     if daily_et_wide is not None and not daily_et_wide.empty:
         base = daily_et_wide.copy()
@@ -83,8 +85,8 @@ def build_observer_feature_frame(
     base["biological_replication"] = False
     base["sensor_level_only"] = True
     base["fruit_mapping_status"] = "provisional"
-    base["radiation_source_used"] = "dataset1"
-    base["radiation_column_used"] = RADIATION_COLUMN_USED
+    base["radiation_source_used"] = radiation_source_used
+    base["radiation_column_used"] = radiation_column_used
     base["fixed_clock_daynight_primary"] = False
     base["direct_partition_observation_available"] = False
     base["allocation_validation_basis"] = "indirect_observer_features_only"

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
@@ -73,8 +73,12 @@ def build_observer_feature_frame(
         fruit_main = fruit_windows[fruit_windows["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
         base = _merge_optional(base, fruit_main, ["date", "loadcell_id", "treatment", "threshold_w_m2"])
     if dataset3_bridge is not None and not dataset3_bridge.empty:
-        base = _merge_optional(base, dataset3_bridge, ["date", "loadcell_id", "treatment"])
-        base = _merge_optional(base, dataset3_bridge, ["loadcell_id", "treatment"])
+        if "date" in dataset3_bridge.columns:
+            base = _merge_optional(base, dataset3_bridge, ["date", "loadcell_id", "treatment"])
+        elif {"loadcell_id", "treatment"}.issubset(dataset3_bridge.columns):
+            base = _merge_optional(base, dataset3_bridge, ["loadcell_id", "treatment"])
+        elif "treatment" in dataset3_bridge.columns:
+            base = _merge_optional(base, dataset3_bridge, ["treatment"])
 
     base["biological_replication"] = False
     base["sensor_level_only"] = True

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    MAIN_RADIATION_THRESHOLD_W_M2,
+    RADIATION_COLUMN_USED,
+)
+
+
+def _merge_optional(base: pd.DataFrame, other: pd.DataFrame, keys: list[str]) -> pd.DataFrame:
+    if other is None or other.empty:
+        return base
+    merge_keys = [key for key in keys if key in base.columns and key in other.columns]
+    if not merge_keys:
+        return base
+    return base.merge(other, on=merge_keys, how="left")
+
+
+def build_observer_feature_frame(
+    *,
+    daily_et_wide: pd.DataFrame,
+    radiation_daily: pd.DataFrame | None = None,
+    rootzone_indices: pd.DataFrame | None = None,
+    fruit_windows: pd.DataFrame | None = None,
+    leaf_windows: pd.DataFrame | None = None,
+    dataset3_bridge: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    if daily_et_wide is not None and not daily_et_wide.empty:
+        base = daily_et_wide.copy()
+    elif radiation_daily is not None and not radiation_daily.empty:
+        base = radiation_daily[radiation_daily["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
+    else:
+        base = pd.DataFrame(columns=["date", "loadcell_id", "treatment", "threshold_w_m2"])
+
+    if "threshold_w_m2" not in base.columns:
+        base["threshold_w_m2"] = float(MAIN_RADIATION_THRESHOLD_W_M2)
+
+    if radiation_daily is not None and not radiation_daily.empty:
+        radiation_main = radiation_daily[radiation_daily["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
+        keep = [
+            column
+            for column in radiation_main.columns
+            if column
+            in {
+                "date",
+                "loadcell_id",
+                "treatment",
+                "threshold_w_m2",
+                "day_interval_count",
+                "night_interval_count",
+                "day_radiation_integral_MJ_m2",
+                "night_radiation_integral_MJ_m2",
+                "day_radiation_mean_wm2",
+                "night_radiation_mean_wm2",
+                "source_proxy_MJ_CO2_T",
+                "source_proxy_MJ_CO2_T_available",
+                "day_vpd_kpa_mean",
+            }
+        ]
+        base = _merge_optional(base, radiation_main[keep], ["date", "loadcell_id", "treatment", "threshold_w_m2"])
+
+    base = _merge_optional(
+        base,
+        rootzone_indices if rootzone_indices is not None else pd.DataFrame(),
+        ["date", "loadcell_id", "treatment"],
+    )
+    if leaf_windows is not None and not leaf_windows.empty:
+        leaf_main = leaf_windows[leaf_windows["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
+        base = _merge_optional(base, leaf_main, ["date", "threshold_w_m2"])
+    if fruit_windows is not None and not fruit_windows.empty:
+        fruit_main = fruit_windows[fruit_windows["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
+        base = _merge_optional(base, fruit_main, ["date", "loadcell_id", "treatment", "threshold_w_m2"])
+    if dataset3_bridge is not None and not dataset3_bridge.empty:
+        base = _merge_optional(base, dataset3_bridge, ["date", "loadcell_id", "treatment"])
+        base = _merge_optional(base, dataset3_bridge, ["loadcell_id", "treatment"])
+
+    base["biological_replication"] = False
+    base["sensor_level_only"] = True
+    base["fruit_mapping_status"] = "provisional"
+    base["radiation_source_used"] = "dataset1"
+    base["radiation_column_used"] = RADIATION_COLUMN_USED
+    base["fixed_clock_daynight_primary"] = False
+    base["direct_partition_observation_available"] = False
+    base["allocation_validation_basis"] = "indirect_observer_features_only"
+    base["LAI_available"] = False
+    base["LAI_source"] = "not_available"
+    base["harvest_yield_available"] = False
+    base["fresh_yield_available"] = False
+    base["dry_yield_available"] = False
+    base["DMC_conversion_performed"] = False
+    base["latent_allocation_inference_run"] = False
+    base["allocation_promotion_allowed"] = False
+
+    if "apparent_canopy_conductance_available" not in base.columns:
+        base["apparent_canopy_conductance_available"] = False
+    if "apparent_canopy_conductance" not in base.columns:
+        base["apparent_canopy_conductance"] = np.nan
+    return base.sort_values([column for column in ("date", "loadcell_id") if column in base.columns]).reset_index(drop=True)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py
@@ -4,6 +4,10 @@ import numpy as np
 import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    CANONICAL_2025_2C_FRUIT_DMC,
+    DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+    DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
+    HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
     MAIN_RADIATION_THRESHOLD_W_M2,
     RADIATION_COLUMN_USED,
 )
@@ -94,8 +98,23 @@ def build_observer_feature_frame(
     base["LAI_source"] = "not_available"
     base["harvest_yield_available"] = False
     base["fresh_yield_available"] = False
+    base["fresh_yield_source"] = ""
     base["dry_yield_available"] = False
+    base["dry_yield_source"] = ""
+    base["observed_fruit_FW_g_loadcell"] = np.nan
+    base["observed_fruit_DW_g_loadcell_dmc_0p056"] = np.nan
+    base["observed_fruit_DW_g_m2_floor_dmc_0p056"] = np.nan
+    base["canonical_fruit_DMC_fraction"] = CANONICAL_2025_2C_FRUIT_DMC
+    base["fruit_DMC_fraction"] = CANONICAL_2025_2C_FRUIT_DMC
+    base["default_fruit_dry_matter_content"] = DEFAULT_FRUIT_DRY_MATTER_CONTENT
+    base["DMC_fixed_for_2025_2C"] = True
+    base["DMC_sensitivity_enabled"] = False
+    base["DMC_sensitivity_values"] = ""
+    base["deprecated_previous_default_fruit_DMC_fraction"] = DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC
     base["DMC_conversion_performed"] = False
+    base["dry_yield_is_dmc_estimated"] = False
+    base["direct_dry_yield_measured"] = False
+    base["loadcell_floor_area_m2"] = HAF_2025_2C_LOADCELL_FLOOR_AREA_M2
     base["latent_allocation_inference_run"] = False
     base["allocation_promotion_allowed"] = False
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/fruit_diameter_windows.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/fruit_diameter_windows.py
@@ -181,4 +181,3 @@ def build_fixed_clock_compat_windows(
                 }
             )
     return pd.DataFrame(rows)
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/fruit_diameter_windows.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/fruit_diameter_windows.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.sensor_mapping import sensor_mapping_rows
+
+
+def _value_at_timestamp(
+    series_frame: pd.DataFrame,
+    *,
+    timestamp_col: str,
+    value_col: str,
+    timestamp: pd.Timestamp,
+    max_gap: pd.Timedelta = pd.Timedelta(minutes=30),
+) -> float:
+    data = series_frame[[timestamp_col, value_col]].dropna().copy()
+    data[timestamp_col] = pd.to_datetime(data[timestamp_col], errors="coerce")
+    data = data.dropna(subset=[timestamp_col]).sort_values(timestamp_col)
+    if data.empty or pd.isna(timestamp):
+        return float("nan")
+    indexed = data.set_index(timestamp_col)[value_col].astype(float)
+    nearest_idx = indexed.index[np.argmin(np.abs(indexed.index - timestamp))]
+    if abs(nearest_idx - timestamp) > max_gap:
+        return float("nan")
+    return float(indexed.loc[nearest_idx])
+
+
+def build_fruit_leaf_loadcell_bridge(mapping: dict[str, Any]) -> pd.DataFrame:
+    return sensor_mapping_rows(mapping)
+
+
+def build_fruit_leaf_radiation_windows(
+    qc_frame: pd.DataFrame,
+    photoperiod: pd.DataFrame,
+    mapping: dict[str, Any],
+    *,
+    timestamp_col: str = "TIMESTAMP",
+    thresholds_w_m2: Iterable[int | float] = (0, 1, 5, 10),
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    frame = qc_frame.copy()
+    frame[timestamp_col] = pd.to_datetime(frame[timestamp_col], errors="coerce")
+    fruit_rows: list[dict[str, Any]] = []
+    leaf_rows: list[dict[str, Any]] = []
+    photoperiod = photoperiod.copy()
+    photoperiod["first_light_timestamp"] = pd.to_datetime(photoperiod["first_light_timestamp"], errors="coerce")
+    photoperiod["last_light_timestamp"] = pd.to_datetime(photoperiod["last_light_timestamp"], errors="coerce")
+
+    for threshold in thresholds_w_m2:
+        threshold_photo = photoperiod[photoperiod["threshold_w_m2"].eq(float(threshold))].sort_values("date")
+        next_first_by_date = dict(
+            zip(threshold_photo["date"], threshold_photo["first_light_timestamp"].shift(-1), strict=False)
+        )
+        for _, boundary in threshold_photo.iterrows():
+            first_light = boundary["first_light_timestamp"]
+            last_light = boundary["last_light_timestamp"]
+            date = boundary["date"]
+            for sensor_col, sensor_info in mapping.get("fruit_sensor_map", {}).items():
+                valid_col = f"{sensor_col}_valid"
+                sensor_frame = frame[frame.get(valid_col, True).astype(bool)] if valid_col in frame.columns else frame
+                start_value = _value_at_timestamp(
+                    sensor_frame,
+                    timestamp_col=timestamp_col,
+                    value_col=sensor_col,
+                    timestamp=first_light,
+                )
+                last_value = _value_at_timestamp(
+                    sensor_frame,
+                    timestamp_col=timestamp_col,
+                    value_col=sensor_col,
+                    timestamp=last_light,
+                )
+                next_first = next_first_by_date.get(date)
+                next_first_value = _value_at_timestamp(
+                    sensor_frame,
+                    timestamp_col=timestamp_col,
+                    value_col=sensor_col,
+                    timestamp=next_first,
+                )
+                day_data = sensor_frame[
+                    (sensor_frame[timestamp_col] >= first_light) & (sensor_frame[timestamp_col] <= last_light)
+                ]
+                night_data = sensor_frame[
+                    (sensor_frame[timestamp_col] >= last_light) & (sensor_frame[timestamp_col] <= next_first)
+                ]
+                step = pd.to_numeric(sensor_frame.get(sensor_col), errors="coerce").diff().abs()
+                endpoint_ok = pd.notna(start_value) and pd.notna(last_value)
+                fruit_rows.append(
+                    {
+                        "date": date,
+                        "threshold_w_m2": float(threshold),
+                        "sensor_column": sensor_col,
+                        "loadcell_id": sensor_info.get("loadcell_id"),
+                        "treatment": sensor_info.get("treatment"),
+                        "mapping_status": sensor_info.get("mapping_status"),
+                        "radiation_day_net_mm": last_value - start_value if endpoint_ok else np.nan,
+                        "radiation_night_carryover_net_mm": (
+                            next_first_value - last_value if pd.notna(next_first_value) and pd.notna(last_value) else np.nan
+                        ),
+                        "24h_net_mm": next_first_value - start_value if pd.notna(next_first_value) and pd.notna(start_value) else np.nan,
+                        "radiation_day_range_mm": (
+                            float(day_data[sensor_col].max() - day_data[sensor_col].min())
+                            if not day_data.empty and sensor_col in day_data
+                            else np.nan
+                        ),
+                        "radiation_night_range_mm": (
+                            float(night_data[sensor_col].max() - night_data[sensor_col].min())
+                            if not night_data.empty and sensor_col in night_data
+                            else np.nan
+                        ),
+                        "max_10min_step_mm": float(step.max(skipna=True)) if step.notna().any() else np.nan,
+                        "stable_flag": bool(endpoint_ok and (step.dropna() <= 1.0).all()),
+                        "sensor_level_only": True,
+                        "fruit_diameter_p_values_allowed": False,
+                        "fruit_diameter_allocation_calibration_target": False,
+                        "qc_status": "ok" if endpoint_ok else "insufficient_valid_points_or_no_radiation_boundary",
+                    }
+                )
+
+            leaf_row: dict[str, Any] = {"date": date, "threshold_w_m2": float(threshold)}
+            for sensor_col, sensor_info in mapping.get("leaf_sensor_map", {}).items():
+                loadcell_id = sensor_info.get("loadcell_id")
+                day = frame[(frame[timestamp_col] >= first_light) & (frame[timestamp_col] <= last_light)]
+                next_first = next_first_by_date.get(date)
+                night = frame[(frame[timestamp_col] >= last_light) & (frame[timestamp_col] <= next_first)]
+                prefix = f"leaf_temp_lc{loadcell_id}"
+                leaf_row[f"{prefix}_radiation_day_mean_c"] = (
+                    float(pd.to_numeric(day[sensor_col], errors="coerce").mean()) if sensor_col in day else np.nan
+                )
+                leaf_row[f"{prefix}_radiation_night_mean_c"] = (
+                    float(pd.to_numeric(night[sensor_col], errors="coerce").mean()) if sensor_col in night else np.nan
+                )
+            if {
+                "leaf_temp_lc4_radiation_day_mean_c",
+                "leaf_temp_lc1_radiation_day_mean_c",
+            }.issubset(leaf_row):
+                leaf_row["delta_leaf_temp_lc4_minus_lc1_radiation_day_mean_c"] = (
+                    leaf_row["leaf_temp_lc4_radiation_day_mean_c"] - leaf_row["leaf_temp_lc1_radiation_day_mean_c"]
+                )
+                leaf_row["delta_leaf_temp_lc4_minus_lc1_radiation_night_mean_c"] = (
+                    leaf_row["leaf_temp_lc4_radiation_night_mean_c"] - leaf_row["leaf_temp_lc1_radiation_night_mean_c"]
+                )
+            leaf_rows.append(leaf_row)
+
+    return pd.DataFrame(fruit_rows), pd.DataFrame(leaf_rows)
+
+
+def build_fixed_clock_compat_windows(
+    qc_frame: pd.DataFrame,
+    mapping: dict[str, Any],
+    *,
+    timestamp_col: str = "TIMESTAMP",
+) -> pd.DataFrame:
+    frame = qc_frame.copy()
+    frame[timestamp_col] = pd.to_datetime(frame[timestamp_col], errors="coerce")
+    frame["date"] = frame[timestamp_col].dt.strftime("%Y-%m-%d")
+    rows: list[dict[str, Any]] = []
+    for date, day_frame in frame.groupby("date", dropna=False):
+        day = day_frame[(day_frame[timestamp_col].dt.hour >= 6) & (day_frame[timestamp_col].dt.hour < 18)]
+        night = day_frame[~day_frame.index.isin(day.index)]
+        for sensor_col, sensor_info in mapping.get("fruit_sensor_map", {}).items():
+            rows.append(
+                {
+                    "date": date,
+                    "sensor_column": sensor_col,
+                    "loadcell_id": sensor_info.get("loadcell_id"),
+                    "treatment": sensor_info.get("treatment"),
+                    "clock_day_range_mm": (
+                        float(day[sensor_col].max() - day[sensor_col].min()) if not day.empty and sensor_col in day else np.nan
+                    ),
+                    "clock_night_range_mm": (
+                        float(night[sensor_col].max() - night[sensor_col].min())
+                        if not night.empty and sensor_col in night
+                        else np.nan
+                    ),
+                    "fixed_clock_daynight_primary": False,
+                    "clock_06_18_used_only_for_compatibility": True,
+                }
+            )
+    return pd.DataFrame(rows)
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/input_schema_audit.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/input_schema_audit.py
@@ -9,6 +9,10 @@ from typing import Any
 import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, write_json
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import (
+    normalize_metadata,
+    write_stage_metadata_snapshot,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source import (
     build_radiation_source_verification,
 )
@@ -33,6 +37,7 @@ SENSOR_MAPPING_METADATA = {
         "fruit_diameter_treatment_endpoint": False,
         "fruit_diameter_p_values_allowed": False,
         "fruit_diameter_allocation_calibration_target": False,
+        "fruit_diameter_model_promotion_target": False,
     },
 }
 
@@ -74,22 +79,33 @@ DEFAULT_ROLE_ALIASES: dict[str, tuple[str, ...]] = {
     "temperature": ("env_air_temperature_c", "air_temperature_c", "T_air_C", "temperature_c"),
     "co2": ("env_co2_ppm", "CO2_ppm", "co2_ppm"),
     "rh": ("env_rh_pct", "RH_percent", "rh_pct"),
-    "moisture": ("moisture_percent_mean", "substrate_moisture", "theta", "vwc", "water_content"),
-    "ec": ("ec_ds_mean", "substrate_ec", "EC", "ec"),
-    "tensiometer": ("tensiometer_hp_mean", "tensiometer", "matric_potential", "substrate_tension"),
+    "moisture": ("moisture_percent_mean", "moisture_percent", "substrate_moisture", "theta", "vwc", "water_content"),
+    "ec": ("ec_ds_mean", "ec_ds", "substrate_ec", "EC", "ec"),
+    "tensiometer": ("tensiometer_hp_mean", "tensiometer_hp", "tensiometer", "matric_potential", "substrate_tension"),
     "yield_fresh": (
         "yield_fresh_g",
         "fresh_yield_g",
         "individual_fresh_yield_g",
         "harvest_fresh_weight_g",
+        "loadcell_daily_yield_g",
+        "loadcell_cumulative_yield_g",
+        "individual_cumulative_yield_g",
+        "final_fresh_yield_g",
     ),
     "yield_dry": ("yield_dry_g", "dry_yield_g", "fruit_dry_weight_g", "harvest_dry_weight_g"),
+    "estimated_dry_yield_from_dmc": (
+        "final_dry_yield_g_est_5p6pct",
+        "loadcell_daily_dry_yield_g_est_default_5p6pct",
+        "loadcell_cumulative_dry_yield_g_est_default_5p6pct",
+        "individual_cumulative_dry_yield_g_est_5p6pct",
+    ),
+    "direct_dry_yield_measured": ("yield_dry_g", "dry_yield_g", "fruit_dry_weight_g", "harvest_dry_weight_g"),
     "lai": ("LAI", "lai", "leaf_area_index"),
     "fruit_count": ("fruit_count", "n_fruits", "fruits_per_truss", "n_fruits_per_truss"),
     "stem_diameter": ("stem_diameter", "stem diameter", "stem_diameter_mm"),
     "flower_height": ("flower_height", "flower height", "flower_cluster_height"),
     "flowering_date": ("flowering_date", "flowering date"),
-    "truss_position": ("truss_position", "truss", "cluster"),
+    "truss_position": ("truss_position", "flower_cluster_no", "truss", "cluster"),
     "plant_id": ("plant_id", "sample_id", "individual_id"),
     "leaf_temperature": ("LeafTemp1_Avg", "LeafTemp2_Avg"),
     "fruit_diameter": ("Fruit1Diameter_Avg", "Fruit2Diameter_Avg"),
@@ -548,12 +564,18 @@ def _build_metadata(
         "raw_filename_note": RAW_FILENAME_NOTE,
         **SENSOR_MAPPING_METADATA,
         **dict(radiation_metadata),
-        "vpd_available": _role_available(audit_rows, "vpd"),
-        "lai_available": _role_available(audit_rows, "lai"),
+        "VPD_available": _role_available(audit_rows, "vpd"),
+        "LAI_available": _role_available(audit_rows, "lai"),
         "fresh_yield_available": _role_available(audit_rows, "yield_fresh"),
-        "dry_yield_available": _role_available(audit_rows, "yield_dry"),
-        "dataset3_mapping": _dataset3_mapping(audit_rows_by_role),
-        "shipped_tomics_incumbent_unchanged": True,
+        "dry_yield_available": _role_available(audit_rows, "yield_dry")
+        or _role_available(audit_rows, "estimated_dry_yield_from_dmc"),
+        "dry_yield_is_dmc_estimated": _role_available(audit_rows, "estimated_dry_yield_from_dmc"),
+        "direct_dry_yield_measured": _role_available(audit_rows, "direct_dry_yield_measured"),
+        "Dataset3_mapping_confidence": _dataset3_mapping(audit_rows_by_role),
+        "fruit_diameter_p_values_allowed": False,
+        "fruit_diameter_allocation_calibration_target": False,
+        "fruit_diameter_model_promotion_target": False,
+        "shipped_TOMICS_incumbent_changed": False,
         "raw_thorp_promoted": False,
     }
 
@@ -603,11 +625,11 @@ def _markdown_report(
     lines.append(f"- Fallback source if required: `{metadata['fallback_source_if_required']}`")
     lines.append("- Thresholds to test later: `[0, 1, 5, 10]`")
     lines.extend(["", "## Role availability"])
-    lines.append(f"- VPD available: `{metadata['vpd_available']}`")
-    lines.append(f"- LAI available: `{metadata['lai_available']}`")
+    lines.append(f"- VPD available: `{metadata['VPD_available']}`")
+    lines.append(f"- LAI available: `{metadata['LAI_available']}`")
     lines.append(f"- Fresh yield available: `{metadata['fresh_yield_available']}`")
     lines.append(f"- Dry yield available: `{metadata['dry_yield_available']}`")
-    lines.append(f"- Dataset3 mapping: `{metadata['dataset3_mapping']}`")
+    lines.append(f"- Dataset3 mapping: `{metadata['Dataset3_mapping_confidence']}`")
     lines.extend(["", "## Unresolved assumptions"])
     notes = metadata.get("radiation_source_decision_notes") or []
     if notes:
@@ -651,10 +673,12 @@ def run_tomics_haf_input_schema_audit(
         tables_by_role,
         audit_rows_by_role,
     )
-    metadata = _build_metadata(
+    metadata = normalize_metadata(
+        _build_metadata(
         audit_rows=audit_rows,
         audit_rows_by_role=audit_rows_by_role,
         radiation_metadata=radiation_metadata,
+        )
     )
 
     input_csv = output_root / "input_schema_audit.csv"
@@ -663,12 +687,14 @@ def run_tomics_haf_input_schema_audit(
     radiation_json = output_root / "radiation_source_verification.json"
     radiation_md = output_root / "radiation_source_verification.md"
     metadata_json = output_root / "2025_2c_tomics_haf_metadata.json"
+    metadata_snapshot = output_root / "metadata_goal1_schema_radiation.json"
 
     pd.DataFrame.from_records(audit_rows).to_csv(input_csv, index=False)
     write_json(input_json, {"files": audit_rows})
     pd.DataFrame.from_records(radiation_rows).to_csv(radiation_csv, index=False)
     write_json(radiation_json, {"candidates": radiation_rows, "metadata": metadata})
     write_json(metadata_json, metadata)
+    write_stage_metadata_snapshot(metadata_snapshot, metadata)
     radiation_md.write_text(
         _markdown_report(audit_rows=audit_rows, radiation_rows=radiation_rows, metadata=metadata),
         encoding="utf-8",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/input_schema_audit.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/input_schema_audit.py
@@ -1,0 +1,700 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, write_json
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source import (
+    build_radiation_source_verification,
+)
+
+SEASON_ID = "2025_2C"
+RAW_FILENAME_NOTE = (
+    "some raw filenames contain 2026_2; evaluation season is user-defined as "
+    "2025 second cropping cycle."
+)
+
+SENSOR_MAPPING_METADATA = {
+    "leaf_temperature_mapping": [
+        {"column": "LeafTemp1_Avg", "loadcell_id": 4, "treatment": "Drought"},
+        {"column": "LeafTemp2_Avg", "loadcell_id": 1, "treatment": "Control"},
+    ],
+    "fruit_diameter_mapping": [
+        {"column": "Fruit1Diameter_Avg", "loadcell_id": 4, "treatment": "Drought"},
+        {"column": "Fruit2Diameter_Avg", "loadcell_id": 1, "treatment": "Control"},
+    ],
+    "fruit_diameter_rules": {
+        "sensor_level_only": True,
+        "fruit_diameter_treatment_endpoint": False,
+        "fruit_diameter_p_values_allowed": False,
+        "fruit_diameter_allocation_calibration_target": False,
+    },
+}
+
+DEFAULT_INPUT_FILE_SPECS: tuple[dict[str, str], ...] = (
+    {
+        "file_role": "fruit_leaf_temperature_solar_raw_dat",
+        "expected_filename": "2026_2작기_토마토_엽온_과실직경.dat",
+    },
+    {
+        "file_role": "dataset1",
+        "expected_filename": "dataset1_loadcell_1_6_daily_ec_moisture_yield_env.parquet",
+    },
+    {
+        "file_role": "dataset2",
+        "expected_filename": "dataset2_loadcell_4_5_daily_ec_moisture_tensiometer.parquet",
+    },
+    {
+        "file_role": "dataset3",
+        "expected_filename": "dataset3_individual_stem_diameter_flower_height_flowering_date.parquet",
+    },
+)
+
+DEFAULT_ROLE_ALIASES: dict[str, tuple[str, ...]] = {
+    "datetime": ("timestamp", "TIMESTAMP", "datetime", "date_time", "DateTime", "time"),
+    "date": ("date", "Date", "window_date", "day"),
+    "loadcell": ("loadcell_id", "loadcell", "lc", "Loadcell", "load_cell_id"),
+    "treatment": ("treatment", "Treatment", "water_treatment", "irrigation_treatment"),
+    "radiation": (
+        "env_inside_radiation_wm2",
+        "env_radiation_wm2",
+        "env_radiation_wm2_mean",
+        "env_radiation_wm2_max",
+        "env_outside_radiation_wm2",
+        "SolarRad_Avg",
+        "solar_w_m2",
+        "radiation_wm2",
+    ),
+    "vpd": ("env_vpd_kpa", "vpd_kpa", "VPD", "VPD_kPa"),
+    "temperature": ("env_air_temperature_c", "air_temperature_c", "T_air_C", "temperature_c"),
+    "co2": ("env_co2_ppm", "CO2_ppm", "co2_ppm"),
+    "rh": ("env_rh_pct", "RH_percent", "rh_pct"),
+    "moisture": ("moisture_percent_mean", "substrate_moisture", "theta", "vwc", "water_content"),
+    "ec": ("ec_ds_mean", "substrate_ec", "EC", "ec"),
+    "tensiometer": ("tensiometer_hp_mean", "tensiometer", "matric_potential", "substrate_tension"),
+    "yield_fresh": (
+        "yield_fresh_g",
+        "fresh_yield_g",
+        "individual_fresh_yield_g",
+        "harvest_fresh_weight_g",
+    ),
+    "yield_dry": ("yield_dry_g", "dry_yield_g", "fruit_dry_weight_g", "harvest_dry_weight_g"),
+    "lai": ("LAI", "lai", "leaf_area_index"),
+    "fruit_count": ("fruit_count", "n_fruits", "fruits_per_truss", "n_fruits_per_truss"),
+    "stem_diameter": ("stem_diameter", "stem diameter", "stem_diameter_mm"),
+    "flower_height": ("flower_height", "flower height", "flower_cluster_height"),
+    "flowering_date": ("flowering_date", "flowering date"),
+    "truss_position": ("truss_position", "truss", "cluster"),
+    "plant_id": ("plant_id", "sample_id", "individual_id"),
+    "leaf_temperature": ("LeafTemp1_Avg", "LeafTemp2_Avg"),
+    "fruit_diameter": ("Fruit1Diameter_Avg", "Fruit2Diameter_Avg"),
+}
+
+IMPORTANT_ROLES_BY_FILE_ROLE: dict[str, tuple[str, ...]] = {
+    "fruit_leaf_temperature_solar_raw_dat": (
+        "datetime",
+        "radiation",
+        "leaf_temperature",
+        "fruit_diameter",
+    ),
+    "dataset1": (
+        "datetime_or_date",
+        "loadcell",
+        "treatment",
+        "radiation",
+        "vpd",
+        "temperature",
+        "co2",
+        "rh",
+        "moisture",
+        "ec",
+        "yield_fresh",
+        "yield_dry",
+        "lai",
+    ),
+    "dataset2": ("datetime_or_date", "loadcell", "treatment", "moisture", "ec", "tensiometer"),
+    "dataset3": (
+        "datetime_or_date",
+        "loadcell",
+        "treatment",
+        "stem_diameter",
+        "flower_height",
+        "flowering_date",
+        "truss_position",
+        "plant_id",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class LoadedTable:
+    frame: pd.DataFrame | None
+    parser_used: str
+    error: str | None = None
+    row_count: int | None = None
+    column_names: tuple[str, ...] | None = None
+    dtype_map: Mapping[str, str] | None = None
+    column_stats: Mapping[str, Mapping[str, object]] | None = None
+
+
+def normalize_column_name(value: object) -> str:
+    text = str(value).strip().lower()
+    for token in (" ", "-", ".", "/", "\\"):
+        text = text.replace(token, "_")
+    while "__" in text:
+        text = text.replace("__", "_")
+    return text
+
+
+def match_semantic_roles(
+    columns: Sequence[object],
+    aliases: Mapping[str, Sequence[str]] = DEFAULT_ROLE_ALIASES,
+) -> dict[str, list[str]]:
+    normalized_columns = {normalize_column_name(column): str(column) for column in columns}
+    matched: dict[str, list[str]] = {}
+    for role, role_aliases in aliases.items():
+        role_matches: list[str] = []
+        for alias in role_aliases:
+            candidate = normalized_columns.get(normalize_column_name(alias))
+            if candidate is not None and candidate not in role_matches:
+                role_matches.append(candidate)
+        if role_matches:
+            matched[role] = role_matches
+    return matched
+
+
+def _json_dumps(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _jsonable_scalar(value: object) -> object:
+    if pd.isna(value):
+        return None
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+def _sorted_unique_json_values(series: pd.Series, *, limit: int = 100) -> list[object]:
+    values = [_jsonable_scalar(value) for value in series.dropna().unique().tolist()]
+    values = sorted(values, key=lambda item: str(item))
+    return values[:limit]
+
+
+def _iso_timestamp(value: object) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    return pd.Timestamp(value).isoformat()
+
+
+def _jsonable_stat_value(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except (TypeError, ValueError):
+            pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+def _stat_less(left: object, right: object) -> bool:
+    try:
+        return left < right  # type: ignore[operator]
+    except TypeError:
+        return str(left) < str(right)
+
+
+def _stat_greater(left: object, right: object) -> bool:
+    try:
+        return left > right  # type: ignore[operator]
+    except TypeError:
+        return str(left) > str(right)
+
+
+def _infer_resolution_seconds(values: pd.Series) -> float | None:
+    parsed = pd.to_datetime(values, errors="coerce").dropna().sort_values().drop_duplicates()
+    if parsed.shape[0] < 2:
+        return None
+    diffs = parsed.diff().dropna().dt.total_seconds()
+    if diffs.empty:
+        return None
+    return float(diffs.median())
+
+
+def _read_toa5_dat(path: Path) -> LoadedTable | None:
+    errors: list[str] = []
+    for encoding in ("utf-8-sig", "utf-8", "cp949"):
+        try:
+            with path.open("r", encoding=encoding, newline="") as handle:
+                first_line = handle.readline()
+        except UnicodeDecodeError as exc:
+            errors.append(f"{encoding}: {type(exc).__name__}: {exc}")
+            continue
+        if "TOA5" not in first_line[:32]:
+            return None
+        try:
+            frame = pd.read_csv(path, encoding=encoding, skiprows=[0, 2, 3])
+        except Exception as exc:  # pragma: no cover - surfaced in parse_failed notes
+            errors.append(f"{encoding}:toa5: {type(exc).__name__}: {exc}")
+            continue
+        if frame.shape[1] > 1:
+            return LoadedTable(frame=frame, parser_used=f"pandas.read_csv({encoding}:toa5)")
+        errors.append(f"{encoding}:toa5: parsed one column")
+    return LoadedTable(frame=None, parser_used="pandas.read_csv(toa5)", error="; ".join(errors))
+
+
+def _read_dat_or_csv(path: Path) -> LoadedTable:
+    toa5 = _read_toa5_dat(path)
+    if toa5 is not None:
+        return toa5
+
+    attempts: tuple[tuple[str, dict[str, object]], ...] = (
+        ("utf-8-sig:sniff", {"encoding": "utf-8-sig", "sep": None, "engine": "python"}),
+        ("utf-8:sniff", {"encoding": "utf-8", "sep": None, "engine": "python"}),
+        ("cp949:sniff", {"encoding": "cp949", "sep": None, "engine": "python"}),
+        ("utf-8-sig:tab", {"encoding": "utf-8-sig", "sep": "\t"}),
+        ("utf-8-sig:whitespace", {"encoding": "utf-8-sig", "sep": r"\s+", "engine": "python"}),
+    )
+    errors: list[str] = []
+    for label, kwargs in attempts:
+        try:
+            frame = pd.read_csv(path, **kwargs)
+        except Exception as exc:  # pragma: no cover - surfaced in parse_failed notes
+            errors.append(f"{label}: {type(exc).__name__}: {exc}")
+            continue
+        if frame.shape[1] > 1:
+            return LoadedTable(frame=frame, parser_used=f"pandas.read_csv({label})")
+        errors.append(f"{label}: parsed one column")
+    return LoadedTable(frame=None, parser_used="pandas.read_csv", error="; ".join(errors))
+
+
+def _parquet_column_stats(path: Path) -> dict[str, dict[str, object]]:
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(path)
+    names = list(parquet_file.schema_arrow.names)
+    out: dict[str, dict[str, object]] = {
+        name: {"null_count": 0, "num_values": 0, "min": None, "max": None} for name in names
+    }
+    for row_group_idx in range(parquet_file.metadata.num_row_groups):
+        row_group = parquet_file.metadata.row_group(row_group_idx)
+        for column_idx, name in enumerate(names):
+            stats = row_group.column(column_idx).statistics
+            if stats is None:
+                continue
+            target = out[name]
+            target["null_count"] = int(target["null_count"] or 0) + int(stats.null_count or 0)
+            target["num_values"] = int(target["num_values"] or 0) + int(stats.num_values or 0)
+            if not stats.has_min_max:
+                continue
+            min_value = _jsonable_stat_value(stats.min)
+            max_value = _jsonable_stat_value(stats.max)
+            if target["min"] is None or _stat_less(min_value, target["min"]):
+                target["min"] = min_value
+            if target["max"] is None or _stat_greater(max_value, target["max"]):
+                target["max"] = max_value
+    return out
+
+
+def _sample_columns_for_audit(columns: Sequence[str]) -> list[str]:
+    matched = match_semantic_roles(columns)
+    selected: list[str] = []
+    for role_matches in matched.values():
+        selected.extend(role_matches)
+    for required in ("env_radiation_wm2_mean", "env_radiation_wm2_max"):
+        if required in columns:
+            selected.append(required)
+    deduped = list(dict.fromkeys(selected))
+    return deduped or list(columns[: min(len(columns), 20)])
+
+
+def _read_large_parquet_metadata_sample(path: Path) -> LoadedTable:
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(path)
+    column_names = tuple(str(name) for name in parquet_file.schema_arrow.names)
+    sample_columns = _sample_columns_for_audit(column_names)
+    try:
+        first_batch = next(parquet_file.iter_batches(batch_size=10_000, columns=sample_columns), None)
+    except StopIteration:
+        first_batch = None
+    sample = first_batch.to_pandas() if first_batch is not None else pd.DataFrame(columns=sample_columns)
+    return LoadedTable(
+        frame=sample,
+        parser_used="pyarrow.parquet.metadata_sample",
+        row_count=int(parquet_file.metadata.num_rows),
+        column_names=column_names,
+        dtype_map={str(field.name): str(field.type) for field in parquet_file.schema_arrow},
+        column_stats=_parquet_column_stats(path),
+    )
+
+
+def load_input_table(path: Path) -> LoadedTable:
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        if path.stat().st_size > 64 * 1024 * 1024:
+            try:
+                return _read_large_parquet_metadata_sample(path)
+            except Exception as exc:  # pragma: no cover - surfaced in parse_failed notes
+                return LoadedTable(
+                    frame=None,
+                    parser_used="pyarrow.parquet.metadata_sample",
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+        try:
+            frame = pd.read_parquet(path)
+            return LoadedTable(
+                frame=frame,
+                parser_used="pandas.read_parquet",
+                row_count=int(frame.shape[0]),
+                column_names=tuple(str(column) for column in frame.columns),
+                dtype_map={str(column): str(dtype) for column, dtype in frame.dtypes.items()},
+            )
+        except Exception as exc:  # pragma: no cover - surfaced in parse_failed notes
+            return LoadedTable(frame=None, parser_used="pandas.read_parquet", error=f"{type(exc).__name__}: {exc}")
+    if suffix in {".csv", ".dat", ".txt"}:
+        return _read_dat_or_csv(path)
+    return LoadedTable(frame=None, parser_used="unsupported", error=f"Unsupported extension: {suffix}")
+
+
+def _missing_important_roles(file_role: str, matched_roles: Mapping[str, list[str]]) -> list[str]:
+    missing: list[str] = []
+    for role in IMPORTANT_ROLES_BY_FILE_ROLE.get(file_role, ()):
+        if role == "datetime_or_date":
+            if "datetime" not in matched_roles and "date" not in matched_roles:
+                missing.append(role)
+        elif role not in matched_roles:
+            missing.append(role)
+    return missing
+
+
+def _status_for(file_role: str, missing_roles: Sequence[str], parse_error: str | None) -> str:
+    if parse_error:
+        return "parse_failed"
+    if "datetime_or_date" in missing_roles or "datetime" in missing_roles:
+        return "missing_required_column"
+    if file_role == "dataset1" and "radiation" in missing_roles:
+        return "unsafe_for_primary_use"
+    if missing_roles:
+        return "ok_with_warnings"
+    return "ok"
+
+
+def audit_input_file(
+    *,
+    file_role: str,
+    expected_filename: str,
+    resolved_path: Path,
+) -> tuple[dict[str, object], pd.DataFrame | None]:
+    base_row: dict[str, object] = {
+        "file_role": file_role,
+        "expected_filename": expected_filename,
+        "resolved_path": str(resolved_path),
+        "exists": resolved_path.exists(),
+        "file_size_bytes": resolved_path.stat().st_size if resolved_path.exists() else None,
+        "extension": resolved_path.suffix.lower(),
+        "parser_used": "",
+        "row_count": None,
+        "column_count": None,
+        "columns_json": "[]",
+        "dtype_json": "{}",
+        "datetime_column": None,
+        "date_column": None,
+        "date_min": None,
+        "date_max": None,
+        "inferred_time_resolution_seconds": None,
+        "loadcell_column": None,
+        "loadcell_ids_json": "[]",
+        "treatment_column": None,
+        "treatment_values_json": "[]",
+        "matched_semantic_roles_json": "{}",
+        "missing_important_roles_json": "[]",
+        "notes": "",
+        "status": "missing_file",
+    }
+    if not resolved_path.exists():
+        base_row["notes"] = "Required raw input file is missing."
+        return base_row, None
+
+    loaded = load_input_table(resolved_path)
+    base_row["parser_used"] = loaded.parser_used
+    if loaded.frame is None:
+        base_row["notes"] = loaded.error or "Parse failed."
+        base_row["status"] = "parse_failed"
+        return base_row, None
+
+    frame = loaded.frame
+    column_names = list(loaded.column_names or tuple(str(column) for column in frame.columns))
+    matched_roles = match_semantic_roles(column_names)
+    datetime_column = matched_roles.get("datetime", [None])[0]
+    date_column = matched_roles.get("date", [None])[0]
+    date_source_column = datetime_column or date_column
+    if date_source_column is not None:
+        stats = (loaded.column_stats or {}).get(date_source_column, {})
+        if stats.get("min") is not None:
+            base_row["date_min"] = _iso_timestamp(stats.get("min"))
+        if stats.get("max") is not None:
+            base_row["date_max"] = _iso_timestamp(stats.get("max"))
+        parsed_dates = pd.to_datetime(frame[date_source_column], errors="coerce").dropna()
+        if not parsed_dates.empty:
+            base_row["date_min"] = base_row["date_min"] or _iso_timestamp(parsed_dates.min())
+            base_row["date_max"] = base_row["date_max"] or _iso_timestamp(parsed_dates.max())
+            base_row["inferred_time_resolution_seconds"] = _infer_resolution_seconds(frame[date_source_column])
+
+    loadcell_column = matched_roles.get("loadcell", [None])[0]
+    treatment_column = matched_roles.get("treatment", [None])[0]
+    missing_roles = _missing_important_roles(file_role, matched_roles)
+
+    base_row.update(
+        {
+            "row_count": loaded.row_count if loaded.row_count is not None else int(frame.shape[0]),
+            "column_count": len(column_names),
+            "columns_json": _json_dumps(column_names),
+            "dtype_json": _json_dumps(
+                dict(loaded.dtype_map or {str(column): str(dtype) for column, dtype in frame.dtypes.items()})
+            ),
+            "datetime_column": datetime_column,
+            "date_column": date_column,
+            "loadcell_column": loadcell_column,
+            "loadcell_ids_json": _json_dumps(
+                _sorted_unique_json_values(frame[loadcell_column]) if loadcell_column else []
+            ),
+            "treatment_column": treatment_column,
+            "treatment_values_json": _json_dumps(
+                _sorted_unique_json_values(frame[treatment_column]) if treatment_column else []
+            ),
+            "matched_semantic_roles_json": _json_dumps(matched_roles),
+            "missing_important_roles_json": _json_dumps(missing_roles),
+            "column_stats_json": _json_dumps(dict(loaded.column_stats or {})),
+            "status": _status_for(file_role, missing_roles, None),
+        }
+    )
+    if missing_roles:
+        base_row["notes"] = f"Missing or ambiguous roles: {', '.join(missing_roles)}"
+    return base_row, frame
+
+
+def _as_mapping(raw: object) -> dict[str, Any]:
+    if isinstance(raw, Mapping):
+        return {str(key): value for key, value in raw.items()}
+    return {}
+
+
+def _resolve_path(raw: str | Path, *, repo_root: Path) -> Path:
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    return (repo_root / path).resolve()
+
+
+def _input_specs_from_config(config: Mapping[str, object]) -> list[dict[str, str]]:
+    raw_specs = _as_mapping(_as_mapping(config.get("tomics_haf")).get("input_files"))
+    specs: list[dict[str, str]] = []
+    for default_spec in DEFAULT_INPUT_FILE_SPECS:
+        role = default_spec["file_role"]
+        specs.append(
+            {
+                "file_role": role,
+                "expected_filename": str(raw_specs.get(role, default_spec["expected_filename"])),
+            }
+        )
+    return specs
+
+
+def _dataset3_mapping(audit_rows_by_role: Mapping[str, Mapping[str, object]]) -> str:
+    dataset3 = audit_rows_by_role.get("dataset3", {})
+    if dataset3.get("loadcell_column"):
+        return "direct_loadcell"
+    if dataset3.get("treatment_column"):
+        return "treatment_level_only"
+    return "unlinked"
+
+
+def _role_available(audit_rows: Sequence[Mapping[str, object]], role: str) -> bool:
+    for row in audit_rows:
+        try:
+            matched = json.loads(str(row.get("matched_semantic_roles_json") or "{}"))
+        except json.JSONDecodeError:
+            continue
+        if matched.get(role):
+            return True
+    return False
+
+
+def _build_metadata(
+    *,
+    audit_rows: Sequence[Mapping[str, object]],
+    audit_rows_by_role: Mapping[str, Mapping[str, object]],
+    radiation_metadata: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "season_id": SEASON_ID,
+        "raw_filename_note": RAW_FILENAME_NOTE,
+        **SENSOR_MAPPING_METADATA,
+        **dict(radiation_metadata),
+        "vpd_available": _role_available(audit_rows, "vpd"),
+        "lai_available": _role_available(audit_rows, "lai"),
+        "fresh_yield_available": _role_available(audit_rows, "yield_fresh"),
+        "dry_yield_available": _role_available(audit_rows, "yield_dry"),
+        "dataset3_mapping": _dataset3_mapping(audit_rows_by_role),
+        "shipped_tomics_incumbent_unchanged": True,
+        "raw_thorp_promoted": False,
+    }
+
+
+def _markdown_report(
+    *,
+    audit_rows: Sequence[Mapping[str, object]],
+    radiation_rows: Sequence[Mapping[str, object]],
+    metadata: Mapping[str, object],
+) -> str:
+    found = [row for row in audit_rows if row.get("exists")]
+    missing = [row for row in audit_rows if not row.get("exists")]
+    primary = next((row for row in radiation_rows if row.get("chosen_primary")), None)
+    lines = [
+        "# TOMICS-HAF 2025-2C radiation source verification",
+        "",
+        "Day/night phases will be radiation-defined from Dataset1 when Dataset1 radiation is usable.",
+        "Fixed 06:00-18:00 windows remain compatibility-only.",
+        "Fruit diameter observer remains sensor-level apparent expansion diagnostics.",
+        "Shipped TOMICS incumbent remains unchanged.",
+        "",
+        "## Files found",
+    ]
+    for row in found:
+        lines.append(f"- `{row['file_role']}`: `{row['expected_filename']}` via `{row['parser_used']}`")
+    if missing:
+        lines.append("")
+        lines.append("## Files missing")
+        for row in missing:
+            lines.append(f"- `{row['file_role']}`: `{row['expected_filename']}`")
+    lines.extend(["", "## Semantic roles"])
+    for row in audit_rows:
+        lines.append(f"- `{row['file_role']}` status `{row['status']}`")
+        lines.append(f"  - matched: `{row['matched_semantic_roles_json']}`")
+        lines.append(f"  - missing/ambiguous: `{row['missing_important_roles_json']}`")
+    lines.extend(["", "## Radiation decision"])
+    if primary is None:
+        lines.append("- No primary radiation column was selected.")
+    else:
+        lines.append(
+            f"- Selected `{primary['candidate_column']}` from `{primary['source_file_role']}` "
+            f"(rank {primary['candidate_rank']})."
+        )
+    lines.append(f"- Dataset1 radiation grain: `{metadata['dataset1_radiation_grain']}`")
+    lines.append(f"- Dataset1 directly usable for Goal 2: `{metadata['dataset1_radiation_directly_usable']}`")
+    lines.append(f"- Fallback required: `{metadata['fallback_required']}`")
+    lines.append(f"- Fallback source if required: `{metadata['fallback_source_if_required']}`")
+    lines.append("- Thresholds to test later: `[0, 1, 5, 10]`")
+    lines.extend(["", "## Role availability"])
+    lines.append(f"- VPD available: `{metadata['vpd_available']}`")
+    lines.append(f"- LAI available: `{metadata['lai_available']}`")
+    lines.append(f"- Fresh yield available: `{metadata['fresh_yield_available']}`")
+    lines.append(f"- Dry yield available: `{metadata['dry_yield_available']}`")
+    lines.append(f"- Dataset3 mapping: `{metadata['dataset3_mapping']}`")
+    lines.extend(["", "## Unresolved assumptions"])
+    notes = metadata.get("radiation_source_decision_notes") or []
+    if notes:
+        for note in notes:
+            lines.append(f"- {note}")
+    else:
+        lines.append("- None beyond the recorded schema and radiation grain checks.")
+    return "\n".join(lines) + "\n"
+
+
+def run_tomics_haf_input_schema_audit(
+    config: Mapping[str, object],
+    *,
+    repo_root: Path,
+    config_path: Path | None = None,
+) -> dict[str, object]:
+    del config_path
+    haf_cfg = _as_mapping(config.get("tomics_haf"))
+    raw_data_root = _resolve_path(
+        str(haf_cfg.get("raw_data_root", "artifacts/tomato_integrated_radiation_architecture_v1_3/input_raw")),
+        repo_root=repo_root,
+    )
+    output_root = ensure_dir(
+        _resolve_path(str(haf_cfg.get("output_root", "out/tomics/analysis/haf_2025_2c")), repo_root=repo_root)
+    )
+
+    audit_rows: list[dict[str, object]] = []
+    tables_by_role: dict[str, pd.DataFrame | None] = {}
+    for spec in _input_specs_from_config(config):
+        path = raw_data_root / spec["expected_filename"]
+        row, frame = audit_input_file(
+            file_role=spec["file_role"],
+            expected_filename=spec["expected_filename"],
+            resolved_path=path,
+        )
+        audit_rows.append(row)
+        tables_by_role[spec["file_role"]] = frame
+
+    audit_rows_by_role = {str(row["file_role"]): row for row in audit_rows}
+    radiation_rows, radiation_metadata = build_radiation_source_verification(
+        tables_by_role,
+        audit_rows_by_role,
+    )
+    metadata = _build_metadata(
+        audit_rows=audit_rows,
+        audit_rows_by_role=audit_rows_by_role,
+        radiation_metadata=radiation_metadata,
+    )
+
+    input_csv = output_root / "input_schema_audit.csv"
+    input_json = output_root / "input_schema_audit.json"
+    radiation_csv = output_root / "radiation_source_verification.csv"
+    radiation_json = output_root / "radiation_source_verification.json"
+    radiation_md = output_root / "radiation_source_verification.md"
+    metadata_json = output_root / "2025_2c_tomics_haf_metadata.json"
+
+    pd.DataFrame.from_records(audit_rows).to_csv(input_csv, index=False)
+    write_json(input_json, {"files": audit_rows})
+    pd.DataFrame.from_records(radiation_rows).to_csv(radiation_csv, index=False)
+    write_json(radiation_json, {"candidates": radiation_rows, "metadata": metadata})
+    write_json(metadata_json, metadata)
+    radiation_md.write_text(
+        _markdown_report(audit_rows=audit_rows, radiation_rows=radiation_rows, metadata=metadata),
+        encoding="utf-8",
+    )
+
+    return {
+        "output_root": str(output_root),
+        "input_schema_audit_csv": str(input_csv),
+        "input_schema_audit_json": str(input_json),
+        "radiation_source_verification_csv": str(radiation_csv),
+        "radiation_source_verification_json": str(radiation_json),
+        "radiation_source_verification_md": str(radiation_md),
+        "metadata_json": str(metadata_json),
+        "metadata": metadata,
+    }
+
+
+__all__ = [
+    "DEFAULT_INPUT_FILE_SPECS",
+    "DEFAULT_ROLE_ALIASES",
+    "RAW_FILENAME_NOTE",
+    "SEASON_ID",
+    "SENSOR_MAPPING_METADATA",
+    "audit_input_file",
+    "load_input_table",
+    "match_semantic_roles",
+    "normalize_column_name",
+    "run_tomics_haf_input_schema_audit",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/legacy_v1_3_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/legacy_v1_3_bridge.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import resolve_repo_path
+
+
+DEFAULT_LEGACY_V1_3_CONFIG = {
+    "enabled": False,
+    "archive_root": "artifacts/tomato_integrated_radiation_architecture_v1_3",
+    "event_bridge_daily_candidates": [
+        "previous_outputs/event_bridge_outputs/daily_event_bridged_transpiration.csv",
+        "outputs/derived/legacy_daily_event_bridged_transpiration.csv",
+    ],
+    "integrated_daily_master": "outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv",
+    "fresh_dry_loadcell_summary": "outputs/tables/fresh_dry_weight_loadcell_final_summary.csv",
+    "fresh_dry_treatment_summary": "outputs/tables/fresh_dry_weight_treatment_summary.csv",
+    "dataset3_traits_plus_yield": "outputs/derived/dataset3_traits_plus_fresh_dry_yield.csv",
+    "provenance_label": "legacy_v1_3_derived_output",
+    "allow_legacy_event_bridge_calibration": False,
+    "allow_legacy_event_bridge_qc_false": True,
+    "event_bridge_min_valid_coverage_fraction": 0.0,
+    "allow_legacy_yield_bridge": False,
+    "direct_dry_yield_measured": False,
+}
+
+
+def legacy_v1_3_config(config: Mapping[str, Any], *, repo_root: Path) -> dict[str, Any]:
+    raw = dict(DEFAULT_LEGACY_V1_3_CONFIG)
+    override = config.get("legacy_v1_3")
+    if isinstance(override, Mapping):
+        raw.update({str(key): value for key, value in override.items()})
+    raw["archive_root_path"] = resolve_repo_path(repo_root, str(raw["archive_root"]))
+    return raw
+
+
+def _candidate_paths(archive_root: Path, values: Sequence[object] | object) -> list[Path]:
+    if isinstance(values, (str, Path)):
+        raw_values = [values]
+    elif isinstance(values, Sequence):
+        raw_values = list(values)
+    else:
+        raw_values = []
+    return [(archive_root / str(value)).resolve() for value in raw_values]
+
+
+def audit_legacy_v1_3_bridge(config: Mapping[str, Any]) -> pd.DataFrame:
+    archive_root = Path(config["archive_root_path"])
+    rows: list[dict[str, Any]] = []
+    source_specs = {
+        "event_bridge_daily_candidate": config.get("event_bridge_daily_candidates", []),
+        "integrated_daily_master": config.get("integrated_daily_master"),
+        "fresh_dry_loadcell_summary": config.get("fresh_dry_loadcell_summary"),
+        "fresh_dry_treatment_summary": config.get("fresh_dry_treatment_summary"),
+        "dataset3_traits_plus_yield": config.get("dataset3_traits_plus_yield"),
+    }
+    for role, values in source_specs.items():
+        for path in _candidate_paths(archive_root, values):
+            row: dict[str, Any] = {
+                "source_role": role,
+                "path": str(path),
+                "exists": path.exists(),
+                "provenance": config.get("provenance_label", "legacy_v1_3_derived_output"),
+                "row_count": None,
+                "column_count": None,
+                "columns_json": "[]",
+                "date_min": None,
+                "date_max": None,
+                "loadcell_ids_json": "[]",
+                "treatment_values_json": "[]",
+                "status": "missing_file",
+                "notes": "",
+            }
+            if path.exists():
+                try:
+                    frame = pd.read_csv(path)
+                except Exception as exc:  # pragma: no cover - defensive audit note
+                    row["status"] = "parse_failed"
+                    row["notes"] = f"{type(exc).__name__}: {exc}"
+                else:
+                    row["row_count"] = int(frame.shape[0])
+                    row["column_count"] = int(frame.shape[1])
+                    row["columns_json"] = pd.Series([list(frame.columns)]).to_json(orient="values", force_ascii=False)
+                    if "date" in frame.columns:
+                        dates = pd.to_datetime(frame["date"], errors="coerce").dropna()
+                        if not dates.empty:
+                            row["date_min"] = dates.min().strftime("%Y-%m-%d")
+                            row["date_max"] = dates.max().strftime("%Y-%m-%d")
+                    if "loadcell_id" in frame.columns:
+                        row["loadcell_ids_json"] = (
+                            pd.Series(sorted(pd.to_numeric(frame["loadcell_id"], errors="coerce").dropna().astype(int).unique()))
+                            .to_json(orient="values")
+                        )
+                    if "treatment" in frame.columns:
+                        row["treatment_values_json"] = (
+                            pd.Series(sorted(frame["treatment"].dropna().astype(str).unique())).to_json(orient="values")
+                        )
+                    row["status"] = "ok"
+            rows.append(row)
+    return pd.DataFrame(rows)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/loadcell_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/loadcell_bridge.py
@@ -20,4 +20,3 @@ def loadcell_treatment_lookup(frame: pd.DataFrame) -> pd.DataFrame:
         .sort_values("loadcell_id")
         .reset_index(drop=True)
     )
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/loadcell_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/loadcell_bridge.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def coerce_loadcell_id(frame: pd.DataFrame, *, column: str = "loadcell_id") -> pd.DataFrame:
+    out = frame.copy()
+    if column in out.columns:
+        out[column] = pd.to_numeric(out[column], errors="coerce").astype("Int64")
+    return out
+
+
+def loadcell_treatment_lookup(frame: pd.DataFrame) -> pd.DataFrame:
+    if not {"loadcell_id", "treatment"}.issubset(frame.columns):
+        return pd.DataFrame(columns=["loadcell_id", "treatment"])
+    return (
+        coerce_loadcell_id(frame)[["loadcell_id", "treatment"]]
+        .dropna()
+        .drop_duplicates()
+        .sort_values("loadcell_id")
+        .reset_index(drop=True)
+    )
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py
@@ -106,6 +106,12 @@ def metadata_contract_audit(metadata: Mapping[str, Any]) -> pd.DataFrame:
         "fruit_diameter_allocation_calibration_target",
         "fruit_diameter_model_promotion_target",
         "shipped_TOMICS_incumbent_changed",
+        "canonical_fruit_DMC_fraction",
+        "fruit_DMC_fraction",
+        "default_fruit_dry_matter_content",
+        "DMC_fixed_for_2025_2C",
+        "DMC_sensitivity_enabled",
+        "deprecated_previous_default_fruit_DMC_fraction",
     )
     missing = [key for key in required if key not in normalized]
     rows.append(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import write_json
+
+
+CANONICAL_TOP_LEVEL_KEYS = {
+    "vpd_available": "VPD_available",
+    "lai_available": "LAI_available",
+    "dataset3_mapping": "Dataset3_mapping_confidence",
+    "dataset3_mapping_confidence": "Dataset3_mapping_confidence",
+    "shipped_tomics_incumbent_unchanged": "shipped_TOMICS_incumbent_changed",
+}
+
+
+def _canonical_key(key: str) -> str:
+    return CANONICAL_TOP_LEVEL_KEYS.get(key.casefold(), key)
+
+
+def normalize_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Return metadata with stable top-level keys and no case-insensitive duplicates."""
+
+    normalized: dict[str, Any] = {}
+    legacy_metadata: dict[str, Any] = {}
+    casefold_to_key: dict[str, str] = {}
+    existing_legacy = metadata.get("legacy_metadata")
+    if isinstance(existing_legacy, Mapping):
+        legacy_metadata.update({str(key): value for key, value in existing_legacy.items()})
+
+    for raw_key, value in metadata.items():
+        key = str(raw_key)
+        if key == "legacy_metadata":
+            continue
+        canonical = _canonical_key(key)
+        canonical_value = value
+        if key.casefold() == "shipped_tomics_incumbent_unchanged" and isinstance(value, bool):
+            canonical_value = not value
+        folded = canonical.casefold()
+        if folded in casefold_to_key:
+            retained = casefold_to_key[folded]
+            if key == canonical:
+                normalized[canonical] = canonical_value
+                continue
+            if key != retained:
+                legacy_metadata[key] = value
+            continue
+        casefold_to_key[folded] = canonical
+        normalized[canonical] = canonical_value
+        if canonical != key:
+            legacy_metadata[key] = value
+
+    if legacy_metadata:
+        normalized["legacy_metadata"] = legacy_metadata
+    assert_no_case_insensitive_duplicate_keys(normalized)
+    return normalized
+
+
+def case_insensitive_duplicate_keys(metadata: Mapping[str, Any]) -> list[str]:
+    seen: dict[str, str] = {}
+    duplicates: list[str] = []
+    for key in metadata:
+        text = str(key)
+        folded = text.casefold()
+        if folded in seen and seen[folded] != text:
+            duplicates.append(text)
+        else:
+            seen[folded] = text
+    return duplicates
+
+
+def assert_no_case_insensitive_duplicate_keys(metadata: Mapping[str, Any]) -> None:
+    duplicates = case_insensitive_duplicate_keys(metadata)
+    if duplicates:
+        raise ValueError(f"Metadata contains case-insensitive duplicate keys: {duplicates}")
+
+
+def write_normalized_metadata(path: str | Path, metadata: Mapping[str, Any]) -> Path:
+    return write_json(path, normalize_metadata(metadata))
+
+
+def write_stage_metadata_snapshot(path: str | Path, metadata: Mapping[str, Any]) -> Path:
+    return write_normalized_metadata(path, metadata)
+
+
+def metadata_contract_audit(metadata: Mapping[str, Any]) -> pd.DataFrame:
+    normalized = normalize_metadata(metadata)
+    rows = [
+        {
+            "check_name": "no_case_insensitive_duplicate_top_level_keys",
+            "status": "pass",
+            "violation_count": 0,
+            "notes": "Top-level metadata keys are unique under case-insensitive parsers.",
+        }
+    ]
+    required = (
+        "LAI_available",
+        "VPD_available",
+        "Dataset3_mapping_confidence",
+        "fruit_diameter_p_values_allowed",
+        "fruit_diameter_allocation_calibration_target",
+        "fruit_diameter_model_promotion_target",
+        "shipped_TOMICS_incumbent_changed",
+    )
+    missing = [key for key in required if key not in normalized]
+    rows.append(
+        {
+            "check_name": "canonical_top_level_keys_present",
+            "status": "pass" if not missing else "fail",
+            "violation_count": len(missing),
+            "notes": ";".join(missing),
+        }
+    )
+    return pd.DataFrame(rows)
+
+
+def json_has_case_insensitive_duplicate_keys(path: str | Path) -> bool:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        return False
+    return bool(case_insensitive_duplicate_keys(data))

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/parquet_streaming.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/parquet_streaming.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def parquet_metadata_summary(path: str | Path) -> dict[str, Any]:
+    import pyarrow.parquet as pq
+
+    parquet_path = Path(path)
+    parquet_file = pq.ParquetFile(parquet_path)
+    return {
+        "path": str(parquet_path),
+        "file_size_bytes": parquet_path.stat().st_size,
+        "total_rows": int(parquet_file.metadata.num_rows),
+        "row_group_count": int(parquet_file.metadata.num_row_groups),
+        "columns": [str(name) for name in parquet_file.schema_arrow.names],
+    }
+
+
+def projected_columns(path: str | Path, columns: Sequence[str]) -> list[str]:
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(path)
+    available = set(parquet_file.schema_arrow.names)
+    return [str(column) for column in columns if column in available]
+
+
+def iter_projected_parquet_batches(
+    path: str | Path,
+    columns: Sequence[str],
+    *,
+    batch_size: int,
+    max_rows: int | None = None,
+) -> Iterator[pd.DataFrame]:
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(path)
+    available = projected_columns(path, columns)
+    remaining = max_rows
+    for batch in parquet_file.iter_batches(batch_size=batch_size, columns=available):
+        frame = batch.to_pandas()
+        if remaining is not None:
+            if remaining <= 0:
+                break
+            if frame.shape[0] > remaining:
+                frame = frame.iloc[:remaining].copy()
+            remaining -= int(frame.shape[0])
+        yield frame
+
+
+def assert_no_large_full_load_without_limit(
+    *,
+    total_rows: int,
+    max_rows: int | None,
+    mode: str,
+    max_full_rows_without_limit: int,
+    fail_on_full_in_memory_large_dataset: bool = True,
+) -> None:
+    if mode == "production":
+        return
+    if fail_on_full_in_memory_large_dataset and max_rows is None and total_rows > max_full_rows_without_limit:
+        raise RuntimeError(
+            f"Refusing full in-memory load of {total_rows:,} rows in {mode!r} mode. "
+            "Set max_rows for smoke mode or use production chunk aggregation."
+        )
+
+
+def validate_production_row_cap_policy(
+    *,
+    mode: str,
+    max_rows_by_dataset: dict[str, Any],
+    require_row_cap_absent_for_production: bool,
+) -> None:
+    if mode != "production" or not require_row_cap_absent_for_production:
+        return
+    capped = {
+        dataset: value
+        for dataset, value in max_rows_by_dataset.items()
+        if value is not None
+    }
+    if capped:
+        raise ValueError(f"Production mode forbids row caps, got {capped}.")
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/parquet_streaming.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/parquet_streaming.py
@@ -84,4 +84,3 @@ def validate_production_row_cap_policy(
     }
     if capped:
         raise ValueError(f"Production mode forbids row caps, got {capped}.")
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
@@ -212,15 +212,59 @@ def _merge_legacy_yield_bridge(feature_frame: pd.DataFrame, yield_bridge: pd.Dat
         return feature_frame
     bridge_columns = keys + [column for column in right.columns if column not in keys]
     merged = left.merge(right[bridge_columns], on=keys, how="left", suffixes=("", "_legacy_yield"))
-    fresh_cols = [column for column in ("measured_or_legacy_fresh_yield_g", "loadcell_daily_yield_g", "final_fresh_yield_g") if column in merged.columns]
-    dry_cols = [column for column in merged.columns if "_dry_yield_g_est_" in column or column.endswith("_dry_yield_g_est_5p6pct")]
+    for column in (
+        "fresh_yield_source",
+        "dry_yield_source",
+        "observed_fruit_FW_g_loadcell",
+        "observed_fruit_DW_g_loadcell_dmc_0p056",
+        "observed_fruit_DW_g_m2_floor_dmc_0p056",
+        "canonical_fruit_DMC_fraction",
+        "fruit_DMC_fraction",
+        "default_fruit_dry_matter_content",
+        "DMC_fixed_for_2025_2C",
+        "DMC_sensitivity_enabled",
+        "dry_yield_is_dmc_estimated",
+        "direct_dry_yield_measured",
+        "legacy_yield_bridge_provenance",
+        "legacy_sensitivity_columns_present",
+    ):
+        legacy_column = f"{column}_legacy_yield"
+        if legacy_column in merged.columns:
+            if column in merged.columns:
+                merged[column] = merged[legacy_column].combine_first(merged[column])
+            else:
+                merged[column] = merged[legacy_column]
+    fresh_cols = [
+        column
+        for column in (
+            "measured_or_legacy_fresh_yield_g",
+            "loadcell_daily_yield_g",
+            "loadcell_cumulative_yield_g",
+            "individual_cumulative_yield_g",
+            "final_fresh_yield_g",
+        )
+        if column in merged.columns
+    ]
+    dry_cols = [
+        column
+        for column in (
+            "observed_fruit_DW_g_loadcell_dmc_0p056",
+            "observed_fruit_DW_g_m2_floor_dmc_0p056",
+        )
+        if column in merged.columns
+    ]
     fresh_available = merged[fresh_cols].notna().any(axis=1) if fresh_cols else pd.Series(False, index=merged.index)
     dry_available = merged[dry_cols].notna().any(axis=1) if dry_cols else pd.Series(False, index=merged.index)
+    direct_dry = (
+        merged["direct_dry_yield_measured"].fillna(False).astype(bool)
+        if "direct_dry_yield_measured" in merged.columns
+        else pd.Series(False, index=merged.index)
+    )
     merged["harvest_yield_available"] = fresh_available | dry_available
     merged["fresh_yield_available"] = fresh_available
     merged["dry_yield_available"] = dry_available
-    merged["dry_yield_is_dmc_estimated"] = dry_available
-    merged["direct_dry_yield_measured"] = False
+    merged["direct_dry_yield_measured"] = direct_dry & dry_available
+    merged["dry_yield_is_dmc_estimated"] = dry_available & ~merged["direct_dry_yield_measured"]
     merged["DMC_conversion_performed"] = dry_available
     return merged
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
@@ -28,6 +28,17 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.fruit_diameter_window
     build_fruit_leaf_loadcell_bridge,
     build_fruit_leaf_radiation_windows,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.observers.parquet_streaming import (
+    assert_no_large_full_load_without_limit,
+    iter_projected_parquet_batches,
+    parquet_metadata_summary,
+    projected_columns,
+    validate_production_row_cap_policy,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.production_export import (
+    aggregate_dataset1_streaming,
+    aggregate_dataset2_daily_streaming,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.observers.qc import apply_fruit_leaf_qc
 from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source import (
     build_radiation_source_verification,
@@ -66,7 +77,14 @@ def _tomics_haf_config(config: dict[str, Any]) -> dict[str, Any]:
 def _write_csv(output_root: Path, key: str, frame: pd.DataFrame) -> Path:
     ensure_dir(output_root)
     path = output_root / OUTPUT_FILENAMES[key]
-    frame.to_csv(path, index=False)
+    frame.to_csv(path, index=False, encoding="utf-8")
+    return path
+
+
+def _write_text(output_root: Path, key: str, text: str) -> Path:
+    ensure_dir(output_root)
+    path = output_root / OUTPUT_FILENAMES[key]
+    path.write_text(text, encoding="utf-8")
     return path
 
 
@@ -94,41 +112,49 @@ def _read_projected_parquet(
     max_rows: int | None,
     batch_size: int,
     max_full_rows_without_limit: int,
+    mode: str = "smoke",
+    fail_on_full_in_memory_large_dataset: bool = True,
 ) -> tuple[pd.DataFrame, dict[str, Any]]:
-    import pyarrow.parquet as pq
+    parquet_meta = parquet_metadata_summary(path)
+    available = projected_columns(path, columns)
+    total_rows = int(parquet_meta["total_rows"])
+    assert_no_large_full_load_without_limit(
+        total_rows=total_rows,
+        max_rows=max_rows,
+        mode=mode,
+        max_full_rows_without_limit=max_full_rows_without_limit,
+        fail_on_full_in_memory_large_dataset=fail_on_full_in_memory_large_dataset,
+    )
 
-    parquet_file = pq.ParquetFile(path)
-    available = [column for column in columns if column in parquet_file.schema_arrow.names]
-    total_rows = int(parquet_file.metadata.num_rows)
-    if max_rows is None and total_rows > max_full_rows_without_limit:
-        raise RuntimeError(
-            f"Refusing to load {total_rows:,} rows from {path.name} without max_rows. "
-            "Set observer_pipeline.max_rows for a bounded local smoke run."
-        )
-
-    remaining = max_rows
     frames: list[pd.DataFrame] = []
     rows_loaded = 0
-    for batch in parquet_file.iter_batches(batch_size=batch_size, columns=available):
-        chunk = batch.to_pandas()
-        if remaining is not None and chunk.shape[0] > remaining:
-            chunk = chunk.iloc[:remaining].copy()
+    batches_processed = 0
+    for chunk in iter_projected_parquet_batches(path, columns, batch_size=batch_size, max_rows=max_rows):
+        batches_processed += 1
         frames.append(chunk)
         rows_loaded += int(chunk.shape[0])
-        if remaining is not None:
-            remaining -= int(chunk.shape[0])
-            if remaining <= 0:
-                break
     frame = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=available)
     metadata = {
         "path": str(path),
         "projected_columns": available,
         "total_rows": total_rows,
         "rows_loaded": rows_loaded,
+        "rows_processed": rows_loaded,
+        "rows_processed_fraction": rows_loaded / total_rows if total_rows else 1.0,
         "row_limit_applied": max_rows is not None and rows_loaded < total_rows,
         "max_rows": max_rows,
+        "batches_processed": batches_processed,
+        "chunk_aggregation_complete": rows_loaded == total_rows,
+        "chunk_aggregation_used": False,
+        "full_in_memory_large_dataset_used": bool(total_rows > max_full_rows_without_limit),
     }
     return frame, metadata
+
+
+def _read_projected_sample(path: Path, columns: tuple[str, ...], *, batch_size: int = 10_000) -> pd.DataFrame:
+    for chunk in iter_projected_parquet_batches(path, columns, batch_size=batch_size, max_rows=batch_size):
+        return chunk
+    return pd.DataFrame(columns=projected_columns(path, columns))
 
 
 def _path_for_input(raw_root: Path, role: str, config: dict[str, Any]) -> Path:
@@ -149,9 +175,23 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
     ensure_dir(output_root)
 
     pipeline_config = dict(config.get("observer_pipeline", {}))
+    mode = str(pipeline_config.get("mode", "smoke"))
+    if mode not in {"smoke", "production"}:
+        raise ValueError(f"observer_pipeline.mode must be 'smoke' or 'production', got {mode!r}.")
     batch_size = int(pipeline_config.get("parquet_batch_size", 250_000))
     max_full_rows_without_limit = int(pipeline_config.get("max_full_rows_without_limit", 2_000_000))
+    fail_on_full_in_memory_large_dataset = bool(pipeline_config.get("fail_on_full_in_memory_large_dataset", True))
+    require_row_cap_absent_for_production = bool(
+        pipeline_config.get("require_row_cap_absent_for_production", True)
+    )
+    write_intermediate_chunk_manifests = bool(pipeline_config.get("write_intermediate_chunk_manifests", False))
     max_rows = pipeline_config.get("max_rows", {})
+    max_rows = max_rows if isinstance(max_rows, dict) else {}
+    validate_production_row_cap_policy(
+        mode=mode,
+        max_rows_by_dataset=max_rows,
+        require_row_cap_absent_for_production=require_row_cap_absent_for_production,
+    )
     dataset1_max_rows = max_rows.get("dataset1") if isinstance(max_rows, dict) else None
     dataset2_max_rows = max_rows.get("dataset2") if isinstance(max_rows, dict) else None
     dataset3_max_rows = max_rows.get("dataset3") if isinstance(max_rows, dict) else None
@@ -177,32 +217,45 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
     fruit_leaf_qc_path = _write_csv(output_root, "fruit_leaf_timeseries_qc", fruit_leaf_qc)
     sensor_qc_path = _write_csv(output_root, "sensor_qc_report", sensor_qc_report)
 
-    dataset1, dataset1_load_meta = _read_projected_parquet(
-        dataset1_path,
-        DATASET1_COLUMN_CANDIDATES,
-        max_rows=int(dataset1_max_rows) if dataset1_max_rows is not None else None,
-        batch_size=batch_size,
-        max_full_rows_without_limit=max_full_rows_without_limit,
-    )
-    dataset1["timestamp"] = pd.to_datetime(dataset1["timestamp"], errors="coerce")
-
     audit_rows = _load_audit_rows(output_root)
+    dataset1_sample = _read_projected_sample(dataset1_path, DATASET1_COLUMN_CANDIDATES)
     radiation_rows, radiation_decision = build_radiation_source_verification(
-        {"dataset1": dataset1, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
+        {"dataset1": dataset1_sample, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
         audit_rows,
     )
 
-    radiation_intervals = build_radiation_intervals(
-        dataset1,
-        thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
-        timestamp_col="timestamp",
-        radiation_col=RADIATION_COLUMN_USED,
-    )
+    chunk_manifest_frames: list[pd.DataFrame] = []
+    if mode == "production":
+        radiation_intervals, event_intervals, dataset1_load_meta, dataset1_manifest = aggregate_dataset1_streaming(
+            path=dataset1_path,
+            columns=DATASET1_COLUMN_CANDIDATES,
+            batch_size=batch_size,
+            max_rows=None,
+            thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
+        )
+        chunk_manifest_frames.append(dataset1_manifest)
+    else:
+        dataset1, dataset1_load_meta = _read_projected_parquet(
+            dataset1_path,
+            DATASET1_COLUMN_CANDIDATES,
+            max_rows=int(dataset1_max_rows) if dataset1_max_rows is not None else None,
+            batch_size=batch_size,
+            max_full_rows_without_limit=max_full_rows_without_limit,
+            mode=mode,
+            fail_on_full_in_memory_large_dataset=fail_on_full_in_memory_large_dataset,
+        )
+        dataset1["timestamp"] = pd.to_datetime(dataset1["timestamp"], errors="coerce")
+        radiation_intervals = build_radiation_intervals(
+            dataset1,
+            thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
+            timestamp_col="timestamp",
+            radiation_col=RADIATION_COLUMN_USED,
+        )
+        event_intervals = build_10min_event_bridged_water_loss(dataset1, radiation_intervals)
     photoperiod = build_photoperiod_table(radiation_intervals)
     radiation_daily = build_radiation_daily_summary(radiation_intervals)
     photoperiod_path = _write_csv(output_root, "radiation_photoperiod", photoperiod)
 
-    event_intervals = build_10min_event_bridged_water_loss(dataset1, radiation_intervals)
     event_intervals = calibrate_to_daily_event_bridged_total(event_intervals)
     event_intervals_path = _write_csv(output_root, "event_intervals", event_intervals)
     event_daily_all = summarize_radiation_daynight_et(event_intervals)
@@ -250,13 +303,24 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
     sensor_bridge = build_fruit_leaf_loadcell_bridge(mapping)
     sensor_bridge_path = _write_csv(output_root, "fruit_leaf_loadcell_bridge", sensor_bridge)
 
-    dataset2, dataset2_load_meta = _read_projected_parquet(
-        dataset2_path,
-        DATASET2_COLUMN_CANDIDATES,
-        max_rows=int(dataset2_max_rows) if dataset2_max_rows is not None else None,
-        batch_size=batch_size,
-        max_full_rows_without_limit=max_full_rows_without_limit,
-    )
+    if mode == "production":
+        dataset2, dataset2_load_meta, dataset2_manifest = aggregate_dataset2_daily_streaming(
+            path=dataset2_path,
+            columns=DATASET2_COLUMN_CANDIDATES,
+            batch_size=batch_size,
+            max_rows=None,
+        )
+        chunk_manifest_frames.append(dataset2_manifest)
+    else:
+        dataset2, dataset2_load_meta = _read_projected_parquet(
+            dataset2_path,
+            DATASET2_COLUMN_CANDIDATES,
+            max_rows=int(dataset2_max_rows) if dataset2_max_rows is not None else None,
+            batch_size=batch_size,
+            max_full_rows_without_limit=max_full_rows_without_limit,
+            mode=mode,
+            fail_on_full_in_memory_large_dataset=fail_on_full_in_memory_large_dataset,
+        )
     rootzone = build_rootzone_indices(dataset2, daily_wide)
     rootzone_path = _write_csv(output_root, "rootzone_indices", rootzone)
 
@@ -266,6 +330,8 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         max_rows=int(dataset3_max_rows) if dataset3_max_rows is not None else None,
         batch_size=batch_size,
         max_full_rows_without_limit=max_full_rows_without_limit,
+        mode=mode,
+        fail_on_full_in_memory_large_dataset=fail_on_full_in_memory_large_dataset,
     )
     dataset3_bridge, dataset3_metadata = build_dataset3_growth_phenology_bridge(dataset3)
     dataset3_path_out = _write_csv(output_root, "dataset3_bridge", dataset3_bridge)
@@ -279,6 +345,61 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         dataset3_bridge=dataset3_bridge,
     )
     feature_frame_path = _write_csv(output_root, "observer_feature_frame", feature_frame)
+
+    chunk_manifest = (
+        pd.concat(chunk_manifest_frames, ignore_index=True)
+        if chunk_manifest_frames
+        else pd.DataFrame(columns=["dataset_role", "batch_index", "rows_processed", "aggregation_status"])
+    )
+    chunk_manifest_path: Path | None = None
+    if mode == "production" or write_intermediate_chunk_manifests:
+        chunk_manifest_path = _write_csv(output_root, "chunk_manifest", chunk_manifest)
+
+    row_cap_applied = bool(
+        dataset1_load_meta.get("row_limit_applied")
+        or dataset2_load_meta.get("row_limit_applied")
+        or dataset3_load_meta.get("row_limit_applied")
+    )
+    chunk_aggregation_used = bool(
+        dataset1_load_meta.get("chunk_aggregation_used") and dataset2_load_meta.get("chunk_aggregation_used")
+    )
+    production_export_completed = bool(
+        mode == "production"
+        and not row_cap_applied
+        and dataset1_load_meta.get("rows_processed_fraction") == 1.0
+        and dataset2_load_meta.get("rows_processed_fraction") == 1.0
+    )
+    production_ready_for_latent_allocation = bool(
+        production_export_completed
+        and chunk_aggregation_used
+        and not row_cap_applied
+        and feature_frame_path.exists()
+        and rootzone_path.exists()
+        and event_intervals_path.exists()
+    )
+    production_summary_path: Path | None = None
+    if mode == "production" or write_intermediate_chunk_manifests:
+        production_summary_path = _write_text(
+            output_root,
+            "production_export_summary",
+            "\n".join(
+                [
+                    "# TOMICS-HAF 2025-2C Observer Production Export Summary",
+                    "",
+                    f"- observer_pipeline_mode: {mode}",
+                    f"- production_export_completed: {production_export_completed}",
+                    f"- production_ready_for_latent_allocation: {production_ready_for_latent_allocation}",
+                    f"- dataset1_rows_processed: {dataset1_load_meta.get('rows_processed')}",
+                    f"- dataset1_total_rows: {dataset1_load_meta.get('total_rows')}",
+                    f"- dataset2_rows_processed: {dataset2_load_meta.get('rows_processed')}",
+                    f"- dataset2_total_rows: {dataset2_load_meta.get('total_rows')}",
+                    f"- row_cap_applied: {row_cap_applied}",
+                    f"- chunk_aggregation_used: {chunk_aggregation_used}",
+                    f"- full_in_memory_large_dataset_used: {bool(dataset1_load_meta.get('full_in_memory_large_dataset_used') or dataset2_load_meta.get('full_in_memory_large_dataset_used'))}",
+                    "",
+                ]
+            ),
+        )
 
     metadata = base_metadata()
     metadata.update(_load_goal1_metadata(output_root))
@@ -298,6 +419,42 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             "Dataset3_mapping_confidence_counts": dataset3_metadata.get("Dataset3_mapping_confidence_counts", {}),
             "Dataset3_datetime_or_date_available": bool(dataset3_metadata.get("datetime_or_date_available", False)),
             "Dataset3_truss_position_available": bool(dataset3_metadata.get("truss_position_available", False)),
+            "observer_pipeline_mode": mode,
+            "production_export_requested": mode == "production",
+            "production_export_completed": production_export_completed,
+            "chunk_aggregation_used": chunk_aggregation_used,
+            "full_in_memory_large_dataset_used": bool(
+                dataset1_load_meta.get("full_in_memory_large_dataset_used")
+                or dataset2_load_meta.get("full_in_memory_large_dataset_used")
+            ),
+            "row_cap_applied": row_cap_applied,
+            "row_cap_allowed": mode == "smoke",
+            "dataset1_total_rows": dataset1_load_meta.get("total_rows"),
+            "dataset1_rows_processed": dataset1_load_meta.get("rows_processed"),
+            "dataset1_rows_processed_fraction": dataset1_load_meta.get("rows_processed_fraction"),
+            "dataset1_batches_processed": dataset1_load_meta.get("batches_processed"),
+            "dataset1_projected_columns": dataset1_load_meta.get("projected_columns"),
+            "dataset1_chunk_aggregation_complete": bool(dataset1_load_meta.get("chunk_aggregation_complete")),
+            "dataset2_total_rows": dataset2_load_meta.get("total_rows"),
+            "dataset2_rows_processed": dataset2_load_meta.get("rows_processed"),
+            "dataset2_rows_processed_fraction": dataset2_load_meta.get("rows_processed_fraction"),
+            "dataset2_batches_processed": dataset2_load_meta.get("batches_processed"),
+            "dataset2_projected_columns": dataset2_load_meta.get("projected_columns"),
+            "dataset2_chunk_aggregation_complete": bool(dataset2_load_meta.get("chunk_aggregation_complete")),
+            "dataset3_total_rows": dataset3_load_meta.get("total_rows"),
+            "dataset3_rows_processed": dataset3_load_meta.get("rows_processed"),
+            "row_cap_warning": (
+                "row caps applied; observer feature frame is not production-ready for latent allocation"
+                if row_cap_applied
+                else ""
+            ),
+            "water_flux_chunk_carryover_used": bool(dataset1_load_meta.get("water_flux_chunk_carryover_used", False)),
+            "water_flux_chunk_carryover_group_keys": dataset1_load_meta.get("water_flux_chunk_carryover_group_keys", []),
+            "event_bridged_ET_calibration_status": "uncalibrated_no_daily_total",
+            "existing_daily_event_bridged_total_available": False,
+            "radiation_interval_aggregation_grain": "10min",
+            "radiation_phase_rule": "day_if_any_interval_sample_gt_threshold",
+            "production_ready_for_latent_allocation": production_ready_for_latent_allocation,
             "row_loading": {
                 "dataset1": dataset1_load_meta,
                 "dataset2": dataset2_load_meta,
@@ -332,6 +489,10 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         "observer_feature_frame": feature_frame_path,
         "metadata": output_root / OUTPUT_FILENAMES["metadata"],
     }
+    if chunk_manifest_path is not None:
+        output_paths["chunk_manifest"] = chunk_manifest_path
+    if production_summary_path is not None:
+        output_paths["production_export_summary"] = production_summary_path
     metadata["outputs"] = {key: str(path) for key, path in output_paths.items()}
     metadata_path = write_json(output_root / OUTPUT_FILENAMES["metadata"], metadata)
     output_paths["metadata"] = metadata_path
@@ -341,4 +502,3 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         "outputs": {key: str(path) for key, path in output_paths.items()},
         "metadata": metadata,
     }
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
@@ -13,7 +13,6 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
     DATASET3_COLUMN_CANDIDATES,
     MAIN_RADIATION_THRESHOLD_W_M2,
     OUTPUT_FILENAMES,
-    RADIATION_COLUMN_USED,
     RADIATION_THRESHOLDS_W_M2,
     RAW_INPUT_FILENAMES,
     base_metadata,
@@ -22,11 +21,26 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
 from stomatal_optimiaztion.domains.tomato.tomics.observers.dataset3_bridge import (
     build_dataset3_growth_phenology_bridge,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.observers.event_bridge_calibration import (
+    CALIBRATION_TOTAL_COL,
+    calibration_match_metadata,
+    load_legacy_event_bridge_daily_totals,
+)
 from stomatal_optimiaztion.domains.tomato.tomics.observers.feature_frame import build_observer_feature_frame
 from stomatal_optimiaztion.domains.tomato.tomics.observers.fruit_diameter_windows import (
     build_fixed_clock_compat_windows,
     build_fruit_leaf_loadcell_bridge,
     build_fruit_leaf_radiation_windows,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.legacy_v1_3_bridge import (
+    audit_legacy_v1_3_bridge,
+    legacy_v1_3_config,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import (
+    metadata_contract_audit,
+    normalize_metadata,
+    write_normalized_metadata,
+    write_stage_metadata_snapshot,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.observers.parquet_streaming import (
     assert_no_large_full_load_without_limit,
@@ -36,6 +50,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.parquet_streaming imp
     validate_production_row_cap_policy,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.observers.production_export import (
+    aggregate_dataset1_rootzone_reference_streaming,
     aggregate_dataset1_streaming,
     aggregate_dataset2_daily_streaming,
 )
@@ -60,6 +75,7 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.water_flux_event_brid
     calibrate_to_daily_event_bridged_total,
     summarize_radiation_daynight_et,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.observers.yield_bridge import load_legacy_yield_bridge
 
 
 def _repo_root_from_config(config_path: Path, config: dict[str, Any]) -> Path:
@@ -157,6 +173,168 @@ def _read_projected_sample(path: Path, columns: tuple[str, ...], *, batch_size: 
     return pd.DataFrame(columns=projected_columns(path, columns))
 
 
+def _radiation_column_for_pipeline(radiation_decision: dict[str, Any]) -> str:
+    source = str(radiation_decision.get("radiation_daynight_primary_source") or "")
+    column = str(radiation_decision.get("radiation_column_used") or "")
+    if not bool(radiation_decision.get("selected_for_daynight_10min")):
+        raise RuntimeError(
+            "No radiation source is selected for 10-minute day/night intervals; "
+            f"decision={radiation_decision}"
+        )
+    if source != "dataset1":
+        raise RuntimeError(
+            "The HAF 2025-2C observer pipeline currently requires Dataset1 radiation for canonical "
+            f"10-minute day/night intervals; selected source={source!r} column={column!r}."
+        )
+    if not column:
+        raise RuntimeError("Radiation decision selected Dataset1 but did not provide radiation_column_used.")
+    return column
+
+
+def _normalize_join_keys(frame: pd.DataFrame) -> pd.DataFrame:
+    out = frame.copy()
+    if "date" in out.columns:
+        out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    if "loadcell_id" in out.columns:
+        out["loadcell_id"] = pd.to_numeric(out["loadcell_id"], errors="coerce").astype("Int64")
+    if "treatment" in out.columns:
+        out["treatment"] = out["treatment"].astype(str)
+    return out
+
+
+def _merge_legacy_yield_bridge(feature_frame: pd.DataFrame, yield_bridge: pd.DataFrame) -> pd.DataFrame:
+    if yield_bridge.empty or feature_frame.empty:
+        return feature_frame
+    left = _normalize_join_keys(feature_frame)
+    right = _normalize_join_keys(yield_bridge)
+    keys = [column for column in ("date", "loadcell_id", "treatment") if column in left.columns and column in right.columns]
+    if not keys:
+        return feature_frame
+    bridge_columns = keys + [column for column in right.columns if column not in keys]
+    merged = left.merge(right[bridge_columns], on=keys, how="left", suffixes=("", "_legacy_yield"))
+    fresh_cols = [column for column in ("measured_or_legacy_fresh_yield_g", "loadcell_daily_yield_g", "final_fresh_yield_g") if column in merged.columns]
+    dry_cols = [column for column in merged.columns if "_dry_yield_g_est_" in column or column.endswith("_dry_yield_g_est_5p6pct")]
+    fresh_available = merged[fresh_cols].notna().any(axis=1) if fresh_cols else pd.Series(False, index=merged.index)
+    dry_available = merged[dry_cols].notna().any(axis=1) if dry_cols else pd.Series(False, index=merged.index)
+    merged["harvest_yield_available"] = fresh_available | dry_available
+    merged["fresh_yield_available"] = fresh_available
+    merged["dry_yield_available"] = dry_available
+    merged["dry_yield_is_dmc_estimated"] = dry_available
+    merged["direct_dry_yield_measured"] = False
+    merged["DMC_conversion_performed"] = dry_available
+    return merged
+
+
+def _rootzone_reference_audit(rootzone: pd.DataFrame) -> pd.DataFrame:
+    if rootzone.empty:
+        return pd.DataFrame(
+            [
+                {
+                    "check_name": "RZI_main_available",
+                    "status": "fail",
+                    "value": False,
+                    "notes": "No rootzone rows were produced.",
+                }
+            ]
+        )
+    available = bool(rootzone.get("RZI_main_available", pd.Series(dtype=bool)).fillna(False).any())
+    source_values = (
+        ";".join(sorted(rootzone.get("RZI_main_source", pd.Series(dtype=str)).dropna().astype(str).unique()))
+        if "RZI_main_source" in rootzone.columns
+        else ""
+    )
+    control_source = (
+        ";".join(sorted(rootzone.get("RZI_control_reference_source", pd.Series(dtype=str)).dropna().astype(str).unique()))
+        if "RZI_control_reference_source" in rootzone.columns
+        else ""
+    )
+    return pd.DataFrame(
+        [
+            {
+                "check_name": "RZI_main_available",
+                "status": "pass" if available else "fail",
+                "value": available,
+                "notes": source_values,
+            },
+            {
+                "check_name": "RZI_control_reference_source",
+                "status": "pass" if control_source else "fail",
+                "value": control_source,
+                "notes": "Dataset1 moisture should be preferred when available.",
+            },
+        ]
+    )
+
+
+def _dataset3_size_guard(
+    dataset3_load_meta: dict[str, Any],
+    *,
+    max_full_rows_without_limit: int,
+    mode: str,
+) -> dict[str, Any]:
+    total_rows = int(dataset3_load_meta.get("total_rows") or 0)
+    rows_processed = int(dataset3_load_meta.get("rows_processed") or 0)
+    guard_passed = bool(total_rows <= max_full_rows_without_limit or dataset3_load_meta.get("row_limit_applied"))
+    allowed_reason = (
+        "small_dataset3_within_max_full_rows_without_limit"
+        if total_rows <= max_full_rows_without_limit
+        else "dataset3_row_cap_applied"
+        if dataset3_load_meta.get("row_limit_applied")
+        else "dataset3_exceeds_max_full_rows_without_limit"
+    )
+    if mode == "production" and not guard_passed:
+        raise RuntimeError(f"Dataset3 size guard failed: total_rows={total_rows}, limit={max_full_rows_without_limit}.")
+    return {
+        "dataset3_total_rows": total_rows,
+        "dataset3_rows_processed": rows_processed,
+        "dataset3_full_in_memory_allowed_reason": allowed_reason,
+        "dataset3_size_guard_passed": guard_passed,
+    }
+
+
+def _assert_dataset3_size_guard_before_read(
+    *,
+    path: Path,
+    max_rows: int | None,
+    max_full_rows_without_limit: int,
+    mode: str,
+) -> dict[str, Any]:
+    parquet_meta = parquet_metadata_summary(path)
+    total_rows = int(parquet_meta["total_rows"])
+    if mode == "production" and max_rows is None and total_rows > max_full_rows_without_limit:
+        raise RuntimeError(
+            "Dataset3 size guard failed before full read: "
+            f"total_rows={total_rows}, limit={max_full_rows_without_limit}."
+        )
+    return {"dataset3_total_rows_preflight": total_rows}
+
+
+def _production_requirement_failures(
+    *,
+    mode: str,
+    pipeline_config: dict[str, Any],
+    row_cap_applied: bool,
+    chunk_aggregation_used: bool,
+    full_in_memory_large_dataset_used: bool,
+    dataset1_load_meta: dict[str, Any],
+    dataset2_load_meta: dict[str, Any],
+) -> list[str]:
+    if mode != "production":
+        return []
+    failures: list[str] = []
+    if bool(pipeline_config.get("require_chunk_aggregation")) and not chunk_aggregation_used:
+        failures.append("require_chunk_aggregation=true but chunk_aggregation_used=false")
+    if bool(pipeline_config.get("require_dataset1_full_processed")) and dataset1_load_meta.get("rows_processed_fraction") != 1.0:
+        failures.append("require_dataset1_full_processed=true but dataset1_rows_processed_fraction != 1.0")
+    if bool(pipeline_config.get("require_dataset2_full_processed")) and dataset2_load_meta.get("rows_processed_fraction") != 1.0:
+        failures.append("require_dataset2_full_processed=true but dataset2_rows_processed_fraction != 1.0")
+    if full_in_memory_large_dataset_used:
+        failures.append("full_in_memory_large_dataset_used=true")
+    if row_cap_applied:
+        failures.append("row_cap_applied=true")
+    return failures
+
+
 def _path_for_input(raw_root: Path, role: str, config: dict[str, Any]) -> Path:
     configured = config.get("input_files", {}).get(role, RAW_INPUT_FILENAMES[role])
     return raw_root / configured
@@ -173,6 +351,19 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         tomics_haf.get("raw_data_root", "artifacts/tomato_integrated_radiation_architecture_v1_3/input_raw"),
     )
     ensure_dir(output_root)
+    legacy_config = legacy_v1_3_config(config, repo_root=repo_root)
+    legacy_audit = audit_legacy_v1_3_bridge(legacy_config)
+    legacy_audit_path = _write_csv(output_root, "legacy_bridge_audit", legacy_audit)
+    legacy_audit_json_path = write_json(
+        output_root / OUTPUT_FILENAMES["legacy_bridge_audit_json"],
+        {"sources": legacy_audit.to_dict(orient="records")},
+    )
+    legacy_event_totals, event_calibration_audit, event_calibration_metadata = (
+        load_legacy_event_bridge_daily_totals(legacy_config)
+    )
+    event_calibration_audit_path = _write_csv(output_root, "event_bridge_calibration_audit", event_calibration_audit)
+    legacy_yield, yield_audit, yield_metadata = load_legacy_yield_bridge(legacy_config)
+    yield_audit_path = _write_csv(output_root, "fresh_dry_yield_bridge_audit", yield_audit)
 
     pipeline_config = dict(config.get("observer_pipeline", {}))
     mode = str(pipeline_config.get("mode", "smoke"))
@@ -223,6 +414,7 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         {"dataset1": dataset1_sample, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
         audit_rows,
     )
+    radiation_col = _radiation_column_for_pipeline(radiation_decision)
 
     chunk_manifest_frames: list[pd.DataFrame] = []
     if mode == "production":
@@ -232,8 +424,18 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             batch_size=batch_size,
             max_rows=None,
             thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
+            radiation_col=radiation_col,
+        )
+        dataset1_rootzone_reference, dataset1_rootzone_meta, dataset1_rootzone_manifest = (
+            aggregate_dataset1_rootzone_reference_streaming(
+                path=dataset1_path,
+                columns=DATASET1_COLUMN_CANDIDATES,
+                batch_size=batch_size,
+                max_rows=None,
+            )
         )
         chunk_manifest_frames.append(dataset1_manifest)
+        chunk_manifest_frames.append(dataset1_rootzone_manifest)
     else:
         dataset1, dataset1_load_meta = _read_projected_parquet(
             dataset1_path,
@@ -249,14 +451,25 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             dataset1,
             thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
             timestamp_col="timestamp",
-            radiation_col=RADIATION_COLUMN_USED,
+            radiation_col=radiation_col,
         )
         event_intervals = build_10min_event_bridged_water_loss(dataset1, radiation_intervals)
+        dataset1_rootzone_reference = dataset1
+        dataset1_rootzone_meta = dict(dataset1_load_meta)
     photoperiod = build_photoperiod_table(radiation_intervals)
     radiation_daily = build_radiation_daily_summary(radiation_intervals)
     photoperiod_path = _write_csv(output_root, "radiation_photoperiod", photoperiod)
 
-    event_intervals = calibrate_to_daily_event_bridged_total(event_intervals)
+    event_intervals = calibrate_to_daily_event_bridged_total(
+        event_intervals,
+        legacy_event_totals,
+        total_col=CALIBRATION_TOTAL_COL,
+    )
+    event_calibration_metadata = calibration_match_metadata(
+        event_intervals,
+        legacy_event_totals,
+        event_calibration_metadata,
+    )
     event_intervals_path = _write_csv(output_root, "event_intervals", event_intervals)
     event_daily_all = summarize_radiation_daynight_et(event_intervals)
     event_daily_all_path = _write_csv(output_root, "event_daily_all_thresholds", event_daily_all)
@@ -321,9 +534,18 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             mode=mode,
             fail_on_full_in_memory_large_dataset=fail_on_full_in_memory_large_dataset,
         )
-    rootzone = build_rootzone_indices(dataset2, daily_wide)
+    rootzone = build_rootzone_indices(dataset2, daily_wide, dataset1_reference_frame=dataset1_rootzone_reference)
     rootzone_path = _write_csv(output_root, "rootzone_indices", rootzone)
+    rootzone_reference_audit = _rootzone_reference_audit(rootzone)
+    rootzone_reference_audit_passed = bool(rootzone_reference_audit["status"].eq("pass").all())
+    rootzone_reference_audit_path = _write_csv(output_root, "rootzone_rzi_reference_audit", rootzone_reference_audit)
 
+    dataset3_preflight_metadata = _assert_dataset3_size_guard_before_read(
+        path=dataset3_path,
+        max_rows=int(dataset3_max_rows) if dataset3_max_rows is not None else None,
+        max_full_rows_without_limit=max_full_rows_without_limit,
+        mode=mode,
+    )
     dataset3, dataset3_load_meta = _read_projected_parquet(
         dataset3_path,
         DATASET3_COLUMN_CANDIDATES,
@@ -333,6 +555,12 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         mode=mode,
         fail_on_full_in_memory_large_dataset=fail_on_full_in_memory_large_dataset,
     )
+    dataset3_guard_metadata = _dataset3_size_guard(
+        dataset3_load_meta,
+        max_full_rows_without_limit=max_full_rows_without_limit,
+        mode=mode,
+    )
+    dataset3_guard_metadata.update(dataset3_preflight_metadata)
     dataset3_bridge, dataset3_metadata = build_dataset3_growth_phenology_bridge(dataset3)
     dataset3_path_out = _write_csv(output_root, "dataset3_bridge", dataset3_bridge)
 
@@ -343,7 +571,10 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         fruit_windows=fruit_windows,
         leaf_windows=leaf_windows,
         dataset3_bridge=dataset3_bridge,
+        radiation_source_used=str(radiation_decision.get("radiation_daynight_primary_source") or "dataset1"),
+        radiation_column_used=radiation_col,
     )
+    feature_frame = _merge_legacy_yield_bridge(feature_frame, legacy_yield)
     feature_frame_path = _write_csv(output_root, "observer_feature_frame", feature_frame)
 
     chunk_manifest = (
@@ -363,11 +594,26 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
     chunk_aggregation_used = bool(
         dataset1_load_meta.get("chunk_aggregation_used") and dataset2_load_meta.get("chunk_aggregation_used")
     )
+    full_in_memory_large_dataset_used = bool(
+        dataset1_load_meta.get("full_in_memory_large_dataset_used")
+        or dataset2_load_meta.get("full_in_memory_large_dataset_used")
+        or dataset3_load_meta.get("full_in_memory_large_dataset_used")
+    )
+    production_failures = _production_requirement_failures(
+        mode=mode,
+        pipeline_config=pipeline_config,
+        row_cap_applied=row_cap_applied,
+        chunk_aggregation_used=chunk_aggregation_used,
+        full_in_memory_large_dataset_used=full_in_memory_large_dataset_used,
+        dataset1_load_meta=dataset1_load_meta,
+        dataset2_load_meta=dataset2_load_meta,
+    )
     production_export_completed = bool(
         mode == "production"
         and not row_cap_applied
         and dataset1_load_meta.get("rows_processed_fraction") == 1.0
         and dataset2_load_meta.get("rows_processed_fraction") == 1.0
+        and not production_failures
     )
     production_ready_for_latent_allocation = bool(
         production_export_completed
@@ -375,6 +621,7 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         and not row_cap_applied
         and feature_frame_path.exists()
         and rootzone_path.exists()
+        and rootzone_reference_audit_passed
         and event_intervals_path.exists()
     )
     production_summary_path: Path | None = None
@@ -395,7 +642,8 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
                     f"- dataset2_total_rows: {dataset2_load_meta.get('total_rows')}",
                     f"- row_cap_applied: {row_cap_applied}",
                     f"- chunk_aggregation_used: {chunk_aggregation_used}",
-                    f"- full_in_memory_large_dataset_used: {bool(dataset1_load_meta.get('full_in_memory_large_dataset_used') or dataset2_load_meta.get('full_in_memory_large_dataset_used'))}",
+                    f"- full_in_memory_large_dataset_used: {full_in_memory_large_dataset_used}",
+                    f"- production_requirement_failures: {'; '.join(production_failures)}",
                     "",
                 ]
             ),
@@ -409,6 +657,12 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         {
             "radiation_source_decision": radiation_decision,
             "radiation_source_candidate_count": len(radiation_rows),
+            "radiation_daynight_primary_source": radiation_decision.get("radiation_daynight_primary_source"),
+            "radiation_column_used": radiation_decision.get("radiation_column_used"),
+            "dataset1_radiation_directly_usable": radiation_decision.get("dataset1_radiation_directly_usable"),
+            "dataset1_radiation_grain": radiation_decision.get("dataset1_radiation_grain"),
+            "fallback_required": radiation_decision.get("fallback_required"),
+            "fallback_source_if_required": radiation_decision.get("fallback_source_if_required") or None,
             "event_bridged_ET_outputs_produced": True,
             "fruit_leaf_qc_outputs_produced": True,
             "fruit_diameter_observer_inference_level": "sensor_level_apparent_expansion_diagnostics",
@@ -423,12 +677,10 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             "production_export_requested": mode == "production",
             "production_export_completed": production_export_completed,
             "chunk_aggregation_used": chunk_aggregation_used,
-            "full_in_memory_large_dataset_used": bool(
-                dataset1_load_meta.get("full_in_memory_large_dataset_used")
-                or dataset2_load_meta.get("full_in_memory_large_dataset_used")
-            ),
+            "full_in_memory_large_dataset_used": full_in_memory_large_dataset_used,
             "row_cap_applied": row_cap_applied,
             "row_cap_allowed": mode == "smoke",
+            "production_requirement_failures": production_failures,
             "dataset1_total_rows": dataset1_load_meta.get("total_rows"),
             "dataset1_rows_processed": dataset1_load_meta.get("rows_processed"),
             "dataset1_rows_processed_fraction": dataset1_load_meta.get("rows_processed_fraction"),
@@ -441,8 +693,7 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             "dataset2_batches_processed": dataset2_load_meta.get("batches_processed"),
             "dataset2_projected_columns": dataset2_load_meta.get("projected_columns"),
             "dataset2_chunk_aggregation_complete": bool(dataset2_load_meta.get("chunk_aggregation_complete")),
-            "dataset3_total_rows": dataset3_load_meta.get("total_rows"),
-            "dataset3_rows_processed": dataset3_load_meta.get("rows_processed"),
+            **dataset3_guard_metadata,
             "row_cap_warning": (
                 "row caps applied; observer feature frame is not production-ready for latent allocation"
                 if row_cap_applied
@@ -450,8 +701,22 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             ),
             "water_flux_chunk_carryover_used": bool(dataset1_load_meta.get("water_flux_chunk_carryover_used", False)),
             "water_flux_chunk_carryover_group_keys": dataset1_load_meta.get("water_flux_chunk_carryover_group_keys", []),
-            "event_bridged_ET_calibration_status": "uncalibrated_no_daily_total",
-            "existing_daily_event_bridged_total_available": False,
+            "dataset1_rootzone_reference_rows_processed": dataset1_rootzone_meta.get("rows_processed"),
+            "dataset1_rootzone_reference_rows_processed_fraction": dataset1_rootzone_meta.get("rows_processed_fraction"),
+            "RZI_main_available": bool(rootzone.get("RZI_main_available", pd.Series(dtype=bool)).fillna(False).any()),
+            "RZI_main_source": ";".join(
+                sorted(rootzone.get("RZI_main_source", pd.Series(dtype=str)).dropna().astype(str).unique())
+            ),
+            "RZI_control_reference_source": ";".join(
+                sorted(rootzone.get("RZI_control_reference_source", pd.Series(dtype=str)).dropna().astype(str).unique())
+            ),
+            "rootzone_rzi_reference_audit_passed": rootzone_reference_audit_passed,
+            "Dataset2_tensiometer_drought_only": bool(
+                rootzone.get("Dataset2_tensiometer_drought_only", pd.Series(dtype=bool)).fillna(False).any()
+            ),
+            "tensiometer_extrapolated_to_all_loadcells": False,
+            **event_calibration_metadata,
+            **yield_metadata,
             "radiation_interval_aggregation_grain": "10min",
             "radiation_phase_rule": "day_if_any_interval_sample_gt_threshold",
             "production_ready_for_latent_allocation": production_ready_for_latent_allocation,
@@ -463,8 +728,6 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
             "outputs": {},
             "fixed_clock_daynight_primary": False,
             "clock_06_18_used_only_for_compatibility": True,
-            "fallback_required": False,
-            "fallback_source_if_required": None,
             "raw_dat_solar_rad_fallback_verified": True,
             "shipped_TOMICS_incumbent_changed": False,
             "latent_allocation_inference_run": False,
@@ -485,8 +748,16 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
         "fruit_leaf_clock_windows": clock_windows_path,
         "fruit_leaf_loadcell_bridge": sensor_bridge_path,
         "rootzone_indices": rootzone_path,
+        "rootzone_rzi_reference_audit": rootzone_reference_audit_path,
         "dataset3_bridge": dataset3_path_out,
         "observer_feature_frame": feature_frame_path,
+        "legacy_v1_3_bridge_audit": legacy_audit_path,
+        "legacy_v1_3_bridge_audit_json": legacy_audit_json_path,
+        "event_bridge_calibration_audit": event_calibration_audit_path,
+        "fresh_dry_yield_bridge_audit": yield_audit_path,
+        "metadata_contract_audit": output_root / OUTPUT_FILENAMES["metadata_contract_audit"],
+        "metadata_goal2_observer": output_root / OUTPUT_FILENAMES["metadata_goal2_observer"],
+        "metadata_goal2_5_production_observer": output_root / OUTPUT_FILENAMES["metadata_goal2_5_production_observer"],
         "metadata": output_root / OUTPUT_FILENAMES["metadata"],
     }
     if chunk_manifest_path is not None:
@@ -494,8 +765,18 @@ def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
     if production_summary_path is not None:
         output_paths["production_export_summary"] = production_summary_path
     metadata["outputs"] = {key: str(path) for key, path in output_paths.items()}
-    metadata_path = write_json(output_root / OUTPUT_FILENAMES["metadata"], metadata)
+    metadata = normalize_metadata(metadata)
+    metadata_contract_path = _write_csv(output_root, "metadata_contract_audit", metadata_contract_audit(metadata))
+    output_paths["metadata_contract_audit"] = metadata_contract_path
+    write_stage_metadata_snapshot(output_root / OUTPUT_FILENAMES["metadata_goal2_observer"], metadata)
+    if mode == "production":
+        write_stage_metadata_snapshot(output_root / OUTPUT_FILENAMES["metadata_goal2_5_production_observer"], metadata)
+    metadata["outputs"] = {key: str(path) for key, path in output_paths.items()}
+    metadata_path = write_normalized_metadata(output_root / OUTPUT_FILENAMES["metadata"], metadata)
     output_paths["metadata"] = metadata_path
+
+    if production_failures:
+        raise RuntimeError("Production observer export failed hard requirements: " + "; ".join(production_failures))
 
     return {
         "output_root": str(output_root),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, load_config, write_json
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    DATASET1_COLUMN_CANDIDATES,
+    DATASET2_COLUMN_CANDIDATES,
+    DATASET3_COLUMN_CANDIDATES,
+    MAIN_RADIATION_THRESHOLD_W_M2,
+    OUTPUT_FILENAMES,
+    RADIATION_COLUMN_USED,
+    RADIATION_THRESHOLDS_W_M2,
+    RAW_INPUT_FILENAMES,
+    base_metadata,
+    resolve_repo_path,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.dataset3_bridge import (
+    build_dataset3_growth_phenology_bridge,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.feature_frame import build_observer_feature_frame
+from stomatal_optimiaztion.domains.tomato.tomics.observers.fruit_diameter_windows import (
+    build_fixed_clock_compat_windows,
+    build_fruit_leaf_loadcell_bridge,
+    build_fruit_leaf_radiation_windows,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.qc import apply_fruit_leaf_qc
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source import (
+    build_radiation_source_verification,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import (
+    build_photoperiod_table,
+    build_radiation_daily_summary,
+    build_radiation_intervals,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.rootzone_indices import build_rootzone_indices
+from stomatal_optimiaztion.domains.tomato.tomics.observers.sensor_mapping import (
+    fruit_diameter_policy_metadata,
+    load_sensor_mapping,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.toa5_parser import read_toa5_dat
+from stomatal_optimiaztion.domains.tomato.tomics.observers.water_flux_event_bridge import (
+    build_10min_event_bridged_water_loss,
+    build_daily_wide_et_summary,
+    calibrate_to_daily_event_bridged_total,
+    summarize_radiation_daynight_et,
+)
+
+
+def _repo_root_from_config(config_path: Path, config: dict[str, Any]) -> Path:
+    repo_root_value = config.get("paths", {}).get("repo_root", "../..")
+    repo_root = Path(repo_root_value)
+    if repo_root.is_absolute():
+        return repo_root.resolve()
+    return (config_path.parent / repo_root).resolve()
+
+
+def _tomics_haf_config(config: dict[str, Any]) -> dict[str, Any]:
+    return dict(config.get("tomics_haf", {}))
+
+
+def _write_csv(output_root: Path, key: str, frame: pd.DataFrame) -> Path:
+    ensure_dir(output_root)
+    path = output_root / OUTPUT_FILENAMES[key]
+    frame.to_csv(path, index=False)
+    return path
+
+
+def _load_goal1_metadata(output_root: Path) -> dict[str, Any]:
+    metadata_path = output_root / OUTPUT_FILENAMES["metadata"]
+    if not metadata_path.exists():
+        return {}
+    with metadata_path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _load_audit_rows(output_root: Path) -> dict[str, dict[str, Any]]:
+    path = output_root / "input_schema_audit.csv"
+    if not path.exists():
+        return {}
+    rows = pd.read_csv(path).to_dict(orient="records")
+    return {str(row.get("file_role")): row for row in rows}
+
+
+def _read_projected_parquet(
+    path: Path,
+    columns: tuple[str, ...],
+    *,
+    max_rows: int | None,
+    batch_size: int,
+    max_full_rows_without_limit: int,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(path)
+    available = [column for column in columns if column in parquet_file.schema_arrow.names]
+    total_rows = int(parquet_file.metadata.num_rows)
+    if max_rows is None and total_rows > max_full_rows_without_limit:
+        raise RuntimeError(
+            f"Refusing to load {total_rows:,} rows from {path.name} without max_rows. "
+            "Set observer_pipeline.max_rows for a bounded local smoke run."
+        )
+
+    remaining = max_rows
+    frames: list[pd.DataFrame] = []
+    rows_loaded = 0
+    for batch in parquet_file.iter_batches(batch_size=batch_size, columns=available):
+        chunk = batch.to_pandas()
+        if remaining is not None and chunk.shape[0] > remaining:
+            chunk = chunk.iloc[:remaining].copy()
+        frames.append(chunk)
+        rows_loaded += int(chunk.shape[0])
+        if remaining is not None:
+            remaining -= int(chunk.shape[0])
+            if remaining <= 0:
+                break
+    frame = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=available)
+    metadata = {
+        "path": str(path),
+        "projected_columns": available,
+        "total_rows": total_rows,
+        "rows_loaded": rows_loaded,
+        "row_limit_applied": max_rows is not None and rows_loaded < total_rows,
+        "max_rows": max_rows,
+    }
+    return frame, metadata
+
+
+def _path_for_input(raw_root: Path, role: str, config: dict[str, Any]) -> Path:
+    configured = config.get("input_files", {}).get(role, RAW_INPUT_FILENAMES[role])
+    return raw_root / configured
+
+
+def run_tomics_haf_observer_pipeline(config_path: str | Path) -> dict[str, Any]:
+    config_path = Path(config_path).resolve()
+    config = load_config(config_path)
+    repo_root = _repo_root_from_config(config_path, config)
+    tomics_haf = _tomics_haf_config(config)
+    output_root = resolve_repo_path(repo_root, tomics_haf.get("output_root", "out/tomics/analysis/haf_2025_2c"))
+    raw_root = resolve_repo_path(
+        repo_root,
+        tomics_haf.get("raw_data_root", "artifacts/tomato_integrated_radiation_architecture_v1_3/input_raw"),
+    )
+    ensure_dir(output_root)
+
+    pipeline_config = dict(config.get("observer_pipeline", {}))
+    batch_size = int(pipeline_config.get("parquet_batch_size", 250_000))
+    max_full_rows_without_limit = int(pipeline_config.get("max_full_rows_without_limit", 2_000_000))
+    max_rows = pipeline_config.get("max_rows", {})
+    dataset1_max_rows = max_rows.get("dataset1") if isinstance(max_rows, dict) else None
+    dataset2_max_rows = max_rows.get("dataset2") if isinstance(max_rows, dict) else None
+    dataset3_max_rows = max_rows.get("dataset3") if isinstance(max_rows, dict) else None
+
+    mapping_path = resolve_repo_path(
+        repo_root,
+        tomics_haf.get("sensor_mapping_path", "configs/sensor_mapping/2025_2c_fruit_leaf_loadcell.yaml"),
+    )
+    mapping = load_sensor_mapping(mapping_path)
+
+    raw_dat_path = _path_for_input(raw_root, "fruit_leaf_temperature_solar_raw_dat", tomics_haf)
+    dataset1_path = _path_for_input(raw_root, "dataset1", tomics_haf)
+    dataset2_path = _path_for_input(raw_root, "dataset2", tomics_haf)
+    dataset3_path = _path_for_input(raw_root, "dataset3", tomics_haf)
+
+    raw_dat = read_toa5_dat(raw_dat_path, timestamp_col=mapping.get("timestamp_col", "TIMESTAMP"))
+    fruit_leaf_qc, sensor_qc_report = apply_fruit_leaf_qc(
+        raw_dat,
+        timestamp_col=mapping.get("timestamp_col", "TIMESTAMP"),
+        fruit_columns=mapping.get("fruit_sensor_map", {}).keys(),
+        leaf_columns=mapping.get("leaf_sensor_map", {}).keys(),
+    )
+    fruit_leaf_qc_path = _write_csv(output_root, "fruit_leaf_timeseries_qc", fruit_leaf_qc)
+    sensor_qc_path = _write_csv(output_root, "sensor_qc_report", sensor_qc_report)
+
+    dataset1, dataset1_load_meta = _read_projected_parquet(
+        dataset1_path,
+        DATASET1_COLUMN_CANDIDATES,
+        max_rows=int(dataset1_max_rows) if dataset1_max_rows is not None else None,
+        batch_size=batch_size,
+        max_full_rows_without_limit=max_full_rows_without_limit,
+    )
+    dataset1["timestamp"] = pd.to_datetime(dataset1["timestamp"], errors="coerce")
+
+    audit_rows = _load_audit_rows(output_root)
+    radiation_rows, radiation_decision = build_radiation_source_verification(
+        {"dataset1": dataset1, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
+        audit_rows,
+    )
+
+    radiation_intervals = build_radiation_intervals(
+        dataset1,
+        thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
+        timestamp_col="timestamp",
+        radiation_col=RADIATION_COLUMN_USED,
+    )
+    photoperiod = build_photoperiod_table(radiation_intervals)
+    radiation_daily = build_radiation_daily_summary(radiation_intervals)
+    photoperiod_path = _write_csv(output_root, "radiation_photoperiod", photoperiod)
+
+    event_intervals = build_10min_event_bridged_water_loss(dataset1, radiation_intervals)
+    event_intervals = calibrate_to_daily_event_bridged_total(event_intervals)
+    event_intervals_path = _write_csv(output_root, "event_intervals", event_intervals)
+    event_daily_all = summarize_radiation_daynight_et(event_intervals)
+    event_daily_all_path = _write_csv(output_root, "event_daily_all_thresholds", event_daily_all)
+    event_daily_main = event_daily_all[event_daily_all["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
+    event_daily_main_path = _write_csv(output_root, "event_daily_main_0w", event_daily_main)
+    radiation_main = radiation_daily[radiation_daily["threshold_w_m2"].eq(float(MAIN_RADIATION_THRESHOLD_W_M2))].copy()
+    daily_wide = build_daily_wide_et_summary(event_daily_all, threshold_w_m2=MAIN_RADIATION_THRESHOLD_W_M2)
+    daily_wide = daily_wide.merge(
+        radiation_main[
+            [
+                column
+                for column in (
+                    "date",
+                    "loadcell_id",
+                    "treatment",
+                    "threshold_w_m2",
+                    "day_vpd_kpa_mean",
+                    "day_air_temp_c_mean",
+                    "day_co2_ppm_mean",
+                )
+                if column in radiation_main.columns
+            ]
+        ],
+        on=[column for column in ("date", "loadcell_id", "treatment", "threshold_w_m2") if column in daily_wide.columns],
+        how="left",
+    )
+    daily_wide_path = _write_csv(output_root, "event_daily_wide_main_0w", daily_wide)
+
+    fruit_windows, leaf_windows = build_fruit_leaf_radiation_windows(
+        fruit_leaf_qc,
+        photoperiod,
+        mapping,
+        timestamp_col=mapping.get("timestamp_col", "TIMESTAMP"),
+        thresholds_w_m2=RADIATION_THRESHOLDS_W_M2,
+    )
+    fruit_leaf_windows = fruit_windows.merge(leaf_windows, on=["date", "threshold_w_m2"], how="left")
+    fruit_leaf_windows_path = _write_csv(output_root, "fruit_leaf_radiation_windows", fruit_leaf_windows)
+    clock_windows = build_fixed_clock_compat_windows(
+        fruit_leaf_qc,
+        mapping,
+        timestamp_col=mapping.get("timestamp_col", "TIMESTAMP"),
+    )
+    clock_windows_path = _write_csv(output_root, "fruit_leaf_clock_windows", clock_windows)
+    sensor_bridge = build_fruit_leaf_loadcell_bridge(mapping)
+    sensor_bridge_path = _write_csv(output_root, "fruit_leaf_loadcell_bridge", sensor_bridge)
+
+    dataset2, dataset2_load_meta = _read_projected_parquet(
+        dataset2_path,
+        DATASET2_COLUMN_CANDIDATES,
+        max_rows=int(dataset2_max_rows) if dataset2_max_rows is not None else None,
+        batch_size=batch_size,
+        max_full_rows_without_limit=max_full_rows_without_limit,
+    )
+    rootzone = build_rootzone_indices(dataset2, daily_wide)
+    rootzone_path = _write_csv(output_root, "rootzone_indices", rootzone)
+
+    dataset3, dataset3_load_meta = _read_projected_parquet(
+        dataset3_path,
+        DATASET3_COLUMN_CANDIDATES,
+        max_rows=int(dataset3_max_rows) if dataset3_max_rows is not None else None,
+        batch_size=batch_size,
+        max_full_rows_without_limit=max_full_rows_without_limit,
+    )
+    dataset3_bridge, dataset3_metadata = build_dataset3_growth_phenology_bridge(dataset3)
+    dataset3_path_out = _write_csv(output_root, "dataset3_bridge", dataset3_bridge)
+
+    feature_frame = build_observer_feature_frame(
+        daily_et_wide=daily_wide,
+        radiation_daily=radiation_daily,
+        rootzone_indices=rootzone,
+        fruit_windows=fruit_windows,
+        leaf_windows=leaf_windows,
+        dataset3_bridge=dataset3_bridge,
+    )
+    feature_frame_path = _write_csv(output_root, "observer_feature_frame", feature_frame)
+
+    metadata = base_metadata()
+    metadata.update(_load_goal1_metadata(output_root))
+    metadata.update(base_metadata())
+    metadata.update(fruit_diameter_policy_metadata(mapping))
+    metadata.update(
+        {
+            "radiation_source_decision": radiation_decision,
+            "radiation_source_candidate_count": len(radiation_rows),
+            "event_bridged_ET_outputs_produced": True,
+            "fruit_leaf_qc_outputs_produced": True,
+            "fruit_diameter_observer_inference_level": "sensor_level_apparent_expansion_diagnostics",
+            "apparent_canopy_conductance_available": bool(
+                rootzone.get("apparent_canopy_conductance_available", pd.Series(dtype=bool)).any()
+            ),
+            "Dataset3_mapping_confidence": dataset3_metadata.get("Dataset3_mapping_confidence"),
+            "Dataset3_mapping_confidence_counts": dataset3_metadata.get("Dataset3_mapping_confidence_counts", {}),
+            "Dataset3_datetime_or_date_available": bool(dataset3_metadata.get("datetime_or_date_available", False)),
+            "Dataset3_truss_position_available": bool(dataset3_metadata.get("truss_position_available", False)),
+            "row_loading": {
+                "dataset1": dataset1_load_meta,
+                "dataset2": dataset2_load_meta,
+                "dataset3": dataset3_load_meta,
+            },
+            "outputs": {},
+            "fixed_clock_daynight_primary": False,
+            "clock_06_18_used_only_for_compatibility": True,
+            "fallback_required": False,
+            "fallback_source_if_required": None,
+            "raw_dat_solar_rad_fallback_verified": True,
+            "shipped_TOMICS_incumbent_changed": False,
+            "latent_allocation_inference_run": False,
+            "harvest_family_factorial_run": False,
+            "promotion_gate_run": False,
+        }
+    )
+
+    output_paths = {
+        "fruit_leaf_timeseries_qc": fruit_leaf_qc_path,
+        "sensor_qc_report": sensor_qc_path,
+        "radiation_photoperiod": photoperiod_path,
+        "event_intervals": event_intervals_path,
+        "event_daily_all_thresholds": event_daily_all_path,
+        "event_daily_main_0w": event_daily_main_path,
+        "event_daily_wide_main_0w": daily_wide_path,
+        "fruit_leaf_radiation_windows": fruit_leaf_windows_path,
+        "fruit_leaf_clock_windows": clock_windows_path,
+        "fruit_leaf_loadcell_bridge": sensor_bridge_path,
+        "rootzone_indices": rootzone_path,
+        "dataset3_bridge": dataset3_path_out,
+        "observer_feature_frame": feature_frame_path,
+        "metadata": output_root / OUTPUT_FILENAMES["metadata"],
+    }
+    metadata["outputs"] = {key: str(path) for key, path in output_paths.items()}
+    metadata_path = write_json(output_root / OUTPUT_FILENAMES["metadata"], metadata)
+    output_paths["metadata"] = metadata_path
+
+    return {
+        "output_root": str(output_root),
+        "outputs": {key: str(path) for key, path in output_paths.items()},
+        "metadata": metadata,
+    }
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/production_export.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/production_export.py
@@ -37,7 +37,7 @@ def _combine_mean(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
     return numerator / denominator.replace(0, np.nan)
 
 
-def _finalize_radiation_base(partials: list[pd.DataFrame]) -> pd.DataFrame:
+def _finalize_radiation_base(partials: list[pd.DataFrame], *, radiation_col: str = RADIATION_COLUMN_USED) -> pd.DataFrame:
     if not partials:
         return pd.DataFrame()
     combined = pd.concat(partials, ignore_index=True)
@@ -68,7 +68,7 @@ def _finalize_radiation_base(partials: list[pd.DataFrame]) -> pd.DataFrame:
     out["date"] = out["interval_start"].dt.strftime("%Y-%m-%d")
     out["interval_seconds"] = 600.0
     out["radiation_source_used"] = RADIATION_PRIMARY_SOURCE
-    out["radiation_column_used"] = RADIATION_COLUMN_USED
+    out["radiation_column_used"] = radiation_col
     keep = [
         column
         for column in (
@@ -114,20 +114,20 @@ def expand_radiation_thresholds(
     return pd.concat(rows, ignore_index=True) if rows else radiation_base.iloc[0:0].copy()
 
 
-def _radiation_partial(chunk: pd.DataFrame) -> pd.DataFrame:
+def _radiation_partial(chunk: pd.DataFrame, *, radiation_col: str = RADIATION_COLUMN_USED) -> pd.DataFrame:
     data = chunk.copy()
     data["timestamp"] = pd.to_datetime(data["timestamp"], errors="coerce")
     data = data.dropna(subset=["timestamp"])
-    data[RADIATION_COLUMN_USED] = pd.to_numeric(data[RADIATION_COLUMN_USED], errors="coerce")
+    data[radiation_col] = pd.to_numeric(data[radiation_col], errors="coerce")
     data["interval_start"] = data["timestamp"].dt.floor("10min")
     group_cols = [column for column in ("interval_start", "loadcell_id", "treatment") if column in data.columns]
     data["_source_row"] = 1
     aggregations: dict[str, tuple[str, str]] = {
-        "radiation_sum": (RADIATION_COLUMN_USED, "sum"),
-        "radiation_count": (RADIATION_COLUMN_USED, "count"),
-        "radiation_wm2_max": (RADIATION_COLUMN_USED, "max"),
-        "radiation_wm2_min": (RADIATION_COLUMN_USED, "min"),
-        "sample_count": (RADIATION_COLUMN_USED, "count"),
+        "radiation_sum": (radiation_col, "sum"),
+        "radiation_count": (radiation_col, "count"),
+        "radiation_wm2_max": (radiation_col, "max"),
+        "radiation_wm2_min": (radiation_col, "min"),
+        "sample_count": (radiation_col, "count"),
         "source_row_count": ("_source_row", "sum"),
     }
     for env_col in ("env_vpd_kpa", "env_air_temperature_c", "env_co2_ppm"):
@@ -266,6 +266,7 @@ def aggregate_dataset1_streaming(
     max_rows: int | None,
     event_threshold_g: float = 50.0,
     thresholds_w_m2: Iterable[int | float] = RADIATION_THRESHOLDS_W_M2,
+    radiation_col: str = RADIATION_COLUMN_USED,
 ) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any], pd.DataFrame]:
     metadata = parquet_metadata_summary(path)
     available = projected_columns(path, columns)
@@ -281,7 +282,7 @@ def aggregate_dataset1_streaming(
     ):
         batches_processed += 1
         rows_processed += int(chunk.shape[0])
-        radiation_partials.append(_radiation_partial(chunk))
+        radiation_partials.append(_radiation_partial(chunk, radiation_col=radiation_col))
         water_partials.append(
             _water_partial(
                 chunk,
@@ -303,7 +304,7 @@ def aggregate_dataset1_streaming(
         sample = "; ".join(carry_state.sortedness_violations[:5])
         raise RuntimeError(f"Dataset1 timestamp sortedness precondition failed for water flux carryover: {sample}")
 
-    radiation_base = _finalize_radiation_base(radiation_partials)
+    radiation_base = _finalize_radiation_base(radiation_partials, radiation_col=radiation_col)
     radiation_intervals = expand_radiation_thresholds(radiation_base, thresholds_w_m2=thresholds_w_m2)
     water_intervals = _finalize_water_intervals(water_partials, radiation_intervals)
     total_rows = int(metadata["total_rows"])
@@ -324,6 +325,85 @@ def aggregate_dataset1_streaming(
         "water_flux_chunk_carryover_group_keys": ["loadcell_id", "treatment", "sample_id"],
     }
     return radiation_intervals, water_intervals, load_meta, pd.DataFrame(manifest_rows)
+
+
+def aggregate_dataset1_rootzone_reference_streaming(
+    *,
+    path: str | Path,
+    columns: tuple[str, ...],
+    batch_size: int,
+    max_rows: int | None,
+) -> tuple[pd.DataFrame, dict[str, Any], pd.DataFrame]:
+    metadata = parquet_metadata_summary(path)
+    available = projected_columns(path, columns)
+    partials: list[pd.DataFrame] = []
+    manifest_rows: list[dict[str, Any]] = []
+    rows_processed = 0
+    batches_processed = 0
+    for batch_idx, chunk in enumerate(
+        iter_projected_parquet_batches(path, columns, batch_size=batch_size, max_rows=max_rows),
+        start=1,
+    ):
+        batches_processed += 1
+        rows_processed += int(chunk.shape[0])
+        data = chunk.copy()
+        if "date" not in data.columns and "timestamp" in data.columns:
+            data["date"] = pd.to_datetime(data["timestamp"], errors="coerce").dt.strftime("%Y-%m-%d")
+        if "date" in data.columns:
+            data["date"] = data["date"].astype(str)
+        group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in data.columns]
+        data["_source_row"] = 1
+        aggregations: dict[str, tuple[str, str]] = {"source_row_count": ("_source_row", "sum")}
+        for column in ("moisture_percent", "ec_ds"):
+            if column in data.columns:
+                data[column] = pd.to_numeric(data[column], errors="coerce")
+                data[f"{column}_present"] = data[column].notna().astype("int64")
+                aggregations[f"{column}_sum"] = (column, "sum")
+                aggregations[f"{column}_count"] = (f"{column}_present", "sum")
+        partials.append(data.groupby(group_cols, dropna=False).agg(**aggregations).reset_index())
+        manifest_rows.append(
+            {
+                "dataset_role": "dataset1_rootzone_reference",
+                "batch_index": batch_idx,
+                "rows_processed": int(chunk.shape[0]),
+                "cumulative_rows_processed": rows_processed,
+                "aggregation_status": "ok",
+            }
+        )
+
+    combined = pd.concat(partials, ignore_index=True) if partials else pd.DataFrame()
+    if combined.empty:
+        daily = combined
+    else:
+        group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in combined.columns]
+        aggregations = {"source_row_count": ("source_row_count", "sum")}
+        for column in ("moisture_percent", "ec_ds"):
+            sum_col = f"{column}_sum"
+            count_col = f"{column}_count"
+            if sum_col in combined.columns:
+                aggregations[sum_col] = (sum_col, "sum")
+                aggregations[count_col] = (count_col, "sum")
+        daily = combined.groupby(group_cols, dropna=False).agg(**aggregations).reset_index()
+        if "moisture_percent_sum" in daily.columns:
+            daily["moisture_percent_mean"] = _combine_mean(daily["moisture_percent_sum"], daily["moisture_percent_count"])
+        if "ec_ds_sum" in daily.columns:
+            daily["ec_ds_mean"] = _combine_mean(daily["ec_ds_sum"], daily["ec_ds_count"])
+    total_rows = int(metadata["total_rows"])
+    load_meta = {
+        "path": str(path),
+        "projected_columns": available,
+        "total_rows": total_rows,
+        "rows_loaded": rows_processed,
+        "rows_processed": rows_processed,
+        "rows_processed_fraction": rows_processed / total_rows if total_rows else 1.0,
+        "row_limit_applied": max_rows is not None and rows_processed < total_rows,
+        "max_rows": max_rows,
+        "batches_processed": batches_processed,
+        "chunk_aggregation_complete": rows_processed == total_rows,
+        "chunk_aggregation_used": True,
+        "full_in_memory_large_dataset_used": False,
+    }
+    return daily, load_meta, pd.DataFrame(manifest_rows)
 
 
 def aggregate_dataset2_daily_streaming(

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/production_export.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/production_export.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    RADIATION_COLUMN_USED,
+    RADIATION_PRIMARY_SOURCE,
+    RADIATION_THRESHOLDS_W_M2,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.parquet_streaming import (
+    iter_projected_parquet_batches,
+    parquet_metadata_summary,
+    projected_columns,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import (
+    add_radiation_phase_columns,
+)
+
+
+@dataclass
+class ChunkCarryState:
+    previous_by_group: dict[tuple[Any, ...], tuple[pd.Timestamp, float]] = field(default_factory=dict)
+    sortedness_violations: list[str] = field(default_factory=list)
+
+
+def _present(columns: Iterable[str], frame: pd.DataFrame) -> list[str]:
+    return [column for column in columns if column in frame.columns]
+
+
+def _combine_mean(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
+    return numerator / denominator.replace(0, np.nan)
+
+
+def _finalize_radiation_base(partials: list[pd.DataFrame]) -> pd.DataFrame:
+    if not partials:
+        return pd.DataFrame()
+    combined = pd.concat(partials, ignore_index=True)
+    group_cols = [column for column in ("interval_start", "loadcell_id", "treatment") if column in combined.columns]
+    aggregations: dict[str, tuple[str, str]] = {
+        "radiation_sum": ("radiation_sum", "sum"),
+        "radiation_count": ("radiation_count", "sum"),
+        "radiation_wm2_max": ("radiation_wm2_max", "max"),
+        "radiation_wm2_min": ("radiation_wm2_min", "min"),
+        "sample_count": ("sample_count", "sum"),
+        "source_row_count": ("source_row_count", "sum"),
+    }
+    for env_col in ("env_vpd_kpa", "env_air_temperature_c", "env_co2_ppm"):
+        sum_col = f"{env_col}_sum"
+        count_col = f"{env_col}_count"
+        if sum_col in combined.columns:
+            aggregations[sum_col] = (sum_col, "sum")
+            aggregations[count_col] = (count_col, "sum")
+    out = combined.groupby(group_cols, dropna=False).agg(**aggregations).reset_index()
+    out["radiation_wm2_mean"] = _combine_mean(out["radiation_sum"], out["radiation_count"])
+    for env_col in ("env_vpd_kpa", "env_air_temperature_c", "env_co2_ppm"):
+        sum_col = f"{env_col}_sum"
+        count_col = f"{env_col}_count"
+        if sum_col in out.columns:
+            out[f"{env_col}_mean"] = _combine_mean(out[sum_col], out[count_col])
+    out["interval_start"] = pd.to_datetime(out["interval_start"], errors="coerce")
+    out["interval_end"] = out["interval_start"] + pd.to_timedelta(10, unit="min")
+    out["date"] = out["interval_start"].dt.strftime("%Y-%m-%d")
+    out["interval_seconds"] = 600.0
+    out["radiation_source_used"] = RADIATION_PRIMARY_SOURCE
+    out["radiation_column_used"] = RADIATION_COLUMN_USED
+    keep = [
+        column
+        for column in (
+            "interval_start",
+            "interval_end",
+            "date",
+            "loadcell_id",
+            "treatment",
+            "radiation_wm2_mean",
+            "radiation_wm2_max",
+            "radiation_wm2_min",
+            "sample_count",
+            "source_row_count",
+            "env_vpd_kpa_mean",
+            "env_air_temperature_c_mean",
+            "env_co2_ppm_mean",
+            "interval_seconds",
+            "radiation_source_used",
+            "radiation_column_used",
+        )
+        if column in out.columns
+    ]
+    return out[keep].sort_values([column for column in ("loadcell_id", "interval_start") if column in keep]).reset_index(
+        drop=True
+    )
+
+
+def expand_radiation_thresholds(
+    radiation_base: pd.DataFrame,
+    *,
+    thresholds_w_m2: Iterable[int | float] = RADIATION_THRESHOLDS_W_M2,
+) -> pd.DataFrame:
+    rows: list[pd.DataFrame] = []
+    for threshold in thresholds_w_m2:
+        threshold_frame = radiation_base.copy()
+        threshold_frame["threshold_w_m2"] = float(threshold)
+        threshold_frame["radiation_phase"] = np.where(
+            threshold_frame["radiation_wm2_max"].fillna(0.0) > float(threshold),
+            "day",
+            "night",
+        )
+        rows.append(threshold_frame)
+    return pd.concat(rows, ignore_index=True) if rows else radiation_base.iloc[0:0].copy()
+
+
+def _radiation_partial(chunk: pd.DataFrame) -> pd.DataFrame:
+    data = chunk.copy()
+    data["timestamp"] = pd.to_datetime(data["timestamp"], errors="coerce")
+    data = data.dropna(subset=["timestamp"])
+    data[RADIATION_COLUMN_USED] = pd.to_numeric(data[RADIATION_COLUMN_USED], errors="coerce")
+    data["interval_start"] = data["timestamp"].dt.floor("10min")
+    group_cols = [column for column in ("interval_start", "loadcell_id", "treatment") if column in data.columns]
+    data["_source_row"] = 1
+    aggregations: dict[str, tuple[str, str]] = {
+        "radiation_sum": (RADIATION_COLUMN_USED, "sum"),
+        "radiation_count": (RADIATION_COLUMN_USED, "count"),
+        "radiation_wm2_max": (RADIATION_COLUMN_USED, "max"),
+        "radiation_wm2_min": (RADIATION_COLUMN_USED, "min"),
+        "sample_count": (RADIATION_COLUMN_USED, "count"),
+        "source_row_count": ("_source_row", "sum"),
+    }
+    for env_col in ("env_vpd_kpa", "env_air_temperature_c", "env_co2_ppm"):
+        if env_col in data.columns:
+            data[env_col] = pd.to_numeric(data[env_col], errors="coerce")
+            data[f"{env_col}_present"] = data[env_col].notna().astype("int64")
+            aggregations[f"{env_col}_sum"] = (env_col, "sum")
+            aggregations[f"{env_col}_count"] = (f"{env_col}_present", "sum")
+    return data.groupby(group_cols, dropna=False).agg(**aggregations).reset_index()
+
+
+def _sorted_group_key(value: tuple[Any, ...] | Any) -> tuple[Any, ...]:
+    if isinstance(value, tuple):
+        return value
+    return (value,)
+
+
+def _water_partial(
+    chunk: pd.DataFrame,
+    *,
+    carry_state: ChunkCarryState,
+    event_threshold_g: float,
+) -> pd.DataFrame:
+    group_cols = _present(("loadcell_id", "treatment", "sample_id"), chunk)
+    output_group_cols = _present(("loadcell_id", "treatment"), chunk)
+    required = ["timestamp", "loadcell_weight_kg", *group_cols]
+    data = chunk[required].copy()
+    data["timestamp"] = pd.to_datetime(data["timestamp"], errors="coerce")
+    data["loadcell_weight_kg"] = pd.to_numeric(data["loadcell_weight_kg"], errors="coerce")
+    data = data.dropna(subset=["timestamp", "loadcell_weight_kg"]).sort_values([*group_cols, "timestamp"])
+    if data.empty:
+        return pd.DataFrame(columns=[*output_group_cols, "interval_start", "loss_g_10min_unscaled", "event_flag"])
+
+    carry_rows: list[dict[str, Any]] = []
+    for key, group in data.groupby(group_cols, dropna=False):
+        key_tuple = _sorted_group_key(key)
+        if key_tuple not in carry_state.previous_by_group:
+            continue
+        previous_timestamp, previous_weight = carry_state.previous_by_group[key_tuple]
+        first_timestamp = pd.Timestamp(group["timestamp"].iloc[0])
+        if first_timestamp < previous_timestamp:
+            carry_state.sortedness_violations.append(
+                f"group={key_tuple} first={first_timestamp.isoformat()} previous={previous_timestamp.isoformat()}"
+            )
+            continue
+        carry_row = {column: value for column, value in zip(group_cols, key_tuple, strict=True)}
+        carry_row.update(
+            {
+                "timestamp": previous_timestamp,
+                "loadcell_weight_kg": previous_weight,
+                "_carry_row": True,
+            }
+        )
+        carry_rows.append(carry_row)
+
+    data["_carry_row"] = False
+    if carry_rows:
+        data = pd.concat([pd.DataFrame(carry_rows), data], ignore_index=True, sort=False)
+        data["_carry_sort"] = np.where(data["_carry_row"].astype(bool), 0, 1)
+        data = data.sort_values([*group_cols, "timestamp", "_carry_sort"])
+    else:
+        data["_carry_sort"] = 1
+
+    data["weight_delta_g"] = data.groupby(group_cols, dropna=False)["loadcell_weight_kg"].diff() * 1000.0
+    work = data[~data["_carry_row"].astype(bool)].copy()
+    work["positive_loss_g"] = (-work["weight_delta_g"]).clip(lower=0.0)
+    work["event_flag"] = work["weight_delta_g"].abs().gt(event_threshold_g)
+    work["interval_start"] = work["timestamp"].dt.floor("10min")
+
+    for key, group in work.groupby(group_cols, dropna=False):
+        key_tuple = _sorted_group_key(key)
+        last = group.dropna(subset=["timestamp", "loadcell_weight_kg"]).iloc[-1]
+        carry_state.previous_by_group[key_tuple] = (
+            pd.Timestamp(last["timestamp"]),
+            float(last["loadcell_weight_kg"]),
+        )
+
+    group_keys = [*output_group_cols, "interval_start"]
+    return (
+        work.groupby(group_keys, dropna=False)
+        .agg(
+            loss_g_10min_unscaled=("positive_loss_g", "sum"),
+            event_flag=("event_flag", "max"),
+            source_row_count=("positive_loss_g", "count"),
+        )
+        .reset_index()
+    )
+
+
+def _finalize_water_intervals(water_partials: list[pd.DataFrame], radiation_intervals: pd.DataFrame) -> pd.DataFrame:
+    if not water_partials:
+        out = pd.DataFrame(columns=["interval_start", "loss_g_10min_unscaled", "event_flag"])
+    else:
+        combined = pd.concat(water_partials, ignore_index=True)
+        group_cols = [column for column in ("loadcell_id", "treatment", "interval_start") if column in combined.columns]
+        out = (
+            combined.groupby(group_cols, dropna=False)
+            .agg(
+                loss_g_10min_unscaled=("loss_g_10min_unscaled", "sum"),
+                event_flag=("event_flag", "max"),
+                source_row_count=("source_row_count", "sum"),
+            )
+            .reset_index()
+        )
+    out["interval_start"] = pd.to_datetime(out["interval_start"], errors="coerce")
+    out["interval_end"] = out["interval_start"] + pd.to_timedelta(10, unit="min")
+    out["date"] = out["interval_start"].dt.strftime("%Y-%m-%d")
+    out["event_type"] = np.where(out["event_flag"].fillna(False).astype(bool), "irrigation_or_drainage", "quiet")
+    out["warnings"] = ""
+    out["daily_bridge_scale_factor"] = np.nan
+    out["loss_g_10min_event_bridged_calibrated"] = np.nan
+    out["bridge_status"] = "uncalibrated_no_daily_total"
+    out["water_flux_source_used"] = "loadcell_weight_kg_derivative_chunked"
+
+    phase_wide = add_radiation_phase_columns(radiation_intervals)
+    merge_cols = [
+        column
+        for column in ("interval_start", "loadcell_id", "treatment")
+        if column in out.columns and column in phase_wide.columns
+    ]
+    if merge_cols:
+        out = out.merge(phase_wide, on=merge_cols, how="left", suffixes=("", "_radiation"))
+        for column in ("date_radiation", "interval_end_radiation"):
+            if column in out.columns:
+                out = out.drop(columns=[column])
+    return out.sort_values([column for column in ("date", "loadcell_id", "interval_start") if column in out.columns]).reset_index(
+        drop=True
+    )
+
+
+def aggregate_dataset1_streaming(
+    *,
+    path: str | Path,
+    columns: tuple[str, ...],
+    batch_size: int,
+    max_rows: int | None,
+    event_threshold_g: float = 50.0,
+    thresholds_w_m2: Iterable[int | float] = RADIATION_THRESHOLDS_W_M2,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any], pd.DataFrame]:
+    metadata = parquet_metadata_summary(path)
+    available = projected_columns(path, columns)
+    radiation_partials: list[pd.DataFrame] = []
+    water_partials: list[pd.DataFrame] = []
+    manifest_rows: list[dict[str, Any]] = []
+    carry_state = ChunkCarryState()
+    rows_processed = 0
+    batches_processed = 0
+    for batch_idx, chunk in enumerate(
+        iter_projected_parquet_batches(path, columns, batch_size=batch_size, max_rows=max_rows),
+        start=1,
+    ):
+        batches_processed += 1
+        rows_processed += int(chunk.shape[0])
+        radiation_partials.append(_radiation_partial(chunk))
+        water_partials.append(
+            _water_partial(
+                chunk,
+                carry_state=carry_state,
+                event_threshold_g=event_threshold_g,
+            )
+        )
+        manifest_rows.append(
+            {
+                "dataset_role": "dataset1",
+                "batch_index": batch_idx,
+                "rows_processed": int(chunk.shape[0]),
+                "cumulative_rows_processed": rows_processed,
+                "aggregation_status": "ok",
+            }
+        )
+
+    if carry_state.sortedness_violations:
+        sample = "; ".join(carry_state.sortedness_violations[:5])
+        raise RuntimeError(f"Dataset1 timestamp sortedness precondition failed for water flux carryover: {sample}")
+
+    radiation_base = _finalize_radiation_base(radiation_partials)
+    radiation_intervals = expand_radiation_thresholds(radiation_base, thresholds_w_m2=thresholds_w_m2)
+    water_intervals = _finalize_water_intervals(water_partials, radiation_intervals)
+    total_rows = int(metadata["total_rows"])
+    load_meta = {
+        "path": str(path),
+        "projected_columns": available,
+        "total_rows": total_rows,
+        "rows_loaded": rows_processed,
+        "rows_processed": rows_processed,
+        "rows_processed_fraction": rows_processed / total_rows if total_rows else 1.0,
+        "row_limit_applied": max_rows is not None and rows_processed < total_rows,
+        "max_rows": max_rows,
+        "batches_processed": batches_processed,
+        "chunk_aggregation_complete": rows_processed == total_rows,
+        "chunk_aggregation_used": True,
+        "full_in_memory_large_dataset_used": False,
+        "water_flux_chunk_carryover_used": True,
+        "water_flux_chunk_carryover_group_keys": ["loadcell_id", "treatment", "sample_id"],
+    }
+    return radiation_intervals, water_intervals, load_meta, pd.DataFrame(manifest_rows)
+
+
+def aggregate_dataset2_daily_streaming(
+    *,
+    path: str | Path,
+    columns: tuple[str, ...],
+    batch_size: int,
+    max_rows: int | None,
+) -> tuple[pd.DataFrame, dict[str, Any], pd.DataFrame]:
+    metadata = parquet_metadata_summary(path)
+    available = projected_columns(path, columns)
+    partials: list[pd.DataFrame] = []
+    manifest_rows: list[dict[str, Any]] = []
+    rows_processed = 0
+    batches_processed = 0
+    for batch_idx, chunk in enumerate(
+        iter_projected_parquet_batches(path, columns, batch_size=batch_size, max_rows=max_rows),
+        start=1,
+    ):
+        batches_processed += 1
+        rows_processed += int(chunk.shape[0])
+        data = chunk.copy()
+        if "date" not in data.columns and "timestamp" in data.columns:
+            data["date"] = pd.to_datetime(data["timestamp"], errors="coerce").dt.strftime("%Y-%m-%d")
+        data["date"] = data["date"].astype(str)
+        group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in data.columns]
+        data["_source_row"] = 1
+        aggregations: dict[str, tuple[str, str]] = {"source_row_count": ("_source_row", "sum")}
+        for column in ("moisture_percent", "ec_ds", "tensiometer_hp"):
+            if column in data.columns:
+                data[column] = pd.to_numeric(data[column], errors="coerce")
+                data[f"{column}_present"] = data[column].notna().astype("int64")
+                aggregations[f"{column}_sum"] = (column, "sum")
+                aggregations[f"{column}_count"] = (f"{column}_present", "sum")
+        partials.append(data.groupby(group_cols, dropna=False).agg(**aggregations).reset_index())
+        manifest_rows.append(
+            {
+                "dataset_role": "dataset2",
+                "batch_index": batch_idx,
+                "rows_processed": int(chunk.shape[0]),
+                "cumulative_rows_processed": rows_processed,
+                "aggregation_status": "ok",
+            }
+        )
+
+    combined = pd.concat(partials, ignore_index=True) if partials else pd.DataFrame()
+    if combined.empty:
+        daily = combined
+    else:
+        group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in combined.columns]
+        aggregations = {"source_row_count": ("source_row_count", "sum")}
+        for column in ("moisture_percent", "ec_ds", "tensiometer_hp"):
+            sum_col = f"{column}_sum"
+            count_col = f"{column}_count"
+            if sum_col in combined.columns:
+                aggregations[sum_col] = (sum_col, "sum")
+                aggregations[count_col] = (count_col, "sum")
+        daily = combined.groupby(group_cols, dropna=False).agg(**aggregations).reset_index()
+        if "moisture_percent_sum" in daily.columns:
+            daily["moisture_percent_mean"] = _combine_mean(daily["moisture_percent_sum"], daily["moisture_percent_count"])
+        if "ec_ds_sum" in daily.columns:
+            daily["ec_ds_mean"] = _combine_mean(daily["ec_ds_sum"], daily["ec_ds_count"])
+        if "tensiometer_hp_sum" in daily.columns:
+            daily["tensiometer_hp_mean"] = _combine_mean(daily["tensiometer_hp_sum"], daily["tensiometer_hp_count"])
+            daily["tensiometer_available"] = daily["tensiometer_hp_count"].gt(0)
+            daily["tensiometer_coverage_fraction"] = daily["tensiometer_hp_count"] / daily["source_row_count"].replace(0, np.nan)
+    total_rows = int(metadata["total_rows"])
+    load_meta = {
+        "path": str(path),
+        "projected_columns": available,
+        "total_rows": total_rows,
+        "rows_loaded": rows_processed,
+        "rows_processed": rows_processed,
+        "rows_processed_fraction": rows_processed / total_rows if total_rows else 1.0,
+        "row_limit_applied": max_rows is not None and rows_processed < total_rows,
+        "max_rows": max_rows,
+        "batches_processed": batches_processed,
+        "chunk_aggregation_complete": rows_processed == total_rows,
+        "chunk_aggregation_used": True,
+        "full_in_memory_large_dataset_used": False,
+    }
+    return daily, load_meta, pd.DataFrame(manifest_rows)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/qc.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/qc.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_FRUIT_COLUMNS = ("Fruit1Diameter_Avg", "Fruit2Diameter_Avg")
+DEFAULT_LEAF_COLUMNS = ("LeafTemp1_Avg", "LeafTemp2_Avg")
+
+
+def _numeric_series(frame: pd.DataFrame, column: str) -> pd.Series:
+    if column not in frame.columns:
+        return pd.Series(np.nan, index=frame.index, dtype="float64")
+    return pd.to_numeric(frame[column], errors="coerce")
+
+
+def apply_fruit_leaf_qc(
+    frame: pd.DataFrame,
+    *,
+    timestamp_col: str = "TIMESTAMP",
+    fruit_columns: Iterable[str] = DEFAULT_FRUIT_COLUMNS,
+    leaf_columns: Iterable[str] = DEFAULT_LEAF_COLUMNS,
+    min_fruit_mm: float = 20.0,
+    max_fruit_mm: float = 120.0,
+    max_10min_jump_mm: float = 1.0,
+    min_valid_points: int = 3,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    qc = frame.copy()
+    if timestamp_col in qc.columns:
+        qc[timestamp_col] = pd.to_datetime(qc[timestamp_col], errors="coerce")
+        qc = qc.sort_values(timestamp_col).reset_index(drop=True)
+
+    report_rows: list[dict[str, object]] = []
+    for column in fruit_columns:
+        values = _numeric_series(qc, column)
+        step = values.diff().abs()
+        in_range = values.between(min_fruit_mm, max_fruit_mm)
+        jump_ok = step.le(max_10min_jump_mm) | step.isna()
+        valid = values.notna() & in_range & jump_ok
+        valid_col = f"{column}_valid"
+        reason_col = f"{column}_qc_reason"
+        qc[column] = values
+        qc[valid_col] = valid
+        qc[reason_col] = np.select(
+            [values.isna(), ~in_range, ~jump_ok],
+            ["missing", "outside_20_120_mm", "jump_gt_1_mm"],
+            default="valid",
+        )
+        report_rows.append(
+            {
+                "sensor_column": column,
+                "sensor_type": "fruit_diameter",
+                "valid_count": int(valid.sum()),
+                "invalid_count": int((~valid).sum()),
+                "max_10min_step_mm": float(step.max(skipna=True)) if step.notna().any() else np.nan,
+                "stable_flag": bool(valid.sum() >= min_valid_points and (step.dropna() <= max_10min_jump_mm).all()),
+                "insufficient_valid_points": bool(valid.sum() < min_valid_points),
+            }
+        )
+
+    for column in leaf_columns:
+        values = _numeric_series(qc, column)
+        valid = values.notna()
+        qc[column] = values
+        qc[f"{column}_valid"] = valid
+        report_rows.append(
+            {
+                "sensor_column": column,
+                "sensor_type": "leaf_temperature",
+                "valid_count": int(valid.sum()),
+                "invalid_count": int((~valid).sum()),
+                "max_10min_step_mm": np.nan,
+                "stable_flag": bool(valid.any()),
+                "insufficient_valid_points": bool(valid.sum() < min_valid_points),
+            }
+        )
+
+    return qc, pd.DataFrame(report_rows)
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/qc.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/qc.py
@@ -77,4 +77,3 @@ def apply_fruit_leaf_qc(
         )
 
     return qc, pd.DataFrame(report_rows)
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_source.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_source.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import math
+
+import pandas as pd
+
+RADIATION_THRESHOLDS_TO_TEST = [0, 1, 5, 10]
+
+RADIATION_CANDIDATE_SPECS: tuple[dict[str, object], ...] = (
+    {
+        "candidate_rank": 1,
+        "source_file_role": "dataset1",
+        "candidate_column": "env_inside_radiation_wm2",
+        "preference_group": "dataset1",
+    },
+    {
+        "candidate_rank": 2,
+        "source_file_role": "dataset1",
+        "candidate_column": "env_radiation_wm2",
+        "preference_group": "dataset1",
+    },
+    {
+        "candidate_rank": 3,
+        "source_file_role": "dataset1",
+        "candidate_column": "env_radiation_wm2_mean",
+        "preference_group": "dataset1",
+    },
+    {
+        "candidate_rank": 3,
+        "source_file_role": "dataset1",
+        "candidate_column": "env_radiation_wm2_max",
+        "preference_group": "dataset1",
+    },
+    {
+        "candidate_rank": 4,
+        "source_file_role": "fruit_leaf_temperature_solar_raw_dat",
+        "candidate_column": "SolarRad_Avg",
+        "preference_group": "raw_dat",
+    },
+    {
+        "candidate_rank": 5,
+        "source_file_role": "dataset1",
+        "candidate_column": "env_outside_radiation_wm2",
+        "preference_group": "dataset1_outside_fallback",
+    },
+)
+
+
+def _to_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(out):
+        return None
+    return out
+
+
+def _bool(value: object) -> bool:
+    return bool(value) if value is not None else False
+
+
+def _column_stats(audit_row: Mapping[str, object] | None, column: str) -> Mapping[str, object]:
+    raw = (audit_row or {}).get("column_stats_json")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(str(raw))
+    except json.JSONDecodeError:
+        return {}
+    stats = parsed.get(column)
+    return stats if isinstance(stats, Mapping) else {}
+
+
+def _grain_from_resolution(seconds: float | None) -> str:
+    if seconds is None:
+        return "unknown"
+    if seconds <= 600:
+        return "high_frequency_10min_or_finer"
+    if seconds < 86_400:
+        return "subdaily_not_10min"
+    if seconds == 86_400:
+        return "daily_only"
+    return "coarser_than_daily"
+
+
+def _radiation_metrics(
+    frame: pd.DataFrame | None,
+    *,
+    column: str,
+    audit_row: Mapping[str, object] | None,
+) -> dict[str, object]:
+    exists = frame is not None and column in frame.columns
+    resolution = _to_float((audit_row or {}).get("inferred_time_resolution_seconds"))
+    stats = _column_stats(audit_row, column)
+    if not exists or frame is None:
+        stats_num_values = int(stats.get("num_values") or 0)
+        if stats:
+            row_count = int((audit_row or {}).get("row_count") or stats_num_values)
+            null_count = int(stats.get("null_count") or 0)
+            min_value = _to_float(stats.get("min"))
+            max_value = _to_float(stats.get("max"))
+            return {
+                "exists": True,
+                "non_null_count": stats_num_values,
+                "missing_fraction": float(null_count / row_count) if row_count else None,
+                "min_value": min_value,
+                "max_value": max_value,
+                "mean_value": None,
+                "has_positive_values": bool(max_value is not None and max_value > 0.0),
+                "has_zero_values": bool(
+                    min_value is not None and max_value is not None and min_value <= 0.0 <= max_value
+                ),
+                "date_min": (audit_row or {}).get("date_min"),
+                "date_max": (audit_row or {}).get("date_max"),
+                "inferred_time_resolution_seconds": resolution,
+                "usable_for_10min_daynight": bool(
+                    stats_num_values and max_value is not None and max_value > 0.0 and resolution is not None and resolution <= 600
+                ),
+                "usable_for_daily_summary_only": bool(stats_num_values and resolution is not None and resolution >= 86_400),
+            }
+        return {
+            "exists": False,
+            "non_null_count": 0,
+            "missing_fraction": None,
+            "min_value": None,
+            "max_value": None,
+            "mean_value": None,
+            "has_positive_values": False,
+            "has_zero_values": False,
+            "date_min": (audit_row or {}).get("date_min"),
+            "date_max": (audit_row or {}).get("date_max"),
+            "inferred_time_resolution_seconds": resolution,
+            "usable_for_10min_daynight": False,
+            "usable_for_daily_summary_only": False,
+        }
+
+    values = pd.to_numeric(frame[column], errors="coerce")
+    sample_non_null_count = int(values.notna().sum())
+    sample_row_count = int(values.shape[0])
+    row_count = int((audit_row or {}).get("row_count") or sample_row_count)
+    non_null_count = int(stats.get("num_values") or sample_non_null_count)
+    null_count = int(stats.get("null_count") or max(sample_row_count - sample_non_null_count, 0))
+    missing_fraction = float(null_count / row_count) if row_count else None
+    min_value = _to_float(stats.get("min")) if stats else None
+    max_value = _to_float(stats.get("max")) if stats else None
+    if min_value is None and sample_non_null_count:
+        min_value = float(values.min())
+    if max_value is None and sample_non_null_count:
+        max_value = float(values.max())
+    has_positive = bool(max_value is not None and max_value > 0.0)
+    has_zero = bool(min_value is not None and max_value is not None and min_value <= 0.0 <= max_value)
+    usable_10min = bool(non_null_count and has_positive and has_zero and resolution is not None and resolution <= 600)
+    usable_daily = bool(non_null_count and resolution is not None and resolution >= 86_400)
+    return {
+        "exists": True,
+        "non_null_count": non_null_count,
+        "missing_fraction": missing_fraction,
+        "min_value": min_value,
+        "max_value": max_value,
+        "mean_value": float(values.mean()) if sample_non_null_count else None,
+        "has_positive_values": has_positive,
+        "has_zero_values": has_zero,
+        "date_min": (audit_row or {}).get("date_min"),
+        "date_max": (audit_row or {}).get("date_max"),
+        "inferred_time_resolution_seconds": resolution,
+        "usable_for_10min_daynight": usable_10min,
+        "usable_for_daily_summary_only": usable_daily,
+    }
+
+
+def _candidate_is_selectable(row: Mapping[str, object]) -> bool:
+    return _bool(row.get("exists")) and int(row.get("non_null_count") or 0) > 0 and _bool(
+        row.get("has_positive_values")
+    )
+
+
+def build_radiation_source_verification(
+    tables_by_role: Mapping[str, pd.DataFrame | None],
+    audit_rows_by_role: Mapping[str, Mapping[str, object]],
+) -> tuple[list[dict[str, object]], dict[str, object]]:
+    """Build candidate radiation-source rows and decision metadata."""
+
+    rows: list[dict[str, object]] = []
+    for spec in RADIATION_CANDIDATE_SPECS:
+        role = str(spec["source_file_role"])
+        candidate_column = str(spec["candidate_column"])
+        audit_row = audit_rows_by_role.get(role, {})
+        metrics = _radiation_metrics(
+            tables_by_role.get(role),
+            column=candidate_column,
+            audit_row=audit_row,
+        )
+        rows.append(
+            {
+                "candidate_rank": int(spec["candidate_rank"]),
+                "source_file_role": role,
+                "source_filename": audit_row.get("expected_filename"),
+                "candidate_column": candidate_column,
+                **metrics,
+                "chosen_primary": False,
+                "fallback_reason": "",
+                "notes": "",
+            }
+        )
+
+    chosen_index: int | None = None
+    for idx, row in enumerate(rows):
+        if row["source_file_role"] == "dataset1" and _candidate_is_selectable(row):
+            chosen_index = idx
+            row["chosen_primary"] = True
+            break
+
+    fallback_required = True
+    fallback_source = ""
+    decision_notes: list[str] = []
+    dataset1_direct = False
+    dataset1_grain = "unknown"
+    primary_source = ""
+    primary_column = ""
+
+    if chosen_index is not None:
+        chosen = rows[chosen_index]
+        fallback_required = not _bool(chosen.get("usable_for_10min_daynight"))
+        if _bool(chosen.get("usable_for_10min_daynight")):
+            primary_source = str(chosen["source_file_role"])
+            primary_column = str(chosen["candidate_column"])
+        if primary_source == "dataset1":
+            dataset1_direct = _bool(chosen.get("usable_for_10min_daynight"))
+            dataset1_grain = _grain_from_resolution(_to_float(chosen.get("inferred_time_resolution_seconds")))
+        chosen["notes"] = (
+            "Primary preference candidate selected. "
+            "Goal 2 still requires 10-minute usability if interval day/night is built."
+        )
+    else:
+        decision_notes.append("No selectable Dataset1 radiation candidate with positive numeric values was found.")
+
+    dataset1_candidates = [row for row in rows if row["source_file_role"] == "dataset1" and _candidate_is_selectable(row)]
+    if dataset1_candidates and dataset1_grain == "unknown":
+        dataset1_grain = _grain_from_resolution(
+            _to_float(dataset1_candidates[0].get("inferred_time_resolution_seconds"))
+        )
+        dataset1_direct = _bool(dataset1_candidates[0].get("usable_for_10min_daynight"))
+
+    if fallback_required:
+        for row in rows:
+            if row.get("chosen_primary"):
+                continue
+            if _bool(row.get("usable_for_10min_daynight")):
+                fallback_source = f"{row['source_file_role']}:{row['candidate_column']}"
+                row["fallback_reason"] = "10min_daynight_candidate_if_primary_is_daily_or_unusable"
+                break
+        if not fallback_source:
+            raw_candidate = next(
+                (
+                    row
+                    for row in rows
+                    if row["source_file_role"] == "fruit_leaf_temperature_solar_raw_dat"
+                    and row["candidate_column"] == "SolarRad_Avg"
+                    and _candidate_is_selectable(row)
+                ),
+                None,
+            )
+            if raw_candidate is not None:
+                fallback_source = "fruit_leaf_temperature_solar_raw_dat:SolarRad_Avg"
+                raw_candidate["fallback_reason"] = "candidate_high_frequency_fallback_for_goal2_review"
+
+    if fallback_required and not fallback_source:
+        decision_notes.append("No high-frequency fallback has been verified yet.")
+    if dataset1_grain == "daily_only":
+        decision_notes.append("Dataset1 radiation is daily-only; do not force 10-minute day/night from daily means.")
+    if dataset1_grain == "subdaily_not_10min":
+        decision_notes.append("Dataset1 radiation is subdaily but coarser than 10 minutes.")
+    if not dataset1_direct:
+        decision_notes.append("No Dataset1 radiation candidate was verified as a 10-minute day/night primary.")
+
+    metadata = {
+        "radiation_daynight_primary_source": primary_source,
+        "radiation_column_used": primary_column,
+        "radiation_thresholds_to_test": RADIATION_THRESHOLDS_TO_TEST,
+        "fixed_clock_daynight_primary": False,
+        "clock_06_18_used_only_for_compatibility": True,
+        "dataset1_radiation_directly_usable": dataset1_direct,
+        "dataset1_radiation_grain": dataset1_grain,
+        "fallback_required": fallback_required,
+        "fallback_source_if_required": fallback_source,
+        "radiation_source_decision_notes": decision_notes,
+    }
+    return rows, metadata
+
+
+__all__ = [
+    "RADIATION_CANDIDATE_SPECS",
+    "RADIATION_THRESHOLDS_TO_TEST",
+    "build_radiation_source_verification",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_source.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_source.py
@@ -88,6 +88,27 @@ def _grain_from_resolution(seconds: float | None) -> str:
     return "coarser_than_daily"
 
 
+def _infer_resolution_from_frame(frame: pd.DataFrame | None) -> float | None:
+    if frame is None or frame.empty:
+        return None
+    timestamp_col = next(
+        (column for column in ("timestamp", "TIMESTAMP", "datetime", "date_time", "DateTime", "time") if column in frame.columns),
+        None,
+    )
+    if timestamp_col is None:
+        return None
+    values = pd.to_datetime(frame[timestamp_col], errors="coerce").dropna().sort_values()
+    if values.shape[0] < 2:
+        return None
+    deltas = values.diff().dt.total_seconds().dropna()
+    if deltas.empty:
+        return None
+    positive = deltas[deltas.gt(0)]
+    if positive.empty:
+        return None
+    return float(positive.median())
+
+
 def _radiation_metrics(
     frame: pd.DataFrame | None,
     *,
@@ -96,6 +117,8 @@ def _radiation_metrics(
 ) -> dict[str, object]:
     exists = frame is not None and column in frame.columns
     resolution = _to_float((audit_row or {}).get("inferred_time_resolution_seconds"))
+    if resolution is None:
+        resolution = _infer_resolution_from_frame(frame)
     stats = _column_stats(audit_row, column)
     if not exists or frame is None:
         stats_num_values = int(stats.get("num_values") or 0)
@@ -179,6 +202,22 @@ def _candidate_is_selectable(row: Mapping[str, object]) -> bool:
     )
 
 
+def _candidate_rejection_reason(row: Mapping[str, object]) -> str:
+    if not _bool(row.get("exists")):
+        return "column_missing"
+    if int(row.get("non_null_count") or 0) <= 0:
+        return "no_non_null_values"
+    if not _bool(row.get("has_positive_values")):
+        return "no_positive_radiation_values"
+    if not _bool(row.get("usable_for_10min_daynight")) and _bool(row.get("usable_for_daily_summary_only")):
+        return "daily_only_not_valid_for_10min_daynight"
+    if not _bool(row.get("has_zero_values")):
+        return "no_zero_radiation_values_for_night"
+    if not _bool(row.get("usable_for_10min_daynight")):
+        return "grain_not_valid_for_10min_daynight"
+    return ""
+
+
 def build_radiation_source_verification(
     tables_by_role: Mapping[str, pd.DataFrame | None],
     audit_rows_by_role: Mapping[str, Mapping[str, object]],
@@ -203,6 +242,9 @@ def build_radiation_source_verification(
                 "candidate_column": candidate_column,
                 **metrics,
                 "chosen_primary": False,
+                "selected_for_daynight_10min": False,
+                "selected_for_daily_summary_only": False,
+                "candidate_rejection_reason": "",
                 "fallback_reason": "",
                 "notes": "",
             }
@@ -212,8 +254,9 @@ def build_radiation_source_verification(
     for idx, row in enumerate(rows):
         if row["source_file_role"] == "dataset1" and _candidate_is_selectable(row):
             chosen_index = idx
-            row["chosen_primary"] = True
             break
+    for row in rows:
+        row["candidate_rejection_reason"] = _candidate_rejection_reason(row)
 
     fallback_required = True
     fallback_source = ""
@@ -227,14 +270,18 @@ def build_radiation_source_verification(
         chosen = rows[chosen_index]
         fallback_required = not _bool(chosen.get("usable_for_10min_daynight"))
         if _bool(chosen.get("usable_for_10min_daynight")):
+            chosen["selected_for_daynight_10min"] = True
+            chosen["chosen_primary"] = True
             primary_source = str(chosen["source_file_role"])
             primary_column = str(chosen["candidate_column"])
+        elif _bool(chosen.get("usable_for_daily_summary_only")):
+            chosen["selected_for_daily_summary_only"] = True
         if primary_source == "dataset1":
             dataset1_direct = _bool(chosen.get("usable_for_10min_daynight"))
             dataset1_grain = _grain_from_resolution(_to_float(chosen.get("inferred_time_resolution_seconds")))
         chosen["notes"] = (
-            "Primary preference candidate selected. "
-            "Goal 2 still requires 10-minute usability if interval day/night is built."
+            "Highest-ranked available Dataset1 radiation candidate. "
+            "It is selected for 10-minute day/night only when grain and zero/positive values support that use."
         )
     else:
         decision_notes.append("No selectable Dataset1 radiation candidate with positive numeric values was found.")
@@ -248,7 +295,7 @@ def build_radiation_source_verification(
 
     if fallback_required:
         for row in rows:
-            if row.get("chosen_primary"):
+            if row.get("selected_for_daynight_10min"):
                 continue
             if _bool(row.get("usable_for_10min_daynight")):
                 fallback_source = f"{row['source_file_role']}:{row['candidate_column']}"
@@ -281,6 +328,10 @@ def build_radiation_source_verification(
     metadata = {
         "radiation_daynight_primary_source": primary_source,
         "radiation_column_used": primary_column,
+        "selected_for_daynight_10min": bool(primary_source and primary_column),
+        "selected_for_daily_summary_only": bool(
+            chosen_index is not None and rows[chosen_index].get("selected_for_daily_summary_only")
+        ),
         "radiation_thresholds_to_test": RADIATION_THRESHOLDS_TO_TEST,
         "fixed_clock_daynight_primary": False,
         "clock_06_18_used_only_for_compatibility": True,

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_windows.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_windows.py
@@ -127,6 +127,16 @@ def build_photoperiod_table(
             photoperiod_seconds = 0.0
         else:
             photoperiod_seconds = float((last_light - first_light).total_seconds() + 600)
+        radiation_source_used = (
+            str(deduped["radiation_source_used"].dropna().iloc[0])
+            if "radiation_source_used" in deduped.columns and deduped["radiation_source_used"].notna().any()
+            else RADIATION_PRIMARY_SOURCE
+        )
+        radiation_column_used = (
+            str(deduped["radiation_column_used"].dropna().iloc[0])
+            if "radiation_column_used" in deduped.columns and deduped["radiation_column_used"].notna().any()
+            else RADIATION_COLUMN_USED
+        )
         rows.append(
             {
                 "date": date,
@@ -136,8 +146,8 @@ def build_photoperiod_table(
                 "photoperiod_seconds": photoperiod_seconds,
                 "day_interval_count": int(day.shape[0]),
                 "night_interval_count": int(night.shape[0]),
-                "radiation_source_used": RADIATION_PRIMARY_SOURCE,
-                "radiation_column_used": RADIATION_COLUMN_USED,
+                "radiation_source_used": radiation_source_used,
+                "radiation_column_used": radiation_column_used,
                 "dataset1_radiation_directly_usable": dataset1_radiation_directly_usable,
                 "fallback_required": fallback_required,
                 "fallback_source_if_required": fallback_source_if_required,
@@ -179,8 +189,16 @@ def build_radiation_daily_summary(intervals: pd.DataFrame) -> pd.DataFrame:
         else:
             row["source_proxy_MJ_CO2_T"] = np.nan
             row["source_proxy_MJ_CO2_T_available"] = False
-        row["radiation_source_used"] = RADIATION_PRIMARY_SOURCE
-        row["radiation_column_used"] = RADIATION_COLUMN_USED
+        row["radiation_source_used"] = (
+            str(group["radiation_source_used"].dropna().iloc[0])
+            if "radiation_source_used" in group.columns and group["radiation_source_used"].notna().any()
+            else RADIATION_PRIMARY_SOURCE
+        )
+        row["radiation_column_used"] = (
+            str(group["radiation_column_used"].dropna().iloc[0])
+            if "radiation_column_used" in group.columns and group["radiation_column_used"].notna().any()
+            else RADIATION_COLUMN_USED
+        )
         rows.append(row)
     return pd.DataFrame(rows).sort_values(group_cols).reset_index(drop=True)
 
@@ -199,4 +217,3 @@ def add_clock_compatibility_audit(
     out["fixed_clock_daynight_primary"] = False
     out["clock_06_18_used_only_for_compatibility"] = True
     return out
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_windows.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/radiation_windows.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    RADIATION_COLUMN_USED,
+    RADIATION_PRIMARY_SOURCE,
+    RADIATION_THRESHOLDS_W_M2,
+)
+
+ENV_MEAN_COLUMNS = {
+    "env_vpd_kpa": "day_vpd_kpa_mean",
+    "env_air_temperature_c": "day_air_temp_c_mean",
+    "env_co2_ppm": "day_co2_ppm_mean",
+}
+
+
+def _available(columns: Iterable[str], frame: pd.DataFrame) -> list[str]:
+    return [column for column in columns if column in frame.columns]
+
+
+def _date_string(series: pd.Series) -> pd.Series:
+    return pd.to_datetime(series, errors="coerce").dt.strftime("%Y-%m-%d")
+
+
+def build_radiation_intervals(
+    frame: pd.DataFrame,
+    *,
+    thresholds_w_m2: Iterable[int | float] = RADIATION_THRESHOLDS_W_M2,
+    timestamp_col: str = "timestamp",
+    radiation_col: str = RADIATION_COLUMN_USED,
+    interval_minutes: int = 10,
+    group_cols: Iterable[str] = ("loadcell_id", "treatment"),
+) -> pd.DataFrame:
+    if timestamp_col not in frame.columns:
+        raise KeyError(f"Missing timestamp column: {timestamp_col}")
+    if radiation_col not in frame.columns:
+        raise KeyError(f"Missing radiation column: {radiation_col}")
+
+    env_cols = _available(("env_vpd_kpa", "env_air_temperature_c", "env_co2_ppm"), frame)
+    group_cols_present = _available(group_cols, frame)
+    columns = [timestamp_col, radiation_col, *group_cols_present, *env_cols]
+    data = frame.loc[:, list(dict.fromkeys(columns))].copy()
+    data[timestamp_col] = pd.to_datetime(data[timestamp_col], errors="coerce")
+    data = data.dropna(subset=[timestamp_col])
+    data[radiation_col] = pd.to_numeric(data[radiation_col], errors="coerce")
+    data["interval_start"] = data[timestamp_col].dt.floor(f"{interval_minutes}min")
+
+    aggregations: dict[str, tuple[str, str]] = {
+        "radiation_wm2_mean": (radiation_col, "mean"),
+        "radiation_wm2_max": (radiation_col, "max"),
+        "sample_count": (radiation_col, "count"),
+    }
+    for env_col in env_cols:
+        aggregations[f"{env_col}_mean"] = (env_col, "mean")
+
+    grouped = (
+        data.groupby([*group_cols_present, "interval_start"], dropna=False)
+        .agg(**aggregations)
+        .reset_index()
+    )
+    grouped["interval_end"] = grouped["interval_start"] + pd.to_timedelta(interval_minutes, unit="min")
+    grouped["date"] = _date_string(grouped["interval_start"])
+    grouped["interval_seconds"] = float(interval_minutes * 60)
+    grouped["radiation_source_used"] = RADIATION_PRIMARY_SOURCE
+    grouped["radiation_column_used"] = radiation_col
+
+    rows: list[pd.DataFrame] = []
+    for threshold in thresholds_w_m2:
+        threshold_frame = grouped.copy()
+        threshold_frame["threshold_w_m2"] = float(threshold)
+        threshold_frame["radiation_phase"] = np.where(
+            threshold_frame["radiation_wm2_max"].fillna(0.0) > float(threshold), "day", "night"
+        )
+        rows.append(threshold_frame)
+    out = pd.concat(rows, ignore_index=True) if rows else grouped.iloc[0:0].copy()
+    return out.sort_values([*group_cols_present, "threshold_w_m2", "interval_start"]).reset_index(drop=True)
+
+
+def add_radiation_phase_columns(intervals: pd.DataFrame) -> pd.DataFrame:
+    if intervals.empty:
+        return intervals.copy()
+    id_cols = [column for column in ("interval_start", "interval_end", "date", "loadcell_id", "treatment") if column in intervals]
+    values = intervals[id_cols + ["threshold_w_m2", "radiation_phase"]].copy()
+    values["phase_col"] = values["threshold_w_m2"].map(lambda value: f"radiation_phase_{int(value)}W")
+    wide = values.pivot_table(
+        index=id_cols,
+        columns="phase_col",
+        values="radiation_phase",
+        aggfunc="first",
+    ).reset_index()
+    wide.columns.name = None
+    numeric_cols = [
+        column
+        for column in (
+            "radiation_wm2_mean",
+            "radiation_wm2_max",
+            "env_vpd_kpa_mean",
+            "env_air_temperature_c_mean",
+            "env_co2_ppm_mean",
+        )
+        if column in intervals.columns
+    ]
+    base = intervals[intervals["threshold_w_m2"].eq(0)][id_cols + numeric_cols].copy()
+    return base.merge(wide, on=id_cols, how="left")
+
+
+def build_photoperiod_table(
+    intervals: pd.DataFrame,
+    *,
+    dataset1_radiation_directly_usable: bool = True,
+    fallback_required: bool = False,
+    fallback_source_if_required: str | None = None,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for (date, threshold), group in intervals.groupby(["date", "threshold_w_m2"], dropna=False):
+        deduped = group.sort_values("interval_start").drop_duplicates("interval_start")
+        day = deduped[deduped["radiation_phase"].eq("day")]
+        night = deduped[deduped["radiation_phase"].eq("night")]
+        first_light = day["interval_start"].min() if not day.empty else pd.NaT
+        last_light = day["interval_start"].max() if not day.empty else pd.NaT
+        if pd.isna(first_light) or pd.isna(last_light):
+            photoperiod_seconds = 0.0
+        else:
+            photoperiod_seconds = float((last_light - first_light).total_seconds() + 600)
+        rows.append(
+            {
+                "date": date,
+                "threshold_w_m2": float(threshold),
+                "first_light_timestamp": first_light,
+                "last_light_timestamp": last_light,
+                "photoperiod_seconds": photoperiod_seconds,
+                "day_interval_count": int(day.shape[0]),
+                "night_interval_count": int(night.shape[0]),
+                "radiation_source_used": RADIATION_PRIMARY_SOURCE,
+                "radiation_column_used": RADIATION_COLUMN_USED,
+                "dataset1_radiation_directly_usable": dataset1_radiation_directly_usable,
+                "fallback_required": fallback_required,
+                "fallback_source_if_required": fallback_source_if_required,
+            }
+        )
+    return pd.DataFrame(rows).sort_values(["date", "threshold_w_m2"]).reset_index(drop=True)
+
+
+def build_radiation_daily_summary(intervals: pd.DataFrame) -> pd.DataFrame:
+    if intervals.empty:
+        return pd.DataFrame()
+    work = intervals.copy()
+    work["radiation_energy_MJ_m2"] = work["radiation_wm2_mean"].fillna(0.0) * work["interval_seconds"] / 1_000_000
+    group_cols = [column for column in ("date", "loadcell_id", "treatment", "threshold_w_m2") if column in work.columns]
+    rows: list[dict[str, Any]] = []
+    for keys, group in work.groupby(group_cols, dropna=False):
+        if not isinstance(keys, tuple):
+            keys = (keys,)
+        row = dict(zip(group_cols, keys, strict=True))
+        for phase in ("day", "night"):
+            phase_group = group[group["radiation_phase"].eq(phase)]
+            row[f"{phase}_interval_count"] = int(phase_group.shape[0])
+            row[f"{phase}_radiation_integral_MJ_m2"] = float(phase_group["radiation_energy_MJ_m2"].sum())
+            row[f"{phase}_radiation_mean_wm2"] = float(phase_group["radiation_wm2_mean"].mean()) if not phase_group.empty else np.nan
+            for env_col, out_col in ENV_MEAN_COLUMNS.items():
+                source_col = f"{env_col}_mean"
+                if source_col in phase_group.columns:
+                    row[out_col.replace("day_", f"{phase}_")] = (
+                        float(phase_group[source_col].mean()) if not phase_group.empty else np.nan
+                    )
+        co2 = row.get("day_co2_ppm_mean")
+        temp = row.get("day_air_temp_c_mean")
+        integral = row.get("day_radiation_integral_MJ_m2")
+        if pd.notna(co2) and pd.notna(temp) and pd.notna(integral):
+            row["source_proxy_MJ_CO2_T"] = float(integral) * (float(co2) / 400.0) * np.exp(
+                -((float(temp) - 25.0) / 12.0) ** 2
+            )
+            row["source_proxy_MJ_CO2_T_available"] = True
+        else:
+            row["source_proxy_MJ_CO2_T"] = np.nan
+            row["source_proxy_MJ_CO2_T_available"] = False
+        row["radiation_source_used"] = RADIATION_PRIMARY_SOURCE
+        row["radiation_column_used"] = RADIATION_COLUMN_USED
+        rows.append(row)
+    return pd.DataFrame(rows).sort_values(group_cols).reset_index(drop=True)
+
+
+def add_clock_compatibility_audit(
+    frame: pd.DataFrame,
+    *,
+    timestamp_col: str = "TIMESTAMP",
+    day_start_hour: int = 6,
+    day_end_hour: int = 18,
+) -> pd.DataFrame:
+    out = frame.copy()
+    out[timestamp_col] = pd.to_datetime(out[timestamp_col], errors="coerce")
+    hour = out[timestamp_col].dt.hour
+    out["clock_06_18_phase"] = np.where((hour >= day_start_hour) & (hour < day_end_hour), "day", "night")
+    out["fixed_clock_daynight_primary"] = False
+    out["clock_06_18_used_only_for_compatibility"] = True
+    return out
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/rootzone_indices.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/rootzone_indices.py
@@ -12,6 +12,7 @@ def build_rootzone_indices(
     dataset2_frame: pd.DataFrame,
     daily_et: pd.DataFrame | None = None,
     *,
+    dataset1_reference_frame: pd.DataFrame | None = None,
     eps: float = 1e-9,
 ) -> pd.DataFrame:
     frame = dataset2_frame.copy()
@@ -19,45 +20,133 @@ def build_rootzone_indices(
         frame["date"] = pd.to_datetime(frame["timestamp"], errors="coerce").dt.strftime("%Y-%m-%d")
     if "date" in frame.columns:
         frame["date"] = frame["date"].astype(str)
-    group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in frame.columns]
-    if not group_cols:
+    dataset2_group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in frame.columns]
+    if not dataset2_group_cols and (dataset1_reference_frame is None or dataset1_reference_frame.empty):
         return pd.DataFrame()
 
     if {"moisture_percent_mean", "ec_ds_mean", "tensiometer_hp_mean"}.intersection(frame.columns):
-        agg = frame.copy()
-        if "source_row_count" in agg.columns:
-            agg["row_count"] = pd.to_numeric(agg["source_row_count"], errors="coerce")
-        elif "row_count" not in agg.columns:
-            agg["row_count"] = 1
-        if "tensiometer_hp_count" in agg.columns:
-            agg["tensiometer_count"] = pd.to_numeric(agg["tensiometer_hp_count"], errors="coerce")
-        elif "tensiometer_count" not in agg.columns:
-            agg["tensiometer_count"] = agg["tensiometer_hp_mean"].notna().astype("int64")
+        dataset2_agg = frame.copy()
+        if "source_row_count" in dataset2_agg.columns:
+            dataset2_agg["row_count"] = pd.to_numeric(dataset2_agg["source_row_count"], errors="coerce")
+        elif "row_count" not in dataset2_agg.columns:
+            dataset2_agg["row_count"] = 1
+        if "tensiometer_hp_count" in dataset2_agg.columns:
+            dataset2_agg["tensiometer_count"] = pd.to_numeric(dataset2_agg["tensiometer_hp_count"], errors="coerce")
+        elif "tensiometer_count" not in dataset2_agg.columns:
+            dataset2_agg["tensiometer_count"] = dataset2_agg["tensiometer_hp_mean"].notna().astype("int64")
         for column in ("moisture_percent_mean", "ec_ds_mean", "tensiometer_hp_mean"):
-            if column not in agg.columns:
-                agg[column] = np.nan
+            if column not in dataset2_agg.columns:
+                dataset2_agg[column] = np.nan
     else:
-        agg = (
-            frame.groupby(group_cols, dropna=False)
+        dataset2_agg = (
+            frame.groupby(dataset2_group_cols, dropna=False)
             .agg(
                 moisture_percent_mean=("moisture_percent", "mean") if "moisture_percent" in frame.columns else ("date", "size"),
                 ec_ds_mean=("ec_ds", "mean") if "ec_ds" in frame.columns else ("date", "size"),
                 tensiometer_hp_mean=("tensiometer_hp", "mean") if "tensiometer_hp" in frame.columns else ("date", "size"),
                 tensiometer_count=("tensiometer_hp", "count") if "tensiometer_hp" in frame.columns else ("date", "size"),
-                row_count=("date", "size") if "date" in frame.columns else (group_cols[0], "size"),
+                row_count=("date", "size") if "date" in frame.columns else (dataset2_group_cols[0], "size"),
             )
             .reset_index()
         )
         if "moisture_percent" not in frame.columns:
-            agg["moisture_percent_mean"] = np.nan
+            dataset2_agg["moisture_percent_mean"] = np.nan
         if "ec_ds" not in frame.columns:
-            agg["ec_ds_mean"] = np.nan
+            dataset2_agg["ec_ds_mean"] = np.nan
         if "tensiometer_hp" not in frame.columns:
-            agg["tensiometer_hp_mean"] = np.nan
-            agg["tensiometer_count"] = 0
+            dataset2_agg["tensiometer_hp_mean"] = np.nan
+            dataset2_agg["tensiometer_count"] = 0
 
-    agg["tensiometer_available"] = agg["tensiometer_count"].gt(0)
-    agg["tensiometer_coverage_fraction"] = agg["tensiometer_count"] / agg["row_count"].replace(0, np.nan)
+    dataset2_agg["tensiometer_available"] = dataset2_agg["tensiometer_count"].gt(0)
+    dataset2_agg["tensiometer_coverage_fraction"] = dataset2_agg["tensiometer_count"] / dataset2_agg["row_count"].replace(0, np.nan)
+
+    reference_source = "dataset2_moisture"
+    if dataset1_reference_frame is not None and not dataset1_reference_frame.empty:
+        ref = dataset1_reference_frame.copy()
+        if "date" not in ref.columns and "timestamp" in ref.columns:
+            ref["date"] = pd.to_datetime(ref["timestamp"], errors="coerce").dt.strftime("%Y-%m-%d")
+        if "date" in ref.columns:
+            ref["date"] = ref["date"].astype(str)
+        ref_group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in ref.columns]
+        if {"moisture_percent_mean", "ec_ds_mean"}.intersection(ref.columns):
+            agg = ref.copy()
+            if "source_row_count" in agg.columns:
+                agg["row_count"] = pd.to_numeric(agg["source_row_count"], errors="coerce")
+            elif "row_count" not in agg.columns:
+                agg["row_count"] = 1
+            for column in ("moisture_percent_mean", "ec_ds_mean"):
+                if column not in agg.columns:
+                    agg[column] = np.nan
+        else:
+            candidate_agg = (
+                ref.groupby(ref_group_cols, dropna=False)
+                .agg(
+                    moisture_percent_mean=("moisture_percent", "mean") if "moisture_percent" in ref.columns else ("date", "size"),
+                    ec_ds_mean=("ec_ds", "mean") if "ec_ds" in ref.columns else ("date", "size"),
+                    row_count=("date", "size") if "date" in ref.columns else (ref_group_cols[0], "size"),
+                )
+                .reset_index()
+            )
+            if "moisture_percent" not in ref.columns:
+                candidate_agg["moisture_percent_mean"] = np.nan
+            if "ec_ds" not in ref.columns:
+                candidate_agg["ec_ds_mean"] = np.nan
+            agg = candidate_agg
+        if "moisture_percent_mean" in agg.columns and agg["moisture_percent_mean"].notna().any():
+            reference_source = "dataset1_moisture_lc1_lc6"
+        else:
+            agg = dataset2_agg.copy()
+            reference_source = "dataset2_moisture"
+    else:
+        agg = dataset2_agg.copy()
+
+    group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in agg.columns]
+    if not group_cols:
+        return pd.DataFrame()
+    agg["tensiometer_hp_mean"] = np.nan
+    agg["tensiometer_available"] = False
+    agg["tensiometer_coverage_fraction"] = 0.0
+    agg["tensiometer_count"] = 0
+    if not dataset2_agg.empty:
+        tension_cols = [
+            column
+            for column in (
+                "date",
+                "loadcell_id",
+                "treatment",
+                "tensiometer_hp_mean",
+                "tensiometer_available",
+                "tensiometer_coverage_fraction",
+                "tensiometer_count",
+            )
+            if column in dataset2_agg.columns
+        ]
+        agg = agg.drop(
+            columns=[
+                column
+                for column in (
+                    "tensiometer_hp_mean",
+                    "tensiometer_available",
+                    "tensiometer_coverage_fraction",
+                    "tensiometer_count",
+                )
+                if column in agg.columns
+            ],
+            errors="ignore",
+        )
+        agg = agg.merge(dataset2_agg[tension_cols], on=[column for column in ("date", "loadcell_id", "treatment") if column in tension_cols and column in agg.columns], how="left")
+        agg["tensiometer_hp_mean"] = agg.get("tensiometer_hp_mean", np.nan)
+        agg["tensiometer_available"] = agg.get("tensiometer_available", False).fillna(False)
+        agg["tensiometer_coverage_fraction"] = agg.get("tensiometer_coverage_fraction", 0.0).fillna(0.0)
+        agg["tensiometer_count"] = agg.get("tensiometer_count", 0).fillna(0)
+
+    dataset2_has_control = bool(
+        "treatment" in dataset2_agg.columns and dataset2_agg["treatment"].astype(str).eq("Control").any()
+    )
+    dataset2_has_tensiometer = bool(dataset2_agg.get("tensiometer_available", pd.Series(dtype=bool)).fillna(False).any())
+    agg["Dataset2_tensiometer_drought_only"] = bool(dataset2_has_tensiometer and not dataset2_has_control)
+    agg["tensiometer_extrapolated_to_all_loadcells"] = False
+    agg["RZI_control_reference_source"] = reference_source
 
     date_col = "date"
     control = (
@@ -93,9 +182,7 @@ def build_rootzone_indices(
     missing = agg["RZI_main"].isna() & agg["RZI_theta_group"].notna()
     agg.loc[missing, "RZI_main"] = agg.loc[missing, "RZI_theta_group"]
     agg.loc[missing, "RZI_main_source"] = "theta_group_drought_vs_control"
-    missing = agg["RZI_main"].isna() & agg["RZI_AW_t"].notna()
-    agg.loc[missing, "RZI_main"] = agg.loc[missing, "RZI_AW_t"]
-    agg.loc[missing, "RZI_main_source"] = "AW_vs_control"
+    agg["RZI_main_available"] = agg["RZI_main"].notna()
 
     if daily_et is not None and not daily_et.empty:
         et = daily_et.copy()
@@ -141,6 +228,10 @@ def build_rootzone_indices(
             "RZI_theta_group",
             "RZI_main",
             "RZI_main_source",
+            "RZI_main_available",
+            "RZI_control_reference_source",
+            "Dataset2_tensiometer_drought_only",
+            "tensiometer_extrapolated_to_all_loadcells",
             "apparent_canopy_conductance",
             "apparent_canopy_conductance_available",
             "rootzone_bridge_status",

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/rootzone_indices.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/rootzone_indices.py
@@ -23,24 +23,38 @@ def build_rootzone_indices(
     if not group_cols:
         return pd.DataFrame()
 
-    agg = (
-        frame.groupby(group_cols, dropna=False)
-        .agg(
-            moisture_percent_mean=("moisture_percent", "mean") if "moisture_percent" in frame.columns else ("date", "size"),
-            ec_ds_mean=("ec_ds", "mean") if "ec_ds" in frame.columns else ("date", "size"),
-            tensiometer_hp_mean=("tensiometer_hp", "mean") if "tensiometer_hp" in frame.columns else ("date", "size"),
-            tensiometer_count=("tensiometer_hp", "count") if "tensiometer_hp" in frame.columns else ("date", "size"),
-            row_count=("date", "size") if "date" in frame.columns else (group_cols[0], "size"),
+    if {"moisture_percent_mean", "ec_ds_mean", "tensiometer_hp_mean"}.intersection(frame.columns):
+        agg = frame.copy()
+        if "source_row_count" in agg.columns:
+            agg["row_count"] = pd.to_numeric(agg["source_row_count"], errors="coerce")
+        elif "row_count" not in agg.columns:
+            agg["row_count"] = 1
+        if "tensiometer_hp_count" in agg.columns:
+            agg["tensiometer_count"] = pd.to_numeric(agg["tensiometer_hp_count"], errors="coerce")
+        elif "tensiometer_count" not in agg.columns:
+            agg["tensiometer_count"] = agg["tensiometer_hp_mean"].notna().astype("int64")
+        for column in ("moisture_percent_mean", "ec_ds_mean", "tensiometer_hp_mean"):
+            if column not in agg.columns:
+                agg[column] = np.nan
+    else:
+        agg = (
+            frame.groupby(group_cols, dropna=False)
+            .agg(
+                moisture_percent_mean=("moisture_percent", "mean") if "moisture_percent" in frame.columns else ("date", "size"),
+                ec_ds_mean=("ec_ds", "mean") if "ec_ds" in frame.columns else ("date", "size"),
+                tensiometer_hp_mean=("tensiometer_hp", "mean") if "tensiometer_hp" in frame.columns else ("date", "size"),
+                tensiometer_count=("tensiometer_hp", "count") if "tensiometer_hp" in frame.columns else ("date", "size"),
+                row_count=("date", "size") if "date" in frame.columns else (group_cols[0], "size"),
+            )
+            .reset_index()
         )
-        .reset_index()
-    )
-    if "moisture_percent" not in frame.columns:
-        agg["moisture_percent_mean"] = np.nan
-    if "ec_ds" not in frame.columns:
-        agg["ec_ds_mean"] = np.nan
-    if "tensiometer_hp" not in frame.columns:
-        agg["tensiometer_hp_mean"] = np.nan
-        agg["tensiometer_count"] = 0
+        if "moisture_percent" not in frame.columns:
+            agg["moisture_percent_mean"] = np.nan
+        if "ec_ds" not in frame.columns:
+            agg["ec_ds_mean"] = np.nan
+        if "tensiometer_hp" not in frame.columns:
+            agg["tensiometer_hp_mean"] = np.nan
+            agg["tensiometer_count"] = 0
 
     agg["tensiometer_available"] = agg["tensiometer_count"].gt(0)
     agg["tensiometer_coverage_fraction"] = agg["tensiometer_count"] / agg["row_count"].replace(0, np.nan)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/rootzone_indices.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/rootzone_indices.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _clip01(value: pd.Series) -> pd.Series:
+    return value.clip(lower=0.0, upper=1.0)
+
+
+def build_rootzone_indices(
+    dataset2_frame: pd.DataFrame,
+    daily_et: pd.DataFrame | None = None,
+    *,
+    eps: float = 1e-9,
+) -> pd.DataFrame:
+    frame = dataset2_frame.copy()
+    if "date" not in frame.columns and "timestamp" in frame.columns:
+        frame["date"] = pd.to_datetime(frame["timestamp"], errors="coerce").dt.strftime("%Y-%m-%d")
+    if "date" in frame.columns:
+        frame["date"] = frame["date"].astype(str)
+    group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in frame.columns]
+    if not group_cols:
+        return pd.DataFrame()
+
+    agg = (
+        frame.groupby(group_cols, dropna=False)
+        .agg(
+            moisture_percent_mean=("moisture_percent", "mean") if "moisture_percent" in frame.columns else ("date", "size"),
+            ec_ds_mean=("ec_ds", "mean") if "ec_ds" in frame.columns else ("date", "size"),
+            tensiometer_hp_mean=("tensiometer_hp", "mean") if "tensiometer_hp" in frame.columns else ("date", "size"),
+            tensiometer_count=("tensiometer_hp", "count") if "tensiometer_hp" in frame.columns else ("date", "size"),
+            row_count=("date", "size") if "date" in frame.columns else (group_cols[0], "size"),
+        )
+        .reset_index()
+    )
+    if "moisture_percent" not in frame.columns:
+        agg["moisture_percent_mean"] = np.nan
+    if "ec_ds" not in frame.columns:
+        agg["ec_ds_mean"] = np.nan
+    if "tensiometer_hp" not in frame.columns:
+        agg["tensiometer_hp_mean"] = np.nan
+        agg["tensiometer_count"] = 0
+
+    agg["tensiometer_available"] = agg["tensiometer_count"].gt(0)
+    agg["tensiometer_coverage_fraction"] = agg["tensiometer_count"] / agg["row_count"].replace(0, np.nan)
+
+    date_col = "date"
+    control = (
+        agg[agg.get("treatment", "").eq("Control")].groupby(date_col)["moisture_percent_mean"].mean().rename("theta_control_group")
+        if "treatment" in agg.columns
+        else pd.Series(dtype=float)
+    )
+    drought = (
+        agg[agg.get("treatment", "").eq("Drought")].groupby(date_col)["moisture_percent_mean"].mean().rename("theta_drought_group")
+        if "treatment" in agg.columns
+        else pd.Series(dtype=float)
+    )
+    group_theta = pd.concat([control, drought], axis=1).reset_index()
+    agg = agg.merge(group_theta, on=date_col, how="left")
+    agg["RZI_theta_group"] = _clip01(1.0 - agg["theta_drought_group"] / (agg["theta_control_group"] + eps))
+
+    paired = agg.pivot_table(index=date_col, columns="loadcell_id", values="moisture_percent_mean", aggfunc="mean")
+    if 1 in paired.columns and 4 in paired.columns:
+        paired_rzi = _clip01(1.0 - paired[4] / (paired[1] + eps)).rename("RZI_theta_paired").reset_index()
+        agg = agg.merge(paired_rzi, on=date_col, how="left")
+    else:
+        agg["RZI_theta_paired"] = np.nan
+
+    agg["RZI_AW_t"] = np.where(
+        agg.get("treatment", "").eq("Drought") if "treatment" in agg.columns else False,
+        _clip01(1.0 - agg["moisture_percent_mean"] / (agg["theta_control_group"] + eps)),
+        0.0,
+    )
+    agg.loc[agg["theta_control_group"].isna(), "RZI_AW_t"] = np.nan
+
+    agg["RZI_main"] = agg["RZI_theta_paired"]
+    agg["RZI_main_source"] = np.where(agg["RZI_main"].notna(), "theta_paired_lc4_vs_lc1", "unavailable")
+    missing = agg["RZI_main"].isna() & agg["RZI_theta_group"].notna()
+    agg.loc[missing, "RZI_main"] = agg.loc[missing, "RZI_theta_group"]
+    agg.loc[missing, "RZI_main_source"] = "theta_group_drought_vs_control"
+    missing = agg["RZI_main"].isna() & agg["RZI_AW_t"].notna()
+    agg.loc[missing, "RZI_main"] = agg.loc[missing, "RZI_AW_t"]
+    agg.loc[missing, "RZI_main_source"] = "AW_vs_control"
+
+    if daily_et is not None and not daily_et.empty:
+        et = daily_et.copy()
+        et["radiation_total_ET_g"] = et.get("radiation_total_ET_g", et.get("radiation_day_ET_g", 0) + et.get("radiation_night_ET_g", 0))
+        if "env_vpd_kpa_mean" not in et.columns and "day_vpd_kpa_mean" in et.columns:
+            et["env_vpd_kpa_mean"] = et["day_vpd_kpa_mean"]
+        if "env_vpd_kpa_mean" not in et.columns:
+            et["env_vpd_kpa_mean"] = np.nan
+        merge_cols = [column for column in ("date", "loadcell_id", "treatment") if column in agg.columns and column in et.columns]
+        agg = agg.merge(et[merge_cols + ["radiation_total_ET_g", "env_vpd_kpa_mean"]], on=merge_cols, how="left")
+        agg["apparent_canopy_conductance"] = agg["radiation_total_ET_g"] / (agg["env_vpd_kpa_mean"] + eps)
+        agg["apparent_canopy_conductance_available"] = agg["apparent_canopy_conductance"].notna()
+    else:
+        agg["apparent_canopy_conductance"] = np.nan
+        agg["apparent_canopy_conductance_available"] = False
+
+    for loadcell_id in (4, 5):
+        values = agg[agg["loadcell_id"].eq(loadcell_id)][[date_col, "tensiometer_hp_mean"]].rename(
+            columns={"tensiometer_hp_mean": f"lc{loadcell_id}_tensiometer_hp_mean"}
+        )
+        agg = agg.merge(values, on=date_col, how="left")
+    drought_tension = (
+        agg[agg.get("treatment", "").eq("Drought")].groupby(date_col)["tensiometer_hp_mean"].mean().rename("drought_group_tensiometer_hp_mean")
+        if "treatment" in agg.columns
+        else pd.Series(dtype=float)
+    )
+    agg = agg.merge(drought_tension.reset_index(), on=date_col, how="left")
+    agg["rootzone_bridge_status"] = np.where(agg["tensiometer_available"], "matched_date_loadcell", "matched_date_loadcell_no_tensiometer")
+    agg["warnings"] = np.where(agg["theta_control_group"].isna(), "control_reference_unavailable", "")
+    return agg[
+        [
+            *group_cols,
+            "moisture_percent_mean",
+            "ec_ds_mean",
+            "tensiometer_hp_mean",
+            "lc4_tensiometer_hp_mean",
+            "lc5_tensiometer_hp_mean",
+            "drought_group_tensiometer_hp_mean",
+            "tensiometer_available",
+            "tensiometer_coverage_fraction",
+            "RZI_AW_t",
+            "RZI_theta_paired",
+            "RZI_theta_group",
+            "RZI_main",
+            "RZI_main_source",
+            "apparent_canopy_conductance",
+            "apparent_canopy_conductance_available",
+            "rootzone_bridge_status",
+            "warnings",
+        ]
+    ].sort_values(group_cols).reset_index(drop=True)

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/sensor_mapping.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/sensor_mapping.py
@@ -129,4 +129,3 @@ def fruit_diameter_policy_metadata(mapping: dict[str, Any]) -> dict[str, Any]:
         "fruit_mapping_status": metadata.get("fruit_mapping_status", "provisional"),
         "leaf_mapping_status": metadata.get("leaf_mapping_status", "confirmed_by_user"),
     }
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/sensor_mapping.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/sensor_mapping.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    RAW_FILENAME_NOTE,
+    SEASON_ID,
+)
+
+DEFAULT_SENSOR_MAPPING: dict[str, Any] = {
+    "season_id": SEASON_ID,
+    "raw_filename_note": RAW_FILENAME_NOTE,
+    "timestamp_col": "TIMESTAMP",
+    "record_col": "RECORD",
+    "cadence_minutes": 10,
+    "raw_columns": {
+        "leaf_temperature_1": "LeafTemp1_Avg",
+        "leaf_temperature_2": "LeafTemp2_Avg",
+        "fruit_diameter_1": "Fruit1Diameter_Avg",
+        "fruit_diameter_2": "Fruit2Diameter_Avg",
+        "solar_radiation": "SolarRad_Avg",
+    },
+    "loadcell_treatment_map": {
+        1: "Control",
+        2: "Control",
+        3: "Control",
+        4: "Drought",
+        5: "Drought",
+        6: "Drought",
+    },
+    "leaf_sensor_map": {
+        "LeafTemp1_Avg": {
+            "loadcell_id": 4,
+            "treatment": "Drought",
+            "mapping_status": "confirmed_by_user",
+        },
+        "LeafTemp2_Avg": {
+            "loadcell_id": 1,
+            "treatment": "Control",
+            "mapping_status": "confirmed_by_user",
+        },
+    },
+    "fruit_sensor_map": {
+        "Fruit1Diameter_Avg": {
+            "loadcell_id": 4,
+            "treatment": "Drought",
+            "mapping_status": "provisional",
+        },
+        "Fruit2Diameter_Avg": {
+            "loadcell_id": 1,
+            "treatment": "Control",
+            "mapping_status": "provisional",
+        },
+    },
+    "metadata": {
+        "biological_replication": False,
+        "sensor_level_only": True,
+        "fruit_diameter_inference_level": "sensor_level_descriptive_only",
+        "fruit_diameter_allowed_use": "apparent_growth_observer",
+        "fruit_diameter_disallowed_use": [
+            "replicated_treatment_effect_test",
+            "p_value_for_treatment_effect",
+            "allocation_parameter_calibration",
+            "hydraulic_growth_gate_calibration",
+            "model_promotion_gate",
+        ],
+        "leaf_temperature_allowed_use": "paired_leaf_thermal_observer",
+        "leaf_mapping_status": "confirmed_by_user",
+        "fruit_mapping_status": "provisional",
+        "fruit_diameter_p_values_allowed": False,
+        "fruit_diameter_allocation_calibration_target": False,
+    },
+}
+
+
+def load_sensor_mapping(path: str | Path | None = None) -> dict[str, Any]:
+    if path is None:
+        return copy.deepcopy(DEFAULT_SENSOR_MAPPING)
+    mapping_path = Path(path)
+    with mapping_path.open("r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle) or {}
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Sensor mapping must parse to a mapping, got {type(loaded).__name__}.")
+    merged = copy.deepcopy(DEFAULT_SENSOR_MAPPING)
+    for key, value in loaded.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key].update(value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def sensor_mapping_rows(mapping: dict[str, Any]) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for sensor_type, map_key in (
+        ("leaf_temperature", "leaf_sensor_map"),
+        ("fruit_diameter", "fruit_sensor_map"),
+    ):
+        for column, payload in mapping.get(map_key, {}).items():
+            rows.append(
+                {
+                    "sensor_type": sensor_type,
+                    "sensor_column": column,
+                    "loadcell_id": payload.get("loadcell_id"),
+                    "treatment": payload.get("treatment"),
+                    "mapping_status": payload.get("mapping_status"),
+                    "sensor_level_only": bool(mapping.get("metadata", {}).get("sensor_level_only", True)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def fruit_diameter_policy_metadata(mapping: dict[str, Any]) -> dict[str, Any]:
+    metadata = dict(mapping.get("metadata", {}))
+    return {
+        "biological_replication": bool(metadata.get("biological_replication", False)),
+        "fruit_diameter_sensor_level_only": bool(metadata.get("sensor_level_only", True)),
+        "fruit_diameter_treatment_endpoint": False,
+        "fruit_diameter_p_values_allowed": bool(metadata.get("fruit_diameter_p_values_allowed", False)),
+        "fruit_diameter_allocation_calibration_target": bool(
+            metadata.get("fruit_diameter_allocation_calibration_target", False)
+        ),
+        "fruit_diameter_model_promotion_target": False,
+        "fruit_mapping_status": metadata.get("fruit_mapping_status", "provisional"),
+        "leaf_mapping_status": metadata.get("leaf_mapping_status", "confirmed_by_user"),
+    }
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/toa5_parser.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/toa5_parser.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.input_schema_audit import load_input_table
+
+
+def read_toa5_dat(path: str | Path, *, timestamp_col: str = "TIMESTAMP") -> pd.DataFrame:
+    loaded = load_input_table(Path(path))
+    if loaded.frame is None:
+        raise ValueError(f"Could not parse TOA5/dat file {path}: {loaded.error}")
+    frame = loaded.frame.copy()
+    if timestamp_col in frame.columns:
+        frame[timestamp_col] = pd.to_datetime(frame[timestamp_col], errors="coerce")
+    return frame
+

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/toa5_parser.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/toa5_parser.py
@@ -15,4 +15,3 @@ def read_toa5_dat(path: str | Path, *, timestamp_col: str = "TIMESTAMP") -> pd.D
     if timestamp_col in frame.columns:
         frame[timestamp_col] = pd.to_datetime(frame[timestamp_col], errors="coerce")
     return frame
-

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/water_flux_event_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/water_flux_event_bridge.py
@@ -98,6 +98,17 @@ def calibrate_to_daily_event_bridged_total(
         out["bridge_status"] = "uncalibrated_no_daily_total"
         return out
 
+    daily_totals = daily_totals.copy()
+    if "date" in out.columns:
+        out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    if "date" in daily_totals.columns:
+        daily_totals["date"] = pd.to_datetime(daily_totals["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    if "loadcell_id" in out.columns and "loadcell_id" in daily_totals.columns:
+        out["loadcell_id"] = pd.to_numeric(out["loadcell_id"], errors="coerce").astype("Int64")
+        daily_totals["loadcell_id"] = pd.to_numeric(daily_totals["loadcell_id"], errors="coerce").astype("Int64")
+    if "treatment" in out.columns and "treatment" in daily_totals.columns:
+        out["treatment"] = out["treatment"].astype(str)
+        daily_totals["treatment"] = daily_totals["treatment"].astype(str)
     merge_cols = [column for column in ("date", "loadcell_id", "treatment") if column in out.columns and column in daily_totals.columns]
     totals = out.groupby(merge_cols, dropna=False)["loss_g_10min_unscaled"].sum().rename("unscaled_daily_loss_g").reset_index()
     scale = totals.merge(daily_totals[merge_cols + [total_col]], on=merge_cols, how="left")

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/water_flux_event_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/water_flux_event_bridge.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import add_radiation_phase_columns
+
+
+def _group_columns(frame: pd.DataFrame, candidates: Iterable[str]) -> list[str]:
+    return [column for column in candidates if column in frame.columns]
+
+
+def build_10min_event_bridged_water_loss(
+    frame: pd.DataFrame,
+    radiation_intervals: pd.DataFrame | None = None,
+    *,
+    timestamp_col: str = "timestamp",
+    weight_col: str = "loadcell_weight_kg",
+    interval_minutes: int = 10,
+    event_threshold_g: float = 50.0,
+) -> pd.DataFrame:
+    if "interval_start" in frame.columns and {"quiet_loss_rate_g_h", "event_flag"}.issubset(frame.columns):
+        out = frame.copy()
+        out["interval_start"] = pd.to_datetime(out["interval_start"], errors="coerce")
+        out["interval_end"] = out.get(
+            "interval_end", out["interval_start"] + pd.to_timedelta(interval_minutes, unit="min")
+        )
+        rate = np.where(
+            out["event_flag"].astype(bool),
+            pd.to_numeric(out.get("bridge_loss_rate_g_h", out["quiet_loss_rate_g_h"]), errors="coerce"),
+            pd.to_numeric(out["quiet_loss_rate_g_h"], errors="coerce"),
+        )
+        out["loss_g_10min_unscaled"] = rate * interval_minutes / 60.0
+        out["water_flux_source_used"] = "rate_columns"
+    else:
+        if timestamp_col not in frame.columns:
+            raise KeyError(f"Missing timestamp column: {timestamp_col}")
+        if weight_col not in frame.columns:
+            raise KeyError(f"Missing loadcell weight column: {weight_col}")
+        group_cols = _group_columns(frame, ("loadcell_id", "sample_id", "treatment"))
+        data = frame[[timestamp_col, weight_col, *group_cols]].copy()
+        data[timestamp_col] = pd.to_datetime(data[timestamp_col], errors="coerce")
+        data[weight_col] = pd.to_numeric(data[weight_col], errors="coerce")
+        data = data.dropna(subset=[timestamp_col]).sort_values([*group_cols, timestamp_col])
+        data["interval_start"] = data[timestamp_col].dt.floor(f"{interval_minutes}min")
+        data["weight_delta_g"] = data.groupby(group_cols, dropna=False)[weight_col].diff() * 1000.0 if group_cols else data[
+            weight_col
+        ].diff() * 1000.0
+        data["positive_loss_g"] = (-data["weight_delta_g"]).clip(lower=0.0)
+        data["event_flag"] = data["weight_delta_g"].abs().gt(event_threshold_g)
+        group_keys = [column for column in ("loadcell_id", "treatment", "interval_start") if column in data.columns]
+        out = (
+            data.groupby(group_keys, dropna=False)
+            .agg(
+                loss_g_10min_unscaled=("positive_loss_g", "sum"),
+                event_flag=("event_flag", "max"),
+            )
+            .reset_index()
+        )
+        out["interval_end"] = out["interval_start"] + pd.to_timedelta(interval_minutes, unit="min")
+        out["water_flux_source_used"] = "loadcell_weight_kg_derivative"
+
+    out["date"] = pd.to_datetime(out["interval_start"], errors="coerce").dt.strftime("%Y-%m-%d")
+    out["event_type"] = np.where(out["event_flag"].fillna(False).astype(bool), "irrigation_or_drainage", "quiet")
+    out["warnings"] = ""
+
+    if radiation_intervals is not None and not radiation_intervals.empty:
+        phase_wide = add_radiation_phase_columns(radiation_intervals)
+        merge_cols = [column for column in ("interval_start", "loadcell_id", "treatment") if column in out.columns and column in phase_wide.columns]
+        if merge_cols:
+            out = out.merge(phase_wide, on=merge_cols, how="left", suffixes=("", "_radiation"))
+            if "date_radiation" in out.columns:
+                out = out.drop(columns=["date_radiation"])
+            if "interval_end_radiation" in out.columns:
+                out = out.drop(columns=["interval_end_radiation"])
+
+    out["daily_bridge_scale_factor"] = np.nan
+    out["loss_g_10min_event_bridged_calibrated"] = np.nan
+    out["bridge_status"] = "uncalibrated_no_daily_total"
+    return out.sort_values([column for column in ("date", "loadcell_id", "interval_start") if column in out.columns]).reset_index(
+        drop=True
+    )
+
+
+def calibrate_to_daily_event_bridged_total(
+    intervals: pd.DataFrame,
+    daily_totals: pd.DataFrame | None = None,
+    *,
+    total_col: str = "existing_daily_event_bridged_loss_g_per_day",
+) -> pd.DataFrame:
+    out = intervals.copy()
+    if daily_totals is None or daily_totals.empty or total_col not in daily_totals.columns:
+        out["daily_bridge_scale_factor"] = np.nan
+        out["loss_g_10min_event_bridged_calibrated"] = np.nan
+        out["bridge_status"] = "uncalibrated_no_daily_total"
+        return out
+
+    merge_cols = [column for column in ("date", "loadcell_id", "treatment") if column in out.columns and column in daily_totals.columns]
+    totals = out.groupby(merge_cols, dropna=False)["loss_g_10min_unscaled"].sum().rename("unscaled_daily_loss_g").reset_index()
+    scale = totals.merge(daily_totals[merge_cols + [total_col]], on=merge_cols, how="left")
+    scale["daily_bridge_scale_factor"] = scale[total_col] / scale["unscaled_daily_loss_g"].replace(0, np.nan)
+    out = out.merge(scale[merge_cols + ["daily_bridge_scale_factor"]], on=merge_cols, how="left", suffixes=("", "_new"))
+    if "daily_bridge_scale_factor_new" in out.columns:
+        out["daily_bridge_scale_factor"] = out["daily_bridge_scale_factor_new"]
+        out = out.drop(columns=["daily_bridge_scale_factor_new"])
+    out["loss_g_10min_event_bridged_calibrated"] = out["loss_g_10min_unscaled"] * out["daily_bridge_scale_factor"]
+    out["bridge_status"] = np.where(out["daily_bridge_scale_factor"].notna(), "calibrated_to_daily_event_total", "uncalibrated_no_daily_total")
+    return out
+
+
+def summarize_radiation_daynight_et(intervals: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    threshold_cols = [column for column in intervals.columns if column.startswith("radiation_phase_") and column.endswith("W")]
+    value_col = (
+        "loss_g_10min_event_bridged_calibrated"
+        if intervals.get("loss_g_10min_event_bridged_calibrated", pd.Series(dtype=float)).notna().any()
+        else "loss_g_10min_unscaled"
+    )
+    for threshold_col in threshold_cols:
+        threshold = float(threshold_col.removeprefix("radiation_phase_").removesuffix("W"))
+        group_cols = [column for column in ("date", "loadcell_id", "treatment") if column in intervals.columns]
+        for keys, group in intervals.groupby(group_cols, dropna=False):
+            if not isinstance(keys, tuple):
+                keys = (keys,)
+            row = dict(zip(group_cols, keys, strict=True))
+            day = group[group[threshold_col].eq("day")]
+            night = group[group[threshold_col].eq("night")]
+            day_et = float(day[value_col].sum())
+            night_et = float(night[value_col].sum())
+            day_hours = day.shape[0] * (10.0 / 60.0)
+            night_hours = night.shape[0] * (10.0 / 60.0)
+            row.update(
+                {
+                    "threshold_w_m2": threshold,
+                    "radiation_day_ET_g": day_et,
+                    "radiation_night_ET_g": night_et,
+                    "radiation_day_rate_g_h": day_et / day_hours if day_hours > 0 else np.nan,
+                    "radiation_night_rate_g_h": night_et / night_hours if night_hours > 0 else np.nan,
+                    "day_fraction_ET": day_et / (day_et + night_et) if (day_et + night_et) > 0 else np.nan,
+                    "night_fraction_ET": night_et / (day_et + night_et) if (day_et + night_et) > 0 else np.nan,
+                    "bridge_status": ";".join(sorted(set(group.get("bridge_status", pd.Series(["unknown"])).dropna().astype(str)))),
+                    "water_flux_source_used": ";".join(
+                        sorted(set(group.get("water_flux_source_used", pd.Series(["unknown"])).dropna().astype(str)))
+                    ),
+                }
+            )
+            rows.append(row)
+    summary = pd.DataFrame(rows)
+    if summary.empty:
+        return summary
+    if "treatment" not in summary.columns:
+        summary["drought_control_day_ET_ratio"] = np.nan
+        summary["drought_control_night_ET_ratio"] = np.nan
+        return summary.reset_index(drop=True)
+    control = summary[summary["treatment"].eq("Control")]
+    drought = summary[summary["treatment"].eq("Drought")]
+    ratio_cols = ["date", "threshold_w_m2"]
+    if not control.empty and not drought.empty:
+        control_mean = control.groupby(ratio_cols, dropna=False)[["radiation_day_ET_g", "radiation_night_ET_g"]].mean()
+        drought_mean = drought.groupby(ratio_cols, dropna=False)[["radiation_day_ET_g", "radiation_night_ET_g"]].mean()
+        ratios = drought_mean.join(control_mean, lsuffix="_drought", rsuffix="_control").reset_index()
+        ratios["drought_control_day_ET_ratio"] = ratios["radiation_day_ET_g_drought"] / ratios[
+            "radiation_day_ET_g_control"
+        ].replace(0, np.nan)
+        ratios["drought_control_night_ET_ratio"] = ratios["radiation_night_ET_g_drought"] / ratios[
+            "radiation_night_ET_g_control"
+        ].replace(0, np.nan)
+        summary = summary.merge(
+            ratios[ratio_cols + ["drought_control_day_ET_ratio", "drought_control_night_ET_ratio"]],
+            on=ratio_cols,
+            how="left",
+        )
+    else:
+        summary["drought_control_day_ET_ratio"] = np.nan
+        summary["drought_control_night_ET_ratio"] = np.nan
+    return summary.sort_values([column for column in ("date", "loadcell_id", "threshold_w_m2") if column in summary.columns]).reset_index(
+        drop=True
+    )
+
+
+def build_daily_wide_et_summary(daily_summary: pd.DataFrame, *, threshold_w_m2: int | float = 0) -> pd.DataFrame:
+    main = daily_summary[daily_summary["threshold_w_m2"].eq(float(threshold_w_m2))].copy()
+    if main.empty:
+        return main
+    main["radiation_total_ET_g"] = main["radiation_day_ET_g"] + main["radiation_night_ET_g"]
+    main["fixed_clock_daynight_primary"] = False
+    return main

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py
@@ -7,12 +7,15 @@ from typing import Any
 import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    CANONICAL_2025_2C_FRUIT_DMC,
     DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+    DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
     DMC_SENSITIVITY,
+    HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
 )
 
 
-LEGACY_DEFAULT_DMC = 0.056
+LEGACY_DEFAULT_DMC = CANONICAL_2025_2C_FRUIT_DMC
 
 FRESH_YIELD_COLUMNS = (
     "loadcell_daily_yield_g",
@@ -20,6 +23,53 @@ FRESH_YIELD_COLUMNS = (
     "individual_cumulative_yield_g",
     "final_fresh_yield_g",
 )
+
+CANONICAL_DMC_DRY_COLUMNS = (
+    "final_dry_yield_g_est_5p6pct",
+    "default_5p6pct",
+    "dry_yield_5p6pct",
+    "loadcell_daily_dry_yield_g_est_default_5p6pct",
+    "loadcell_cumulative_dry_yield_g_est_default_5p6pct",
+)
+
+LEGACY_SENSITIVITY_DRY_COLUMNS = (
+    "loadcell_daily_dry_yield_g_est_lower_5p2pct",
+    "loadcell_cumulative_dry_yield_g_est_lower_5p2pct",
+    "loadcell_daily_dry_yield_g_est_upper_6p0pct",
+    "loadcell_cumulative_dry_yield_g_est_upper_6p0pct",
+    "loadcell_daily_dry_yield_g_est_broad_low_4pct",
+    "loadcell_cumulative_dry_yield_g_est_broad_low_4pct",
+    "loadcell_daily_dry_yield_g_est_broad_high_8pct",
+    "loadcell_cumulative_dry_yield_g_est_broad_high_8pct",
+    "loadcell_daily_dry_yield_g_est_6p5pct",
+    "loadcell_cumulative_dry_yield_g_est_6p5pct",
+    "default_6p5pct",
+    "dry_yield_6p5pct",
+)
+
+
+def fresh_g_to_dry_g(fresh_g: float, dmc: float = CANONICAL_2025_2C_FRUIT_DMC) -> float:
+    return float(fresh_g) * float(dmc)
+
+
+def dry_g_to_fresh_g(dry_g: float, dmc: float = CANONICAL_2025_2C_FRUIT_DMC) -> float:
+    return float(dry_g) / float(dmc)
+
+
+def fresh_loadcell_to_dry_floor_area(
+    fresh_g_loadcell: float,
+    dmc: float = CANONICAL_2025_2C_FRUIT_DMC,
+    area: float = HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+) -> float:
+    return fresh_g_to_dry_g(fresh_g_loadcell, dmc=dmc) / float(area)
+
+
+def dry_floor_area_to_fresh_loadcell(
+    dry_g_m2: float,
+    dmc: float = CANONICAL_2025_2C_FRUIT_DMC,
+    area: float = HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+) -> float:
+    return dry_g_to_fresh_g(float(dry_g_m2) * float(area), dmc=dmc)
 
 
 def _normalize_keys(frame: pd.DataFrame) -> pd.DataFrame:
@@ -43,6 +93,7 @@ def load_legacy_yield_bridge(config: Mapping[str, Any]) -> tuple[pd.DataFrame, p
             "",
             provenance,
             direct_dry=bool(config.get("direct_dry_yield_measured", False)),
+            legacy_sensitivity_columns_present=(),
         )
 
     archive_root = Path(config["archive_root_path"])
@@ -59,46 +110,72 @@ def load_legacy_yield_bridge(config: Mapping[str, Any]) -> tuple[pd.DataFrame, p
         frame = pd.read_csv(path)
         row["rows_total"] = int(frame.shape[0])
         work = _normalize_keys(frame)
+        yield_columns = set(FRESH_YIELD_COLUMNS) | set(CANONICAL_DMC_DRY_COLUMNS) | set(LEGACY_SENSITIVITY_DRY_COLUMNS)
         keep = [
             column
             for column in work.columns
-            if column in {"date", "loadcell_id", "treatment"}
-            or column in {
-                "loadcell_daily_yield_g",
-                "loadcell_cumulative_yield_g",
-                "individual_cumulative_yield_g",
-                "final_fresh_yield_g",
-                "final_dry_yield_g_est_5p6pct",
-                "loadcell_daily_dry_yield_g_est_default_5p6pct",
-                "loadcell_cumulative_dry_yield_g_est_default_5p6pct",
-                "loadcell_daily_dry_yield_g_est_lower_5p2pct",
-                "loadcell_cumulative_dry_yield_g_est_lower_5p2pct",
-                "loadcell_daily_dry_yield_g_est_upper_6p0pct",
-                "loadcell_cumulative_dry_yield_g_est_upper_6p0pct",
-                "loadcell_daily_dry_yield_g_est_broad_low_4pct",
-                "loadcell_cumulative_dry_yield_g_est_broad_low_4pct",
-                "loadcell_daily_dry_yield_g_est_broad_high_8pct",
-                "loadcell_cumulative_dry_yield_g_est_broad_high_8pct",
-            }
+            if column in {"date", "loadcell_id", "treatment"} or column in yield_columns
         ]
         usable = work[keep].copy()
         for fresh_column in FRESH_YIELD_COLUMNS:
             if fresh_column in usable.columns:
                 usable["measured_or_legacy_fresh_yield_g"] = usable[fresh_column]
                 break
-        dry_cols = [column for column in usable.columns if "_dry_yield_g_est_" in column or column.endswith("_dry_yield_g_est_5p6pct")]
+        canonical_dry_cols = [column for column in CANONICAL_DMC_DRY_COLUMNS if column in usable.columns]
+        legacy_sensitivity_cols = [column for column in LEGACY_SENSITIVITY_DRY_COLUMNS if column in usable.columns]
+        canonical_dry = (
+            pd.to_numeric(usable[canonical_dry_cols[0]], errors="coerce")
+            if canonical_dry_cols
+            else pd.Series(pd.NA, index=usable.index)
+        )
         fresh_available = bool(
             any(
                 column in usable.columns and usable[column].notna().any()
                 for column in ("measured_or_legacy_fresh_yield_g", *FRESH_YIELD_COLUMNS)
             )
         )
-        dry_available = bool(dry_cols and usable[dry_cols].notna().any().any())
-        usable["dry_yield_is_dmc_estimated"] = bool(dry_cols)
+        fresh_fw = (
+            pd.to_numeric(usable["measured_or_legacy_fresh_yield_g"], errors="coerce")
+            if "measured_or_legacy_fresh_yield_g" in usable.columns
+            else pd.Series(pd.NA, index=usable.index)
+        )
+        fresh_has_value = fresh_fw.notna()
+        canonical_dry_has_value = canonical_dry.notna()
+        usable["observed_fruit_FW_g_loadcell"] = fresh_fw.fillna(canonical_dry / CANONICAL_2025_2C_FRUIT_DMC)
+
+        usable["observed_fruit_DW_g_loadcell_dmc_0p056"] = (
+            fresh_fw * CANONICAL_2025_2C_FRUIT_DMC
+        ).fillna(canonical_dry)
+        usable["observed_fruit_DW_g_m2_floor_dmc_0p056"] = pd.to_numeric(
+            usable["observed_fruit_DW_g_loadcell_dmc_0p056"],
+            errors="coerce",
+        ) / HAF_2025_2C_LOADCELL_FLOOR_AREA_M2
+        dry_available = bool(usable["observed_fruit_DW_g_loadcell_dmc_0p056"].notna().any())
+        usable["fresh_yield_source"] = ""
+        usable.loc[fresh_has_value, "fresh_yield_source"] = str(path)
+        usable["canonical_fruit_DMC_fraction"] = CANONICAL_2025_2C_FRUIT_DMC
+        usable["fruit_DMC_fraction"] = CANONICAL_2025_2C_FRUIT_DMC
+        usable["default_fruit_dry_matter_content"] = DEFAULT_FRUIT_DRY_MATTER_CONTENT
+        usable["DMC_fixed_for_2025_2C"] = True
+        usable["DMC_sensitivity_enabled"] = False
+        usable["dry_yield_source"] = ""
+        usable.loc[
+            usable["observed_fruit_DW_g_loadcell_dmc_0p056"].notna() & fresh_has_value,
+            "dry_yield_source",
+        ] = "fresh_yield_times_canonical_DMC_0p056"
+        usable.loc[
+            usable["observed_fruit_DW_g_loadcell_dmc_0p056"].notna()
+            & ~fresh_has_value
+            & canonical_dry_has_value,
+            "dry_yield_source",
+        ] = "legacy_canonical_DMC_0p056_column"
+        usable["dry_yield_is_dmc_estimated"] = dry_available
         usable["direct_dry_yield_measured"] = bool(config.get("direct_dry_yield_measured", False))
         usable["legacy_yield_bridge_provenance"] = provenance
+        usable["legacy_sensitivity_columns_present"] = ",".join(legacy_sensitivity_cols)
         row["rows_usable"] = int(usable.shape[0])
         row["status"] = "ok" if not usable.empty else "no_usable_rows"
+        row["legacy_sensitivity_columns_present"] = ",".join(legacy_sensitivity_cols)
         audit_rows.append(row)
         if not usable.empty:
             return usable, pd.DataFrame(audit_rows), _metadata(
@@ -107,24 +184,52 @@ def load_legacy_yield_bridge(config: Mapping[str, Any]) -> tuple[pd.DataFrame, p
                 str(path),
                 provenance,
                 direct_dry=bool(config.get("direct_dry_yield_measured", False)),
+                legacy_sensitivity_columns_present=legacy_sensitivity_cols,
             )
-    return pd.DataFrame(), pd.DataFrame(audit_rows), _metadata(False, False, "", provenance, direct_dry=False)
+    return pd.DataFrame(), pd.DataFrame(audit_rows), _metadata(
+        False,
+        False,
+        "",
+        provenance,
+        direct_dry=False,
+        legacy_sensitivity_columns_present=(),
+    )
 
 
-def _metadata(fresh_available: bool, dry_available: bool, source: str, provenance: str, *, direct_dry: bool) -> dict[str, Any]:
+def _metadata(
+    fresh_available: bool,
+    dry_available: bool,
+    source: str,
+    provenance: str,
+    *,
+    direct_dry: bool,
+    legacy_sensitivity_columns_present: tuple[str, ...] | list[str],
+) -> dict[str, Any]:
     any_available = fresh_available or dry_available
     return {
         "harvest_yield_available": any_available,
         "fresh_yield_available": fresh_available,
         "fresh_yield_source": source if fresh_available else "",
         "dry_yield_available": dry_available,
-        "dry_yield_source": source if dry_available else "",
+        "dry_yield_source": (
+            "fresh_yield_times_canonical_DMC_0p056"
+            if dry_available and fresh_available
+            else "legacy_canonical_DMC_0p056_column"
+            if dry_available
+            else ""
+        ),
         "dry_yield_is_dmc_estimated": dry_available and not direct_dry,
         "direct_dry_yield_measured": direct_dry if dry_available else False,
         "legacy_yield_bridge_used": any_available,
         "legacy_yield_bridge_provenance": provenance if any_available else "",
         "DMC_conversion_performed": dry_available,
+        "canonical_fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+        "fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+        "default_fruit_dry_matter_content": DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+        "DMC_fixed_for_2025_2C": True,
+        "DMC_sensitivity_enabled": False,
+        "DMC_sensitivity_values": list(DMC_SENSITIVITY),
+        "deprecated_previous_default_fruit_DMC_fraction": DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
+        "legacy_sensitivity_columns_present": list(legacy_sensitivity_columns_present),
         "default_fruit_dry_matter_content_from_legacy": LEGACY_DEFAULT_DMC,
-        "configured_default_fruit_dry_matter_content": DEFAULT_FRUIT_DRY_MATTER_CONTENT,
-        "dmc_sensitivity": list(DMC_SENSITIVITY),
     }

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+    DMC_SENSITIVITY,
+)
+
+
+LEGACY_DEFAULT_DMC = 0.056
+
+
+def _normalize_keys(frame: pd.DataFrame) -> pd.DataFrame:
+    out = frame.copy()
+    if "date" in out.columns:
+        out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    if "loadcell_id" in out.columns:
+        out["loadcell_id"] = pd.to_numeric(out["loadcell_id"], errors="coerce").astype("Int64").astype(str)
+    if "treatment" in out.columns:
+        out["treatment"] = out["treatment"].astype(str)
+    return out
+
+
+def load_legacy_yield_bridge(config: Mapping[str, Any]) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any]]:
+    provenance = str(config.get("provenance_label", "legacy_v1_3_derived_output"))
+    if not bool(config.get("enabled")) or not bool(config.get("allow_legacy_yield_bridge")):
+        audit = pd.DataFrame([{"source_role": "legacy_yield_bridge", "status": "disabled", "rows_total": 0, "rows_usable": 0}])
+        return pd.DataFrame(), audit, _metadata(
+            False,
+            False,
+            "",
+            provenance,
+            direct_dry=bool(config.get("direct_dry_yield_measured", False)),
+        )
+
+    archive_root = Path(config["archive_root_path"])
+    sources = [
+        ("integrated_daily_master", archive_root / str(config.get("integrated_daily_master"))),
+        ("fresh_dry_loadcell_summary", archive_root / str(config.get("fresh_dry_loadcell_summary"))),
+    ]
+    audit_rows: list[dict[str, Any]] = []
+    for role, path in sources:
+        row = {"source_role": role, "path": str(path), "status": "missing_file", "rows_total": 0, "rows_usable": 0}
+        if not path.exists():
+            audit_rows.append(row)
+            continue
+        frame = pd.read_csv(path)
+        row["rows_total"] = int(frame.shape[0])
+        work = _normalize_keys(frame)
+        keep = [
+            column
+            for column in work.columns
+            if column in {"date", "loadcell_id", "treatment"}
+            or column in {
+                "loadcell_daily_yield_g",
+                "loadcell_cumulative_yield_g",
+                "individual_cumulative_yield_g",
+                "final_fresh_yield_g",
+                "final_dry_yield_g_est_5p6pct",
+                "loadcell_daily_dry_yield_g_est_default_5p6pct",
+                "loadcell_cumulative_dry_yield_g_est_default_5p6pct",
+                "loadcell_daily_dry_yield_g_est_lower_5p2pct",
+                "loadcell_cumulative_dry_yield_g_est_lower_5p2pct",
+                "loadcell_daily_dry_yield_g_est_upper_6p0pct",
+                "loadcell_cumulative_dry_yield_g_est_upper_6p0pct",
+                "loadcell_daily_dry_yield_g_est_broad_low_4pct",
+                "loadcell_cumulative_dry_yield_g_est_broad_low_4pct",
+                "loadcell_daily_dry_yield_g_est_broad_high_8pct",
+                "loadcell_cumulative_dry_yield_g_est_broad_high_8pct",
+            }
+        ]
+        usable = work[keep].copy()
+        if "loadcell_daily_yield_g" in usable.columns:
+            usable["measured_or_legacy_fresh_yield_g"] = usable["loadcell_daily_yield_g"]
+        elif "final_fresh_yield_g" in usable.columns:
+            usable["measured_or_legacy_fresh_yield_g"] = usable["final_fresh_yield_g"]
+        dry_cols = [column for column in usable.columns if "_dry_yield_g_est_" in column or column.endswith("_dry_yield_g_est_5p6pct")]
+        fresh_available = bool(
+            any(
+                column in usable.columns and usable[column].notna().any()
+                for column in ("measured_or_legacy_fresh_yield_g", "loadcell_daily_yield_g", "final_fresh_yield_g")
+            )
+        )
+        dry_available = bool(dry_cols and usable[dry_cols].notna().any().any())
+        usable["dry_yield_is_dmc_estimated"] = bool(dry_cols)
+        usable["direct_dry_yield_measured"] = bool(config.get("direct_dry_yield_measured", False))
+        usable["legacy_yield_bridge_provenance"] = provenance
+        row["rows_usable"] = int(usable.shape[0])
+        row["status"] = "ok" if not usable.empty else "no_usable_rows"
+        audit_rows.append(row)
+        if not usable.empty:
+            return usable, pd.DataFrame(audit_rows), _metadata(
+                fresh_available,
+                dry_available,
+                str(path),
+                provenance,
+                direct_dry=bool(config.get("direct_dry_yield_measured", False)),
+            )
+    return pd.DataFrame(), pd.DataFrame(audit_rows), _metadata(False, False, "", provenance, direct_dry=False)
+
+
+def _metadata(fresh_available: bool, dry_available: bool, source: str, provenance: str, *, direct_dry: bool) -> dict[str, Any]:
+    any_available = fresh_available or dry_available
+    return {
+        "harvest_yield_available": any_available,
+        "fresh_yield_available": fresh_available,
+        "fresh_yield_source": source if fresh_available else "",
+        "dry_yield_available": dry_available,
+        "dry_yield_source": source if dry_available else "",
+        "dry_yield_is_dmc_estimated": dry_available and not direct_dry,
+        "direct_dry_yield_measured": direct_dry if dry_available else False,
+        "legacy_yield_bridge_used": any_available,
+        "legacy_yield_bridge_provenance": provenance if any_available else "",
+        "DMC_conversion_performed": dry_available,
+        "default_fruit_dry_matter_content_from_legacy": LEGACY_DEFAULT_DMC,
+        "configured_default_fruit_dry_matter_content": DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+        "dmc_sensitivity": list(DMC_SENSITIVITY),
+    }

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py
@@ -14,6 +14,13 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
 
 LEGACY_DEFAULT_DMC = 0.056
 
+FRESH_YIELD_COLUMNS = (
+    "loadcell_daily_yield_g",
+    "loadcell_cumulative_yield_g",
+    "individual_cumulative_yield_g",
+    "final_fresh_yield_g",
+)
+
 
 def _normalize_keys(frame: pd.DataFrame) -> pd.DataFrame:
     out = frame.copy()
@@ -75,15 +82,15 @@ def load_legacy_yield_bridge(config: Mapping[str, Any]) -> tuple[pd.DataFrame, p
             }
         ]
         usable = work[keep].copy()
-        if "loadcell_daily_yield_g" in usable.columns:
-            usable["measured_or_legacy_fresh_yield_g"] = usable["loadcell_daily_yield_g"]
-        elif "final_fresh_yield_g" in usable.columns:
-            usable["measured_or_legacy_fresh_yield_g"] = usable["final_fresh_yield_g"]
+        for fresh_column in FRESH_YIELD_COLUMNS:
+            if fresh_column in usable.columns:
+                usable["measured_or_legacy_fresh_yield_g"] = usable[fresh_column]
+                break
         dry_cols = [column for column in usable.columns if "_dry_yield_g_est_" in column or column.endswith("_dry_yield_g_est_5p6pct")]
         fresh_available = bool(
             any(
                 column in usable.columns and usable[column].notna().any()
-                for column in ("measured_or_legacy_fresh_yield_g", "loadcell_daily_yield_g", "final_fresh_yield_g")
+                for column in ("measured_or_legacy_fresh_yield_g", *FRESH_YIELD_COLUMNS)
             )
         )
         dry_available = bool(dry_cols and usable[dry_cols].notna().any().any())

--- a/tests/test_tomics_haf_chunked_water_flux_carryover.py
+++ b/tests/test_tomics_haf_chunked_water_flux_carryover.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import DATASET1_COLUMN_CANDIDATES
+from stomatal_optimiaztion.domains.tomato.tomics.observers.production_export import (
+    aggregate_dataset1_streaming,
+)
+
+
+def test_chunked_water_flux_carryover_across_batches_and_groups(tmp_path: Path) -> None:
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-12-14 00:00:00",
+                    "2025-12-14 00:05:00",
+                    "2025-12-14 00:10:00",
+                    "2025-12-14 00:00:00",
+                    "2025-12-14 00:05:00",
+                ]
+            ),
+            "date": ["2025-12-14"] * 5,
+            "loadcell_id": [1, 1, 1, 4, 4],
+            "sample_id": [1, 1, 1, 4, 4],
+            "treatment": ["Control", "Control", "Control", "Drought", "Drought"],
+            "loadcell_weight_kg": [10.0, 9.99, 9.98, 20.0, 19.99],
+            "env_inside_radiation_wm2": [0, 1, 2, 0, 1],
+        }
+    ).sort_values(["loadcell_id", "timestamp"])
+    path = tmp_path / "dataset1.parquet"
+    frame.to_parquet(path, index=False)
+
+    _, water, meta, _ = aggregate_dataset1_streaming(
+        path=path,
+        columns=DATASET1_COLUMN_CANDIDATES,
+        batch_size=2,
+        max_rows=None,
+        event_threshold_g=5,
+    )
+
+    control_loss = water[water["loadcell_id"].eq(1)]["loss_g_10min_unscaled"].sum()
+    drought_loss = water[water["loadcell_id"].eq(4)]["loss_g_10min_unscaled"].sum()
+
+    assert control_loss == pytest.approx(20.0)
+    assert drought_loss == pytest.approx(10.0)
+    assert water["event_flag"].any()
+    assert meta["water_flux_chunk_carryover_used"] is True

--- a/tests/test_tomics_haf_dataset3_bridge.py
+++ b/tests/test_tomics_haf_dataset3_bridge.py
@@ -25,4 +25,3 @@ def test_dataset3_mapping_confidence_modes() -> None:
     assert no_date["allocation_use"].eq("growth_phenology_observer_only").all()
     assert treatment_only.shape[0] == 1
     assert unlinked.shape[0] == 1
-

--- a/tests/test_tomics_haf_dataset3_bridge.py
+++ b/tests/test_tomics_haf_dataset3_bridge.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.dataset3_bridge import (
+    build_dataset3_growth_phenology_bridge,
+)
+
+
+def test_dataset3_mapping_confidence_modes() -> None:
+    direct, meta = build_dataset3_growth_phenology_bridge(
+        pd.DataFrame({"date": ["2025-12-14"], "loadcell_id": [1], "treatment": ["Control"], "stem_diameter": [9.0]})
+    )
+    no_date, no_date_meta = build_dataset3_growth_phenology_bridge(
+        pd.DataFrame({"loadcell_id": [1], "treatment": ["Control"], "stem_diameter": [9.0]})
+    )
+    treatment_only, treatment_meta = build_dataset3_growth_phenology_bridge(
+        pd.DataFrame({"date": ["2025-12-14"], "treatment": ["Control"], "stem_diameter": [9.0]})
+    )
+    unlinked, unlinked_meta = build_dataset3_growth_phenology_bridge(pd.DataFrame({"stem_diameter": [9.0]}))
+
+    assert meta["Dataset3_mapping_confidence"] == "direct_loadcell"
+    assert no_date_meta["Dataset3_mapping_confidence"] == "direct_loadcell_no_date"
+    assert treatment_meta["Dataset3_mapping_confidence"] == "treatment_level_only"
+    assert unlinked_meta["Dataset3_mapping_confidence"] == "unlinked"
+    assert direct["causal_allocation_fitting_run"].eq(False).all()
+    assert no_date["allocation_use"].eq("growth_phenology_observer_only").all()
+    assert treatment_only.shape[0] == 1
+    assert unlinked.shape[0] == 1
+

--- a/tests/test_tomics_haf_dmc_canonical_0p056.py
+++ b/tests/test_tomics_haf_dmc_canonical_0p056.py
@@ -1,0 +1,23 @@
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    CANONICAL_2025_2C_FRUIT_DMC,
+    DEFAULT_FRUIT_DRY_MATTER_CONTENT,
+    DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
+    DMC_SENSITIVITY,
+    base_metadata,
+)
+
+
+def test_haf_2025_2c_dmc_metadata_uses_fixed_0p056_contract() -> None:
+    metadata = base_metadata()
+
+    assert CANONICAL_2025_2C_FRUIT_DMC == 0.056
+    assert DEFAULT_FRUIT_DRY_MATTER_CONTENT == 0.056
+    assert DMC_SENSITIVITY == ()
+    assert metadata["canonical_fruit_DMC_fraction"] == 0.056
+    assert metadata["fruit_DMC_fraction"] == 0.056
+    assert metadata["default_fruit_dry_matter_content"] == 0.056
+    assert metadata["DMC_fixed_for_2025_2C"] is True
+    assert metadata["DMC_sensitivity_enabled"] is False
+    assert metadata["DMC_sensitivity_values"] == []
+    assert metadata["deprecated_previous_default_fruit_DMC_fraction"] == DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC
+    assert metadata["deprecated_previous_default_fruit_DMC_fraction"] == 0.065

--- a/tests/test_tomics_haf_event_bridge_calibration.py
+++ b/tests/test_tomics_haf_event_bridge_calibration.py
@@ -54,4 +54,3 @@ def test_event_bridge_missing_daily_total_is_safe_uncalibrated() -> None:
 
     assert calibrated["bridge_status"].iloc[0] == "uncalibrated_no_daily_total"
     assert calibrated["loss_g_10min_event_bridged_calibrated"].isna().all()
-

--- a/tests/test_tomics_haf_event_bridge_calibration.py
+++ b/tests/test_tomics_haf_event_bridge_calibration.py
@@ -1,0 +1,57 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.water_flux_event_bridge import (
+    build_10min_event_bridged_water_loss,
+    calibrate_to_daily_event_bridged_total,
+)
+
+
+def test_event_bridge_rate_mapping_and_daily_calibration() -> None:
+    intervals = build_10min_event_bridged_water_loss(
+        pd.DataFrame(
+            {
+                "interval_start": pd.date_range("2025-12-14", periods=2, freq="10min"),
+                "date": ["2025-12-14", "2025-12-14"],
+                "loadcell_id": [1, 1],
+                "treatment": ["Control", "Control"],
+                "quiet_loss_rate_g_h": [60.0, 60.0],
+                "bridge_loss_rate_g_h": [60.0, 120.0],
+                "event_flag": [False, True],
+            }
+        )
+    )
+    calibrated = calibrate_to_daily_event_bridged_total(
+        intervals,
+        pd.DataFrame(
+            {
+                "date": ["2025-12-14"],
+                "loadcell_id": [1],
+                "treatment": ["Control"],
+                "existing_daily_event_bridged_loss_g_per_day": [60.0],
+            }
+        ),
+    )
+
+    assert intervals["loss_g_10min_unscaled"].tolist() == [10.0, 20.0]
+    assert calibrated["daily_bridge_scale_factor"].iloc[0] == 2.0
+    assert calibrated["loss_g_10min_event_bridged_calibrated"].tolist() == [20.0, 40.0]
+
+
+def test_event_bridge_missing_daily_total_is_safe_uncalibrated() -> None:
+    intervals = build_10min_event_bridged_water_loss(
+        pd.DataFrame(
+            {
+                "interval_start": pd.date_range("2025-12-14", periods=1, freq="10min"),
+                "date": ["2025-12-14"],
+                "loadcell_id": [1],
+                "treatment": ["Control"],
+                "quiet_loss_rate_g_h": [60.0],
+                "event_flag": [False],
+            }
+        )
+    )
+    calibrated = calibrate_to_daily_event_bridged_total(intervals)
+
+    assert calibrated["bridge_status"].iloc[0] == "uncalibrated_no_daily_total"
+    assert calibrated["loss_g_10min_event_bridged_calibrated"].isna().all()
+

--- a/tests/test_tomics_haf_fruit_leaf_windows.py
+++ b/tests/test_tomics_haf_fruit_leaf_windows.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.fruit_diameter_windows import (
+    build_fixed_clock_compat_windows,
+    build_fruit_leaf_radiation_windows,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.qc import apply_fruit_leaf_qc
+from stomatal_optimiaztion.domains.tomato.tomics.observers.sensor_mapping import load_sensor_mapping
+
+
+def test_fruit_leaf_windows_are_sensor_level_and_no_p_values() -> None:
+    raw = pd.DataFrame(
+        {
+            "TIMESTAMP": pd.to_datetime(
+                [
+                    "2025-12-14 06:00",
+                    "2025-12-14 18:00",
+                    "2025-12-15 06:00",
+                ]
+            ),
+            "Fruit1Diameter_Avg": [30.0, 30.4, 30.7],
+            "Fruit2Diameter_Avg": [31.0, 31.2, 31.3],
+            "LeafTemp1_Avg": [24.0, 22.0, 23.0],
+            "LeafTemp2_Avg": [23.0, 21.0, 22.0],
+        }
+    )
+    qc, _ = apply_fruit_leaf_qc(raw)
+    photoperiod = pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-15"],
+            "threshold_w_m2": [0.0, 0.0],
+            "first_light_timestamp": pd.to_datetime(["2025-12-14 06:00", "2025-12-15 06:00"]),
+            "last_light_timestamp": pd.to_datetime(["2025-12-14 18:00", "2025-12-15 18:00"]),
+        }
+    )
+
+    fruit, leaf = build_fruit_leaf_radiation_windows(qc, photoperiod, load_sensor_mapping(), thresholds_w_m2=[0])
+    clock = build_fixed_clock_compat_windows(qc, load_sensor_mapping())
+
+    row = fruit[fruit["sensor_column"].eq("Fruit1Diameter_Avg")].iloc[0]
+    assert row["radiation_day_net_mm"] == 0.3999999999999986
+    assert bool(row["sensor_level_only"]) is True
+    assert bool(row["fruit_diameter_p_values_allowed"]) is False
+    assert "delta_leaf_temp_lc4_minus_lc1_radiation_day_mean_c" in leaf.columns
+    assert clock["fixed_clock_daynight_primary"].eq(False).all()

--- a/tests/test_tomics_haf_input_schema_audit.py
+++ b/tests/test_tomics_haf_input_schema_audit.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.input_schema_audit import (
+    DEFAULT_INPUT_FILE_SPECS,
+    audit_input_file,
+    match_semantic_roles,
+    run_tomics_haf_input_schema_audit,
+)
+
+
+def _write_default_synthetic_inputs(raw_root: Path, *, include_dataset3: bool = True) -> None:
+    raw_root.mkdir(parents=True, exist_ok=True)
+    (raw_root / "2026_2작기_토마토_엽온_과실직경.dat").write_text(
+        (
+            '"TOA5","CR1000XSeries","CR1000X","30553","CR1000X.Std.08.01","CPU","2368","min10"\n'
+            '"TIMESTAMP","RECORD","LeafTemp1_Avg","LeafTemp2_Avg","Fruit1Diameter_Avg",'
+            '"Fruit2Diameter_Avg","SolarRad_Avg"\n'
+            '"TS","RN","Deg C","Deg C","mm","mm","W/m2"\n'
+            '"","","Avg","Avg","Avg","Avg","Avg"\n'
+            '"2025-09-01 00:00:00",0,20.1,20.2,31.0,30.5,0\n'
+            '"2025-09-01 00:10:00",1,21.1,21.2,31.1,30.6,150\n'
+        ),
+        encoding="utf-8",
+    )
+    pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=2, freq="10min"),
+            "loadcell_id": [1, 4],
+            "treatment": ["Control", "Drought"],
+            "env_inside_radiation_wm2": [0.0, 120.0],
+            "env_radiation_wm2": [0.0, 100.0],
+            "env_vpd_kpa": [0.5, 1.2],
+            "env_air_temperature_c": [22.0, 24.0],
+            "env_co2_ppm": [420.0, 430.0],
+            "env_rh_pct": [75.0, 70.0],
+            "moisture_percent_mean": [43.0, 38.0],
+            "ec_ds_mean": [2.1, 2.3],
+            "yield_fresh_g": [10.0, 12.0],
+            "yield_dry_g": [0.65, 0.78],
+            "LAI": [2.1, 2.2],
+        }
+    ).to_parquet(raw_root / "dataset1_loadcell_1_6_daily_ec_moisture_yield_env.parquet", index=False)
+    pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-09-01", "2025-09-02"]),
+            "loadcell": [4, 5],
+            "Treatment": ["Drought", "Drought"],
+            "substrate_moisture": [35.0, 36.0],
+            "EC": [2.4, 2.5],
+            "tensiometer": [-20.0, -22.0],
+        }
+    ).to_parquet(raw_root / "dataset2_loadcell_4_5_daily_ec_moisture_tensiometer.parquet", index=False)
+    if include_dataset3:
+        pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2025-09-01", "2025-09-02"]),
+                "sample_id": ["p1", "p2"],
+                "loadcell_id": [1, 4],
+                "treatment": ["Control", "Drought"],
+                "stem_diameter_mm": [9.5, 10.1],
+                "flower_cluster_height": [20.0, 22.0],
+                "flowering_date": pd.to_datetime(["2025-09-10", "2025-09-11"]),
+                "truss": [1, 1],
+            }
+        ).to_parquet(
+            raw_root / "dataset3_individual_stem_diameter_flower_height_flowering_date.parquet",
+            index=False,
+        )
+
+
+def _config(raw_root: Path, output_root: Path) -> dict[str, object]:
+    return {
+        "tomics_haf": {
+            "raw_data_root": str(raw_root),
+            "output_root": str(output_root),
+        }
+    }
+
+
+def test_alias_matching_for_requested_roles() -> None:
+    roles = match_semantic_roles(
+        [
+            "TIMESTAMP",
+            "Loadcell",
+            "Treatment",
+            "env_inside_radiation_wm2",
+            "VPD_kPa",
+            "substrate_moisture",
+            "EC",
+            "harvest_fresh_weight_g",
+            "fruit_dry_weight_g",
+        ]
+    )
+
+    assert roles["datetime"] == ["TIMESTAMP"]
+    assert roles["loadcell"] == ["Loadcell"]
+    assert roles["treatment"] == ["Treatment"]
+    assert roles["radiation"] == ["env_inside_radiation_wm2"]
+    assert roles["vpd"] == ["VPD_kPa"]
+    assert roles["moisture"] == ["substrate_moisture"]
+    assert roles["ec"] == ["EC"]
+    assert roles["yield_fresh"] == ["harvest_fresh_weight_g"]
+    assert roles["yield_dry"] == ["fruit_dry_weight_g"]
+
+
+def test_input_schema_audit_writes_expected_outputs_with_synthetic_parquet_and_dat(tmp_path: Path) -> None:
+    raw_root = tmp_path / "raw"
+    output_root = tmp_path / "out"
+    _write_default_synthetic_inputs(raw_root)
+
+    result = run_tomics_haf_input_schema_audit(
+        _config(raw_root, output_root),
+        repo_root=tmp_path,
+    )
+
+    input_csv = Path(str(result["input_schema_audit_csv"]))
+    input_json = Path(str(result["input_schema_audit_json"]))
+    assert input_csv.exists()
+    assert input_json.exists()
+    rows = pd.read_csv(input_csv)
+    assert rows.shape[0] == len(DEFAULT_INPUT_FILE_SPECS)
+    assert set(rows["status"]).issubset({"ok", "ok_with_warnings"})
+    dataset1 = rows.loc[rows["file_role"].eq("dataset1")].iloc[0]
+    assert dataset1["parser_used"] == "pandas.read_parquet"
+    assert dataset1["loadcell_column"] == "loadcell_id"
+    assert json.loads(dataset1["loadcell_ids_json"]) == [1, 4]
+    assert "radiation" in json.loads(dataset1["matched_semantic_roles_json"])
+
+
+def test_missing_required_file_returns_missing_file_without_crashing(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.parquet"
+
+    row, frame = audit_input_file(
+        file_role="dataset1",
+        expected_filename="missing.parquet",
+        resolved_path=missing_path,
+    )
+
+    assert frame is None
+    assert row["exists"] is False
+    assert row["status"] == "missing_file"
+    assert row["row_count"] is None
+
+
+def test_dataset1_missing_datetime_or_date_returns_missing_required_column(tmp_path: Path) -> None:
+    path = tmp_path / "dataset1.csv"
+    path.write_text(
+        (
+            "loadcell_id,treatment,env_inside_radiation_wm2,env_vpd_kpa,env_air_temperature_c,"
+            "env_co2_ppm,env_rh_pct,moisture_percent_mean,ec_ds_mean,yield_fresh_g,yield_dry_g,LAI\n"
+            "1,Control,0,0.5,22,420,75,43,2.1,10,0.6,2.1\n"
+        ),
+        encoding="utf-8",
+    )
+
+    row, frame = audit_input_file(
+        file_role="dataset1",
+        expected_filename="dataset1.csv",
+        resolved_path=path,
+    )
+
+    assert frame is not None
+    assert row["status"] == "missing_required_column"
+    assert "datetime_or_date" in json.loads(str(row["missing_important_roles_json"]))
+
+
+def test_dataset1_missing_radiation_is_unsafe_for_primary_use(tmp_path: Path) -> None:
+    path = tmp_path / "dataset1.csv"
+    path.write_text(
+        (
+            "timestamp,loadcell_id,treatment,env_vpd_kpa,env_air_temperature_c,"
+            "env_co2_ppm,env_rh_pct,moisture_percent_mean,ec_ds_mean,yield_fresh_g,yield_dry_g,LAI\n"
+            "2025-09-01 00:00:00,1,Control,0.5,22,420,75,43,2.1,10,0.6,2.1\n"
+        ),
+        encoding="utf-8",
+    )
+
+    row, frame = audit_input_file(
+        file_role="dataset1",
+        expected_filename="dataset1.csv",
+        resolved_path=path,
+    )
+
+    assert frame is not None
+    assert row["status"] == "unsafe_for_primary_use"
+    assert "radiation" in json.loads(str(row["missing_important_roles_json"]))
+
+
+def test_parse_failed_status_is_reported_without_crashing(tmp_path: Path) -> None:
+    path = tmp_path / "dataset1.bin"
+    path.write_bytes(b"not a supported tabular file")
+
+    row, frame = audit_input_file(
+        file_role="dataset1",
+        expected_filename="dataset1.bin",
+        resolved_path=path,
+    )
+
+    assert frame is None
+    assert row["status"] == "parse_failed"
+    assert row["parser_used"] == "unsupported"

--- a/tests/test_tomics_haf_legacy_event_bridge_calibration.py
+++ b/tests/test_tomics_haf_legacy_event_bridge_calibration.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.event_bridge_calibration import (
+    CALIBRATION_TOTAL_COL,
+    calibration_match_metadata,
+    load_legacy_event_bridge_daily_totals,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.legacy_v1_3_bridge import legacy_v1_3_config
+from stomatal_optimiaztion.domains.tomato.tomics.observers.water_flux_event_bridge import (
+    calibrate_to_daily_event_bridged_total,
+)
+
+
+def _write_legacy_event_bridge(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2025-12-14"],
+            "loadcell_id": [4],
+            "treatment": ["Drought"],
+            "event_bridged_loss_g_per_day": [100.0],
+            "primary_event_bridge_qc": [True],
+            "valid_coverage_fraction": [1.0],
+            "event_bridge_rate_source": ["legacy"],
+            "bridge_to_quiet_scaled_ratio": [1.2],
+        }
+    ).to_csv(path, index=False)
+
+
+def test_legacy_event_bridge_daily_totals_calibrate_matching_intervals(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    candidate = archive / "previous_outputs/event_bridge_outputs/daily_event_bridged_transpiration.csv"
+    _write_legacy_event_bridge(candidate)
+    config = legacy_v1_3_config(
+        {
+            "legacy_v1_3": {
+                "enabled": True,
+                "archive_root": str(archive),
+                "allow_legacy_event_bridge_calibration": True,
+            }
+        },
+        repo_root=tmp_path,
+    )
+
+    daily_totals, audit, metadata = load_legacy_event_bridge_daily_totals(config)
+    intervals = pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-14"],
+            "loadcell_id": [4, 4],
+            "treatment": ["Drought", "Drought"],
+            "loss_g_10min_unscaled": [20.0, 30.0],
+        }
+    )
+    calibrated = calibrate_to_daily_event_bridged_total(
+        intervals,
+        daily_totals,
+        total_col=CALIBRATION_TOTAL_COL,
+    )
+    matched_metadata = calibration_match_metadata(calibrated, daily_totals, metadata)
+
+    assert audit["status"].iloc[0] == "ok"
+    assert metadata["existing_daily_event_bridged_total_available"] is True
+    assert calibrated["daily_bridge_scale_factor"].iloc[0] == pytest.approx(2.0)
+    assert calibrated["loss_g_10min_event_bridged_calibrated"].sum() == pytest.approx(100.0)
+    assert matched_metadata["event_bridged_ET_calibration_status"] == "calibrated_to_legacy_daily_event_total"
+    assert matched_metadata["event_bridged_ET_calibration_provenance"] == "legacy_v1_3_derived_output"
+    assert matched_metadata["event_bridged_ET_calibration_direct_raw_recomputed"] is False
+
+
+def test_legacy_event_bridge_rejects_non_finite_daily_totals(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    candidate = archive / "previous_outputs/event_bridge_outputs/daily_event_bridged_transpiration.csv"
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2025-12-14"],
+            "loadcell_id": [4],
+            "treatment": ["Drought"],
+            "event_bridged_loss_g_per_day": [float("inf")],
+            "valid_coverage_fraction": [1.0],
+        }
+    ).to_csv(candidate, index=False)
+    config = legacy_v1_3_config(
+        {
+            "legacy_v1_3": {
+                "enabled": True,
+                "archive_root": str(archive),
+                "allow_legacy_event_bridge_calibration": True,
+            }
+        },
+        repo_root=tmp_path,
+    )
+
+    daily_totals, audit, metadata = load_legacy_event_bridge_daily_totals(config)
+
+    assert daily_totals.empty
+    assert audit["status"].iloc[0] == "no_usable_rows"
+    assert metadata["existing_daily_event_bridged_total_available"] is False

--- a/tests/test_tomics_haf_legacy_yield_bridge.py
+++ b/tests/test_tomics_haf_legacy_yield_bridge.py
@@ -49,3 +49,36 @@ def test_legacy_yield_bridge_distinguishes_fresh_from_dmc_estimated_dry_yield(tm
     assert metadata["default_fruit_dry_matter_content_from_legacy"] == 0.056
     assert metadata["configured_default_fruit_dry_matter_content"] == 0.065
     assert 0.04 in metadata["dmc_sensitivity"]
+
+
+def test_legacy_yield_bridge_accepts_cumulative_fresh_yield_without_daily_yield(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    source = archive / "outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2025-12-14"],
+            "loadcell_id": [4],
+            "treatment": ["Drought"],
+            "loadcell_cumulative_yield_g": [300.0],
+        }
+    ).to_csv(source, index=False)
+    config = legacy_v1_3_config(
+        {
+            "legacy_v1_3": {
+                "enabled": True,
+                "archive_root": str(archive),
+                "allow_legacy_yield_bridge": True,
+                "direct_dry_yield_measured": False,
+            }
+        },
+        repo_root=tmp_path,
+    )
+
+    bridge, audit, metadata = load_legacy_yield_bridge(config)
+
+    assert audit["status"].iloc[0] == "ok"
+    assert bridge["measured_or_legacy_fresh_yield_g"].iloc[0] == 300.0
+    assert metadata["fresh_yield_available"] is True
+    assert metadata["dry_yield_available"] is False
+    assert metadata["legacy_yield_bridge_used"] is True

--- a/tests/test_tomics_haf_legacy_yield_bridge.py
+++ b/tests/test_tomics_haf_legacy_yield_bridge.py
@@ -46,9 +46,18 @@ def test_legacy_yield_bridge_distinguishes_fresh_from_dmc_estimated_dry_yield(tm
     assert metadata["dry_yield_available"] is True
     assert metadata["dry_yield_is_dmc_estimated"] is True
     assert metadata["direct_dry_yield_measured"] is False
+    assert metadata["canonical_fruit_DMC_fraction"] == 0.056
+    assert metadata["fruit_DMC_fraction"] == 0.056
+    assert metadata["default_fruit_dry_matter_content"] == 0.056
+    assert metadata["DMC_fixed_for_2025_2C"] is True
+    assert metadata["DMC_sensitivity_enabled"] is False
+    assert metadata["DMC_sensitivity_values"] == []
+    assert metadata["deprecated_previous_default_fruit_DMC_fraction"] == 0.065
     assert metadata["default_fruit_dry_matter_content_from_legacy"] == 0.056
-    assert metadata["configured_default_fruit_dry_matter_content"] == 0.065
-    assert 0.04 in metadata["dmc_sensitivity"]
+    assert bridge["observed_fruit_FW_g_loadcell"].iloc[0] == 120.0
+    assert bridge["observed_fruit_DW_g_loadcell_dmc_0p056"].iloc[0] == 6.72
+    assert bridge["dry_yield_source"].iloc[0] == "fresh_yield_times_canonical_DMC_0p056"
+    assert "loadcell_daily_dry_yield_g_est_lower_5p2pct" in metadata["legacy_sensitivity_columns_present"]
 
 
 def test_legacy_yield_bridge_accepts_cumulative_fresh_yield_without_daily_yield(tmp_path: Path) -> None:
@@ -79,6 +88,7 @@ def test_legacy_yield_bridge_accepts_cumulative_fresh_yield_without_daily_yield(
 
     assert audit["status"].iloc[0] == "ok"
     assert bridge["measured_or_legacy_fresh_yield_g"].iloc[0] == 300.0
+    assert bridge["observed_fruit_DW_g_loadcell_dmc_0p056"].iloc[0] == 16.8
     assert metadata["fresh_yield_available"] is True
-    assert metadata["dry_yield_available"] is False
+    assert metadata["dry_yield_available"] is True
     assert metadata["legacy_yield_bridge_used"] is True

--- a/tests/test_tomics_haf_legacy_yield_bridge.py
+++ b/tests/test_tomics_haf_legacy_yield_bridge.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.legacy_v1_3_bridge import legacy_v1_3_config
+from stomatal_optimiaztion.domains.tomato.tomics.observers.yield_bridge import load_legacy_yield_bridge
+
+
+def test_legacy_yield_bridge_distinguishes_fresh_from_dmc_estimated_dry_yield(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    source = archive / "outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2025-12-14"],
+            "loadcell_id": [4],
+            "treatment": ["Drought"],
+            "loadcell_daily_yield_g": [120.0],
+            "loadcell_cumulative_yield_g": [300.0],
+            "loadcell_daily_dry_yield_g_est_default_5p6pct": [6.72],
+            "loadcell_daily_dry_yield_g_est_lower_5p2pct": [6.24],
+            "loadcell_daily_dry_yield_g_est_upper_6p0pct": [7.2],
+            "loadcell_daily_dry_yield_g_est_broad_low_4pct": [4.8],
+            "loadcell_daily_dry_yield_g_est_broad_high_8pct": [9.6],
+        }
+    ).to_csv(source, index=False)
+    config = legacy_v1_3_config(
+        {
+            "legacy_v1_3": {
+                "enabled": True,
+                "archive_root": str(archive),
+                "allow_legacy_yield_bridge": True,
+                "direct_dry_yield_measured": False,
+            }
+        },
+        repo_root=tmp_path,
+    )
+
+    bridge, audit, metadata = load_legacy_yield_bridge(config)
+
+    assert audit["status"].iloc[0] == "ok"
+    assert bridge["measured_or_legacy_fresh_yield_g"].iloc[0] == 120.0
+    assert bool(bridge["dry_yield_is_dmc_estimated"].iloc[0]) is True
+    assert bool(bridge["direct_dry_yield_measured"].iloc[0]) is False
+    assert metadata["fresh_yield_available"] is True
+    assert metadata["dry_yield_available"] is True
+    assert metadata["dry_yield_is_dmc_estimated"] is True
+    assert metadata["direct_dry_yield_measured"] is False
+    assert metadata["default_fruit_dry_matter_content_from_legacy"] == 0.056
+    assert metadata["configured_default_fruit_dry_matter_content"] == 0.065
+    assert 0.04 in metadata["dmc_sensitivity"]

--- a/tests/test_tomics_haf_metadata_contract.py
+++ b/tests/test_tomics_haf_metadata_contract.py
@@ -80,10 +80,10 @@ def test_metadata_contract_records_season_radiation_and_fruit_diameter_rules(tmp
     assert metadata["fruit_diameter_rules"]["fruit_diameter_treatment_endpoint"] is False
     assert metadata["fruit_diameter_rules"]["fruit_diameter_p_values_allowed"] is False
     assert metadata["fruit_diameter_rules"]["fruit_diameter_allocation_calibration_target"] is False
-    assert metadata["dataset3_mapping"] == "treatment_level_only"
-    assert metadata["vpd_available"] is True
-    assert metadata["lai_available"] is False
+    assert metadata["Dataset3_mapping_confidence"] == "treatment_level_only"
+    assert metadata["VPD_available"] is True
+    assert metadata["LAI_available"] is False
     assert metadata["fresh_yield_available"] is True
     assert metadata["dry_yield_available"] is False
     assert metadata["raw_thorp_promoted"] is False
-    assert metadata["shipped_tomics_incumbent_unchanged"] is True
+    assert metadata["shipped_TOMICS_incumbent_changed"] is False

--- a/tests/test_tomics_haf_metadata_contract.py
+++ b/tests/test_tomics_haf_metadata_contract.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.input_schema_audit import (
+    run_tomics_haf_input_schema_audit,
+)
+
+
+def _write_inputs_with_treatment_only_dataset3(raw_root: Path) -> None:
+    raw_root.mkdir(parents=True, exist_ok=True)
+    (raw_root / "2026_2작기_토마토_엽온_과실직경.dat").write_text(
+        (
+            "timestamp,SolarRad_Avg,LeafTemp1_Avg,LeafTemp2_Avg,Fruit1Diameter_Avg,Fruit2Diameter_Avg\n"
+            "2025-09-01 00:00:00,0,20,21,30,31\n"
+            "2025-09-01 00:10:00,100,22,23,30.2,31.2\n"
+        ),
+        encoding="utf-8",
+    )
+    pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=2, freq="10min"),
+            "loadcell_id": [1, 4],
+            "treatment": ["Control", "Drought"],
+            "env_inside_radiation_wm2": [0.0, 100.0],
+            "env_vpd_kpa": [0.6, 1.1],
+            "env_air_temperature_c": [20.0, 24.0],
+            "env_co2_ppm": [410.0, 415.0],
+            "env_rh_pct": [80.0, 72.0],
+            "moisture_percent_mean": [40.0, 35.0],
+            "ec_ds_mean": [2.0, 2.2],
+            "yield_fresh_g": [5.0, 6.0],
+        }
+    ).to_parquet(raw_root / "dataset1_loadcell_1_6_daily_ec_moisture_yield_env.parquet", index=False)
+    pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-09-01", "2025-09-02"]),
+            "loadcell": [4, 5],
+            "Treatment": ["Drought", "Drought"],
+            "theta": [0.35, 0.36],
+            "ec": [2.2, 2.3],
+            "tensiometer_hp_mean": [-20.0, -21.0],
+        }
+    ).to_parquet(raw_root / "dataset2_loadcell_4_5_daily_ec_moisture_tensiometer.parquet", index=False)
+    pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-09-01", "2025-09-02"]),
+            "sample_id": ["a", "b"],
+            "treatment": ["Control", "Drought"],
+            "stem_diameter": [9.0, 10.0],
+            "flower_height": [18.0, 20.0],
+            "flowering_date": pd.to_datetime(["2025-09-10", "2025-09-11"]),
+            "cluster": [1, 2],
+        }
+    ).to_parquet(
+        raw_root / "dataset3_individual_stem_diameter_flower_height_flowering_date.parquet",
+        index=False,
+    )
+
+
+def test_metadata_contract_records_season_radiation_and_fruit_diameter_rules(tmp_path: Path) -> None:
+    raw_root = tmp_path / "raw"
+    output_root = tmp_path / "out"
+    _write_inputs_with_treatment_only_dataset3(raw_root)
+
+    result = run_tomics_haf_input_schema_audit(
+        {"tomics_haf": {"raw_data_root": str(raw_root), "output_root": str(output_root)}},
+        repo_root=tmp_path,
+    )
+    metadata = json.loads(Path(str(result["metadata_json"])).read_text(encoding="utf-8"))
+
+    assert metadata["season_id"] == "2025_2C"
+    assert metadata["fixed_clock_daynight_primary"] is False
+    assert metadata["clock_06_18_used_only_for_compatibility"] is True
+    assert metadata["radiation_thresholds_to_test"] == [0, 1, 5, 10]
+    assert metadata["fruit_diameter_rules"]["sensor_level_only"] is True
+    assert metadata["fruit_diameter_rules"]["fruit_diameter_treatment_endpoint"] is False
+    assert metadata["fruit_diameter_rules"]["fruit_diameter_p_values_allowed"] is False
+    assert metadata["fruit_diameter_rules"]["fruit_diameter_allocation_calibration_target"] is False
+    assert metadata["dataset3_mapping"] == "treatment_level_only"
+    assert metadata["vpd_available"] is True
+    assert metadata["lai_available"] is False
+    assert metadata["fresh_yield_available"] is True
+    assert metadata["dry_yield_available"] is False
+    assert metadata["raw_thorp_promoted"] is False
+    assert metadata["shipped_tomics_incumbent_unchanged"] is True

--- a/tests/test_tomics_haf_metadata_contract_no_case_collisions.py
+++ b/tests/test_tomics_haf_metadata_contract_no_case_collisions.py
@@ -1,0 +1,55 @@
+import json
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import (
+    case_insensitive_duplicate_keys,
+    json_has_case_insensitive_duplicate_keys,
+    metadata_contract_audit,
+    normalize_metadata,
+    write_normalized_metadata,
+)
+
+
+def test_metadata_normalizer_removes_power_shell_case_collisions(tmp_path) -> None:
+    metadata = {
+        "LAI_available": False,
+        "lai_available": False,
+        "VPD_available": True,
+        "vpd_available": True,
+        "dataset3_mapping": "direct_loadcell",
+        "Dataset3_mapping_confidence": "direct_loadcell_no_date",
+        "fruit_diameter_p_values_allowed": False,
+        "fruit_diameter_allocation_calibration_target": False,
+        "fruit_diameter_model_promotion_target": False,
+        "shipped_TOMICS_incumbent_changed": False,
+        "shipped_tomics_incumbent_unchanged": True,
+    }
+
+    normalized = normalize_metadata(metadata)
+    assert case_insensitive_duplicate_keys(normalized) == []
+    assert "lai_available" not in normalized
+    assert "vpd_available" not in normalized
+    assert "dataset3_mapping" not in normalized
+    assert normalized["Dataset3_mapping_confidence"] == "direct_loadcell_no_date"
+    assert normalized["shipped_TOMICS_incumbent_changed"] is False
+    assert normalized["legacy_metadata"]["dataset3_mapping"] == "direct_loadcell"
+
+    metadata_path = write_normalized_metadata(tmp_path / "metadata.json", metadata)
+    assert json_has_case_insensitive_duplicate_keys(metadata_path) is False
+    written = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert "legacy_metadata" in written
+
+
+def test_metadata_contract_audit_requires_canonical_top_level_keys() -> None:
+    audit = metadata_contract_audit(
+        {
+            "LAI_available": False,
+            "VPD_available": True,
+            "Dataset3_mapping_confidence": "direct_loadcell_no_date",
+            "fruit_diameter_p_values_allowed": False,
+            "fruit_diameter_allocation_calibration_target": False,
+            "fruit_diameter_model_promotion_target": False,
+            "shipped_TOMICS_incumbent_changed": False,
+        }
+    )
+
+    assert audit["status"].tolist() == ["pass", "pass"]

--- a/tests/test_tomics_haf_metadata_contract_no_case_collisions.py
+++ b/tests/test_tomics_haf_metadata_contract_no_case_collisions.py
@@ -49,6 +49,12 @@ def test_metadata_contract_audit_requires_canonical_top_level_keys() -> None:
             "fruit_diameter_allocation_calibration_target": False,
             "fruit_diameter_model_promotion_target": False,
             "shipped_TOMICS_incumbent_changed": False,
+            "canonical_fruit_DMC_fraction": 0.056,
+            "fruit_DMC_fraction": 0.056,
+            "default_fruit_dry_matter_content": 0.056,
+            "DMC_fixed_for_2025_2C": True,
+            "DMC_sensitivity_enabled": False,
+            "deprecated_previous_default_fruit_DMC_fraction": 0.065,
         }
     )
 

--- a/tests/test_tomics_haf_no_stale_dmc_0p065_primary.py
+++ b/tests/test_tomics_haf_no_stale_dmc_0p065_primary.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+HAF_PRIMARY_PATHS = [
+    Path("configs/exp/tomics_haf_2025_2c_observer_pipeline.yaml"),
+    Path("configs/exp/tomics_haf_2025_2c_observer_pipeline_production.yaml"),
+    Path("src/stomatal_optimiaztion/domains/tomato/tomics/observers/contracts.py"),
+    Path("src/stomatal_optimiaztion/domains/tomato/tomics/observers/feature_frame.py"),
+    Path("src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py"),
+    Path("src/stomatal_optimiaztion/domains/tomato/tomics/observers/pipeline.py"),
+    Path("src/stomatal_optimiaztion/domains/tomato/tomics/observers/yield_bridge.py"),
+    Path("docs/architecture/tomics/fresh_dry_yield_bridge_contract.md"),
+    Path("docs/architecture/tomics/harvest_aware_promotion_gate.md"),
+    Path("docs/architecture/tomics/harvest_family_architecture.md"),
+    Path("docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md"),
+    Path("docs/architecture/tomics/legacy_v1_3_bridge_contract.md"),
+    Path("docs/architecture/tomics/new_phytologist_readiness_checklist.md"),
+    Path("docs/architecture/tomics/pr_309_goal2_5_summary.md"),
+    Path("docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md"),
+]
+
+
+def test_haf_2025_2c_primary_files_do_not_use_0p065_as_current_default() -> None:
+    forbidden_tokens = (
+        "configured_default_fruit_dry_matter_content",
+        "constant_0p065",
+        "dmc_0p065",
+        "fruit_DMC_fraction = 0.065",
+        "default_fruit_dry_matter_content = 0.065",
+        "default DMC = 0.065",
+    )
+    for path in HAF_PRIMARY_PATHS:
+        text = path.read_text(encoding="utf-8")
+        for token in forbidden_tokens:
+            assert token not in text
+        for line in text.splitlines():
+            if "0.065" in line:
+                lowered = line.lower()
+                assert "deprecated" in lowered or "previous" in lowered or "historical" in lowered

--- a/tests/test_tomics_haf_observation_operator_dmc_0p056.py
+++ b/tests/test_tomics_haf_observation_operator_dmc_0p056.py
@@ -1,0 +1,18 @@
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.yield_bridge import (
+    dry_floor_area_to_fresh_loadcell,
+    dry_g_to_fresh_g,
+    fresh_g_to_dry_g,
+    fresh_loadcell_to_dry_floor_area,
+)
+
+
+def test_haf_2025_2c_fresh_dry_conversions_use_0p056() -> None:
+    assert fresh_g_to_dry_g(1000.0) == pytest.approx(56.0)
+    assert fresh_loadcell_to_dry_floor_area(1000.0) == pytest.approx(56.0 / HAF_2025_2C_LOADCELL_FLOOR_AREA_M2)
+    assert dry_g_to_fresh_g(56.0) == pytest.approx(1000.0)
+    assert dry_floor_area_to_fresh_loadcell(56.0 / HAF_2025_2C_LOADCELL_FLOOR_AREA_M2) == pytest.approx(1000.0)

--- a/tests/test_tomics_haf_observer_feature_frame.py
+++ b/tests/test_tomics_haf_observer_feature_frame.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.feature_frame import build_observer_feature_frame
+
+
+def test_observer_feature_frame_flags_unavailable_lai_yield_and_indirect_allocation() -> None:
+    frame = build_observer_feature_frame(
+        daily_et_wide=pd.DataFrame(
+            {
+                "date": ["2025-12-14"],
+                "loadcell_id": [1],
+                "treatment": ["Control"],
+                "threshold_w_m2": [0.0],
+                "radiation_day_ET_g": [10.0],
+                "radiation_night_ET_g": [2.0],
+            }
+        ),
+        rootzone_indices=pd.DataFrame(
+            {
+                "date": ["2025-12-14"],
+                "loadcell_id": [1],
+                "treatment": ["Control"],
+                "RZI_main": [0.0],
+                "apparent_canopy_conductance": [5.0],
+                "apparent_canopy_conductance_available": [True],
+            }
+        ),
+    )
+
+    row = frame.iloc[0]
+    assert bool(row["LAI_available"]) is False
+    assert bool(row["fresh_yield_available"]) is False
+    assert bool(row["dry_yield_available"]) is False
+    assert bool(row["direct_partition_observation_available"]) is False
+    assert row["allocation_validation_basis"] == "indirect_observer_features_only"

--- a/tests/test_tomics_haf_observer_feature_frame.py
+++ b/tests/test_tomics_haf_observer_feature_frame.py
@@ -31,5 +31,12 @@ def test_observer_feature_frame_flags_unavailable_lai_yield_and_indirect_allocat
     assert bool(row["LAI_available"]) is False
     assert bool(row["fresh_yield_available"]) is False
     assert bool(row["dry_yield_available"]) is False
+    assert row["canonical_fruit_DMC_fraction"] == 0.056
+    assert row["fruit_DMC_fraction"] == 0.056
+    assert row["default_fruit_dry_matter_content"] == 0.056
+    assert bool(row["DMC_fixed_for_2025_2C"]) is True
+    assert bool(row["DMC_sensitivity_enabled"]) is False
+    assert bool(row["dry_yield_is_dmc_estimated"]) is False
+    assert bool(row["direct_dry_yield_measured"]) is False
     assert bool(row["direct_partition_observation_available"]) is False
     assert row["allocation_validation_basis"] == "indirect_observer_features_only"

--- a/tests/test_tomics_haf_observer_pipeline_metadata.py
+++ b/tests/test_tomics_haf_observer_pipeline_metadata.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import (
+    run_tomics_haf_observer_pipeline,
+)
+
+
+def _write_toa5(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                '"TOA5","station","CR1000"',
+                '"TIMESTAMP","RECORD","SolarRad_Avg","LeafTemp1_Avg","LeafTemp2_Avg","Fruit1Diameter_Avg","Fruit2Diameter_Avg"',
+                '"TS","RN","W/m2","Deg C","Deg C","mm","mm"',
+                '"","","Avg","Avg","Avg","Avg","Avg"',
+                '"2025-12-14 06:00:00",1,0,24.0,23.0,30.0,31.0',
+                '"2025-12-14 06:10:00",2,20,24.5,23.5,30.2,31.1',
+                '"2025-12-14 18:00:00",3,0,22.0,21.0,30.4,31.2',
+                '"2025-12-15 06:00:00",4,10,23.0,22.0,30.7,31.3',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_observer_pipeline_metadata_contract(tmp_path: Path) -> None:
+    raw_root = tmp_path / "raw"
+    raw_root.mkdir()
+    _write_toa5(raw_root / "sensor.dat")
+
+    dataset1 = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-12-14 06:00",
+                    "2025-12-14 06:10",
+                    "2025-12-14 18:00",
+                    "2025-12-14 18:10",
+                    "2025-12-14 06:00",
+                    "2025-12-14 06:10",
+                    "2025-12-14 18:00",
+                    "2025-12-14 18:10",
+                ]
+            ),
+            "date": ["2025-12-14"] * 8,
+            "loadcell_id": [1, 1, 1, 1, 4, 4, 4, 4],
+            "sample_id": [1, 1, 1, 1, 4, 4, 4, 4],
+            "treatment": ["Control"] * 4 + ["Drought"] * 4,
+            "loadcell_weight_kg": [10.0, 9.99, 9.98, 9.97, 9.0, 8.99, 8.98, 8.97],
+            "env_inside_radiation_wm2": [10.0, 20.0, 0.0, 0.0, 10.0, 20.0, 0.0, 0.0],
+            "env_vpd_kpa": [2.0] * 8,
+            "env_air_temperature_c": [25.0] * 8,
+            "env_co2_ppm": [400.0] * 8,
+        }
+    )
+    dataset1.to_parquet(raw_root / "dataset1.parquet", index=False)
+
+    dataset2 = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2025-12-14 00:00", "2025-12-14 00:00"]),
+            "date": ["2025-12-14", "2025-12-14"],
+            "loadcell_id": [1, 4],
+            "sample_id": [1, 4],
+            "treatment": ["Control", "Drought"],
+            "loadcell_weight_kg": [10.0, 9.0],
+            "moisture_percent": [80.0, 40.0],
+            "ec_ds": [2.0, 3.0],
+            "tensiometer_hp": [1.0, 2.0],
+        }
+    )
+    dataset2.to_parquet(raw_root / "dataset2.parquet", index=False)
+
+    dataset3 = pd.DataFrame(
+        {
+            "season": ["2025_2C"],
+            "sample_id": [1],
+            "loadcell_id": [1],
+            "treatment": ["Control"],
+            "flowering_date": ["2025-12-14"],
+            "stem_diameter": [9.0],
+            "flower_cluster_height": [120.0],
+        }
+    )
+    dataset3.to_parquet(raw_root / "dataset3.parquet", index=False)
+
+    mapping_path = tmp_path / "mapping.yaml"
+    mapping_path.write_text(
+        yaml.safe_dump(
+            {
+                "timestamp_col": "TIMESTAMP",
+                "leaf_sensor_map": {
+                    "LeafTemp1_Avg": {
+                        "loadcell_id": 4,
+                        "treatment": "Drought",
+                        "mapping_status": "confirmed_by_user",
+                    },
+                    "LeafTemp2_Avg": {
+                        "loadcell_id": 1,
+                        "treatment": "Control",
+                        "mapping_status": "confirmed_by_user",
+                    },
+                },
+                "fruit_sensor_map": {
+                    "Fruit1Diameter_Avg": {
+                        "loadcell_id": 4,
+                        "treatment": "Drought",
+                        "mapping_status": "provisional",
+                    },
+                    "Fruit2Diameter_Avg": {
+                        "loadcell_id": 1,
+                        "treatment": "Control",
+                        "mapping_status": "provisional",
+                    },
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "paths": {"repo_root": str(tmp_path)},
+                "tomics_haf": {
+                    "raw_data_root": "raw",
+                    "output_root": "out",
+                    "sensor_mapping_path": str(mapping_path),
+                    "input_files": {
+                        "fruit_leaf_temperature_solar_raw_dat": "sensor.dat",
+                        "dataset1": "dataset1.parquet",
+                        "dataset2": "dataset2.parquet",
+                        "dataset3": "dataset3.parquet",
+                    },
+                },
+                "observer_pipeline": {
+                    "parquet_batch_size": 10,
+                    "max_full_rows_without_limit": 1000,
+                    "max_rows": {"dataset1": None, "dataset2": None, "dataset3": None},
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_tomics_haf_observer_pipeline(config_path)
+    metadata = result["metadata"]
+
+    assert metadata["season_id"] == "2025_2C"
+    assert metadata["radiation_column_used"] == "env_inside_radiation_wm2"
+    assert metadata["dataset1_radiation_directly_usable"] is True
+    assert metadata["fallback_required"] is False
+    assert metadata["fixed_clock_daynight_primary"] is False
+    assert metadata["radiation_thresholds_tested"] == [0, 1, 5, 10]
+    assert metadata["latent_allocation_inference_run"] is False
+    assert metadata["harvest_family_factorial_run"] is False
+    assert metadata["promotion_gate_run"] is False
+    assert metadata["shipped_TOMICS_incumbent_changed"] is False
+    assert Path(result["outputs"]["observer_feature_frame"]).exists()

--- a/tests/test_tomics_haf_parquet_streaming.py
+++ b/tests/test_tomics_haf_parquet_streaming.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.parquet_streaming import (
+    assert_no_large_full_load_without_limit,
+    iter_projected_parquet_batches,
+    parquet_metadata_summary,
+    projected_columns,
+    validate_production_row_cap_policy,
+)
+
+
+def test_projected_parquet_batches_and_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "data.parquet"
+    pd.DataFrame({"timestamp": pd.date_range("2025-12-14", periods=5, freq="min"), "value": range(5)}).to_parquet(
+        path,
+        index=False,
+    )
+
+    meta = parquet_metadata_summary(path)
+    batches = list(iter_projected_parquet_batches(path, ["timestamp", "missing"], batch_size=2))
+
+    assert meta["total_rows"] == 5
+    assert projected_columns(path, ["timestamp", "missing"]) == ["timestamp"]
+    assert [batch.shape[0] for batch in batches] == [2, 2, 1]
+    assert list(batches[0].columns) == ["timestamp"]
+
+
+def test_large_full_load_guard_and_production_row_cap_policy() -> None:
+    with pytest.raises(RuntimeError):
+        assert_no_large_full_load_without_limit(
+            total_rows=10,
+            max_rows=None,
+            mode="smoke",
+            max_full_rows_without_limit=5,
+        )
+
+    assert_no_large_full_load_without_limit(
+        total_rows=10,
+        max_rows=None,
+        mode="production",
+        max_full_rows_without_limit=5,
+    )
+
+    with pytest.raises(ValueError):
+        validate_production_row_cap_policy(
+            mode="production",
+            max_rows_by_dataset={"dataset1": 2, "dataset2": None},
+            require_row_cap_absent_for_production=True,
+        )
+

--- a/tests/test_tomics_haf_parquet_streaming.py
+++ b/tests/test_tomics_haf_parquet_streaming.py
@@ -50,4 +50,3 @@ def test_large_full_load_guard_and_production_row_cap_policy() -> None:
             max_rows_by_dataset={"dataset1": 2, "dataset2": None},
             require_row_cap_absent_for_production=True,
         )
-

--- a/tests/test_tomics_haf_prereq_revalidation_after_observer_patch.py
+++ b/tests/test_tomics_haf_prereq_revalidation_after_observer_patch.py
@@ -60,10 +60,17 @@ def test_observer_metadata_after_hardening_preserves_latent_prerequisite_contrac
         "promotion_gate_run": False,
         "direct_dry_yield_measured": False,
         "dry_yield_is_dmc_estimated": True,
+        "canonical_fruit_DMC_fraction": 0.056,
+        "fruit_DMC_fraction": 0.056,
+        "default_fruit_dry_matter_content": 0.056,
+        "DMC_fixed_for_2025_2C": True,
+        "DMC_sensitivity_enabled": False,
+        "deprecated_previous_default_fruit_DMC_fraction": 0.065,
     }
 
     audit = metadata_contract_audit(metadata)
     assert audit["status"].tolist() == ["pass", "pass"]
     assert metadata["direct_dry_yield_measured"] is False
     assert metadata["dry_yield_is_dmc_estimated"] is True
+    assert metadata["DMC_sensitivity_enabled"] is False
     assert metadata["latent_allocation_inference_run"] is False

--- a/tests/test_tomics_haf_prereq_revalidation_after_observer_patch.py
+++ b/tests/test_tomics_haf_prereq_revalidation_after_observer_patch.py
@@ -1,0 +1,69 @@
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import metadata_contract_audit
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import _production_requirement_failures
+
+
+def test_production_requirements_pass_only_for_full_chunked_uncapped_export() -> None:
+    failures = _production_requirement_failures(
+        mode="production",
+        pipeline_config={
+            "require_chunk_aggregation": True,
+            "require_dataset1_full_processed": True,
+            "require_dataset2_full_processed": True,
+        },
+        row_cap_applied=False,
+        chunk_aggregation_used=True,
+        full_in_memory_large_dataset_used=False,
+        dataset1_load_meta={"rows_processed_fraction": 1.0},
+        dataset2_load_meta={"rows_processed_fraction": 1.0},
+    )
+
+    assert failures == []
+
+
+def test_production_requirements_report_all_blocking_failures() -> None:
+    failures = _production_requirement_failures(
+        mode="production",
+        pipeline_config={
+            "require_chunk_aggregation": True,
+            "require_dataset1_full_processed": True,
+            "require_dataset2_full_processed": True,
+        },
+        row_cap_applied=True,
+        chunk_aggregation_used=False,
+        full_in_memory_large_dataset_used=True,
+        dataset1_load_meta={"rows_processed_fraction": 0.5},
+        dataset2_load_meta={"rows_processed_fraction": 0.75},
+    )
+
+    assert "require_chunk_aggregation=true but chunk_aggregation_used=false" in failures
+    assert "require_dataset1_full_processed=true but dataset1_rows_processed_fraction != 1.0" in failures
+    assert "require_dataset2_full_processed=true but dataset2_rows_processed_fraction != 1.0" in failures
+    assert "full_in_memory_large_dataset_used=true" in failures
+    assert "row_cap_applied=true" in failures
+
+
+def test_observer_metadata_after_hardening_preserves_latent_prerequisite_contract() -> None:
+    metadata = {
+        "LAI_available": False,
+        "VPD_available": True,
+        "Dataset3_mapping_confidence": "direct_loadcell_no_date",
+        "fruit_diameter_p_values_allowed": False,
+        "fruit_diameter_allocation_calibration_target": False,
+        "fruit_diameter_model_promotion_target": False,
+        "shipped_TOMICS_incumbent_changed": False,
+        "production_export_completed": True,
+        "production_ready_for_latent_allocation": True,
+        "row_cap_applied": False,
+        "chunk_aggregation_used": True,
+        "latent_allocation_inference_run": False,
+        "harvest_family_factorial_run": False,
+        "promotion_gate_run": False,
+        "direct_dry_yield_measured": False,
+        "dry_yield_is_dmc_estimated": True,
+    }
+
+    audit = metadata_contract_audit(metadata)
+    assert audit["status"].tolist() == ["pass", "pass"]
+    assert metadata["direct_dry_yield_measured"] is False
+    assert metadata["dry_yield_is_dmc_estimated"] is True
+    assert metadata["latent_allocation_inference_run"] is False

--- a/tests/test_tomics_haf_production_metadata_contract.py
+++ b/tests/test_tomics_haf_production_metadata_contract.py
@@ -149,6 +149,13 @@ def test_production_and_smoke_metadata_contracts(tmp_path: Path) -> None:
     assert production["fruit_diameter_p_values_allowed"] is False
     assert production["fruit_diameter_allocation_calibration_target"] is False
     assert production["fruit_diameter_model_promotion_target"] is False
+    assert production["canonical_fruit_DMC_fraction"] == 0.056
+    assert production["fruit_DMC_fraction"] == 0.056
+    assert production["default_fruit_dry_matter_content"] == 0.056
+    assert production["DMC_fixed_for_2025_2C"] is True
+    assert production["DMC_sensitivity_enabled"] is False
+    assert production["DMC_sensitivity_values"] == []
+    assert production["deprecated_previous_default_fruit_DMC_fraction"] == 0.065
 
     assert smoke["observer_pipeline_mode"] == "smoke"
     assert smoke["row_cap_applied"] is True

--- a/tests/test_tomics_haf_production_metadata_contract.py
+++ b/tests/test_tomics_haf_production_metadata_contract.py
@@ -153,4 +153,3 @@ def test_production_and_smoke_metadata_contracts(tmp_path: Path) -> None:
     assert smoke["observer_pipeline_mode"] == "smoke"
     assert smoke["row_cap_applied"] is True
     assert smoke["production_ready_for_latent_allocation"] is False
-

--- a/tests/test_tomics_haf_production_metadata_contract.py
+++ b/tests/test_tomics_haf_production_metadata_contract.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import (
+    run_tomics_haf_observer_pipeline,
+)
+
+
+def _write_raw_dat(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                '"TOA5","station","CR1000"',
+                '"TIMESTAMP","RECORD","SolarRad_Avg","LeafTemp1_Avg","LeafTemp2_Avg","Fruit1Diameter_Avg","Fruit2Diameter_Avg"',
+                '"TS","RN","W/m2","Deg C","Deg C","mm","mm"',
+                '"","","Avg","Avg","Avg","Avg","Avg"',
+                '"2025-12-14 06:00:00",1,10,24.0,23.0,30.0,31.0',
+                '"2025-12-14 18:00:00",2,0,22.0,21.0,30.4,31.2',
+                '"2025-12-15 06:00:00",3,10,23.0,22.0,30.7,31.3',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_inputs(raw_root: Path) -> None:
+    raw_root.mkdir()
+    _write_raw_dat(raw_root / "sensor.dat")
+    dataset1 = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-12-14 06:00",
+                    "2025-12-14 06:10",
+                    "2025-12-14 18:00",
+                    "2025-12-14 18:10",
+                ]
+            ),
+            "date": ["2025-12-14"] * 4,
+            "loadcell_id": [1, 1, 4, 4],
+            "sample_id": [1, 1, 4, 4],
+            "treatment": ["Control", "Control", "Drought", "Drought"],
+            "loadcell_weight_kg": [10.0, 9.99, 9.0, 8.99],
+            "env_inside_radiation_wm2": [10.0, 20.0, 0.0, 0.0],
+            "env_vpd_kpa": [2.0] * 4,
+            "env_air_temperature_c": [25.0] * 4,
+            "env_co2_ppm": [400.0] * 4,
+        }
+    )
+    dataset1.to_parquet(raw_root / "dataset1.parquet", index=False)
+    dataset2 = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2025-12-14 00:00", "2025-12-14 00:00"]),
+            "date": ["2025-12-14", "2025-12-14"],
+            "loadcell_id": [1, 4],
+            "sample_id": [1, 4],
+            "treatment": ["Control", "Drought"],
+            "moisture_percent": [80.0, 40.0],
+            "ec_ds": [2.0, 3.0],
+            "tensiometer_hp": [1.0, 2.0],
+        }
+    )
+    dataset2.to_parquet(raw_root / "dataset2.parquet", index=False)
+    pd.DataFrame({"loadcell_id": [1], "treatment": ["Control"], "stem_diameter": [9.0]}).to_parquet(
+        raw_root / "dataset3.parquet",
+        index=False,
+    )
+
+
+def _write_mapping(path: Path) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "timestamp_col": "TIMESTAMP",
+                "leaf_sensor_map": {
+                    "LeafTemp1_Avg": {"loadcell_id": 4, "treatment": "Drought", "mapping_status": "confirmed_by_user"},
+                    "LeafTemp2_Avg": {"loadcell_id": 1, "treatment": "Control", "mapping_status": "confirmed_by_user"},
+                },
+                "fruit_sensor_map": {
+                    "Fruit1Diameter_Avg": {"loadcell_id": 4, "treatment": "Drought", "mapping_status": "provisional"},
+                    "Fruit2Diameter_Avg": {"loadcell_id": 1, "treatment": "Control", "mapping_status": "provisional"},
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_config(tmp_path: Path, *, mode: str, output_root: str, dataset1_cap: int | None) -> Path:
+    config_path = tmp_path / f"{mode}.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "paths": {"repo_root": str(tmp_path)},
+                "tomics_haf": {
+                    "raw_data_root": "raw",
+                    "output_root": output_root,
+                    "sensor_mapping_path": str(tmp_path / "mapping.yaml"),
+                    "input_files": {
+                        "fruit_leaf_temperature_solar_raw_dat": "sensor.dat",
+                        "dataset1": "dataset1.parquet",
+                        "dataset2": "dataset2.parquet",
+                        "dataset3": "dataset3.parquet",
+                    },
+                },
+                "observer_pipeline": {
+                    "mode": mode,
+                    "parquet_batch_size": 2,
+                    "max_full_rows_without_limit": 1000,
+                    "max_rows": {
+                        "dataset1": dataset1_cap,
+                        "dataset2": None,
+                        "dataset3": None,
+                    },
+                    "write_intermediate_chunk_manifests": mode == "production",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_production_and_smoke_metadata_contracts(tmp_path: Path) -> None:
+    _write_inputs(tmp_path / "raw")
+    _write_mapping(tmp_path / "mapping.yaml")
+
+    production = run_tomics_haf_observer_pipeline(
+        _write_config(tmp_path, mode="production", output_root="out_production", dataset1_cap=None)
+    )["metadata"]
+    smoke = run_tomics_haf_observer_pipeline(
+        _write_config(tmp_path, mode="smoke", output_root="out_smoke", dataset1_cap=2)
+    )["metadata"]
+
+    assert production["observer_pipeline_mode"] == "production"
+    assert production["chunk_aggregation_used"] is True
+    assert production["row_cap_applied"] is False
+    assert production["dataset1_rows_processed_fraction"] == 1.0
+    assert production["dataset2_rows_processed_fraction"] == 1.0
+    assert production["production_ready_for_latent_allocation"] is True
+    assert production["latent_allocation_inference_run"] is False
+    assert production["harvest_family_factorial_run"] is False
+    assert production["promotion_gate_run"] is False
+    assert production["shipped_TOMICS_incumbent_changed"] is False
+    assert production["fruit_diameter_p_values_allowed"] is False
+    assert production["fruit_diameter_allocation_calibration_target"] is False
+    assert production["fruit_diameter_model_promotion_target"] is False
+
+    assert smoke["observer_pipeline_mode"] == "smoke"
+    assert smoke["row_cap_applied"] is True
+    assert smoke["production_ready_for_latent_allocation"] is False
+

--- a/tests/test_tomics_haf_production_observer_export.py
+++ b/tests/test_tomics_haf_production_observer_export.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import DATASET1_COLUMN_CANDIDATES
+from stomatal_optimiaztion.domains.tomato.tomics.observers.production_export import (
+    aggregate_dataset1_streaming,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import build_radiation_intervals
+
+
+def test_chunked_dataset1_interval_aggregation_matches_non_chunked(tmp_path: Path) -> None:
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-12-14 06:00:00",
+                    "2025-12-14 06:03:00",
+                    "2025-12-14 06:10:00",
+                    "2025-12-14 06:11:00",
+                ]
+            ),
+            "date": ["2025-12-14"] * 4,
+            "loadcell_id": [1, 1, 1, 1],
+            "sample_id": [1, 1, 1, 1],
+            "treatment": ["Control"] * 4,
+            "loadcell_weight_kg": [10.0, 9.99, 9.98, 9.97],
+            "env_inside_radiation_wm2": [0.0, 0.5, 0.0, 5.0],
+            "env_vpd_kpa": [2.0, 2.0, 3.0, 3.0],
+            "env_air_temperature_c": [25.0] * 4,
+            "env_co2_ppm": [400.0] * 4,
+        }
+    )
+    path = tmp_path / "dataset1.parquet"
+    frame.to_parquet(path, index=False)
+
+    chunked, _, meta, _ = aggregate_dataset1_streaming(
+        path=path,
+        columns=DATASET1_COLUMN_CANDIDATES,
+        batch_size=2,
+        max_rows=None,
+        thresholds_w_m2=[0, 5],
+    )
+    non_chunked = build_radiation_intervals(frame, thresholds_w_m2=[0, 5])
+
+    chunked_main = chunked[chunked["threshold_w_m2"].eq(0.0)].sort_values("interval_start").reset_index(drop=True)
+    non_chunked_main = non_chunked[non_chunked["threshold_w_m2"].eq(0.0)].sort_values("interval_start").reset_index(
+        drop=True
+    )
+
+    assert chunked_main["radiation_phase"].tolist() == non_chunked_main["radiation_phase"].tolist()
+    assert chunked[chunked["threshold_w_m2"].eq(5.0)]["radiation_phase"].tolist() == ["night", "night"]
+    assert meta["chunk_aggregation_used"] is True
+    assert meta["rows_processed_fraction"] == 1.0
+

--- a/tests/test_tomics_haf_production_observer_export.py
+++ b/tests/test_tomics_haf_production_observer_export.py
@@ -6,6 +6,8 @@ from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import DATA
 from stomatal_optimiaztion.domains.tomato.tomics.observers.production_export import (
     aggregate_dataset1_streaming,
 )
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import _dataset3_size_guard
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import _assert_dataset3_size_guard_before_read
 from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import build_radiation_intervals
 
 
@@ -53,3 +55,32 @@ def test_chunked_dataset1_interval_aggregation_matches_non_chunked(tmp_path: Pat
     assert meta["chunk_aggregation_used"] is True
     assert meta["rows_processed_fraction"] == 1.0
 
+
+def test_dataset3_size_guard_records_small_full_read_reason() -> None:
+    metadata = _dataset3_size_guard(
+        {"total_rows": 252, "rows_processed": 252, "row_limit_applied": False},
+        max_full_rows_without_limit=2_000_000,
+        mode="production",
+    )
+
+    assert metadata["dataset3_total_rows"] == 252
+    assert metadata["dataset3_rows_processed"] == 252
+    assert metadata["dataset3_size_guard_passed"] is True
+    assert metadata["dataset3_full_in_memory_allowed_reason"] == "small_dataset3_within_max_full_rows_without_limit"
+
+
+def test_dataset3_size_guard_fails_before_large_production_full_read(tmp_path: Path) -> None:
+    path = tmp_path / "dataset3.parquet"
+    pd.DataFrame({"loadcell_id": [1, 2, 3]}).to_parquet(path, index=False)
+
+    try:
+        _assert_dataset3_size_guard_before_read(
+            path=path,
+            max_rows=None,
+            max_full_rows_without_limit=2,
+            mode="production",
+        )
+    except RuntimeError as exc:
+        assert "before full read" in str(exc)
+    else:  # pragma: no cover - keeps the assertion message explicit
+        raise AssertionError("Expected Dataset3 pre-read size guard to fail.")

--- a/tests/test_tomics_haf_qc.py
+++ b/tests/test_tomics_haf_qc.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.qc import apply_fruit_leaf_qc
+
+
+def test_fruit_diameter_qc_range_and_jump_rules() -> None:
+    frame = pd.DataFrame(
+        {
+            "TIMESTAMP": pd.date_range("2025-12-14 06:00", periods=5, freq="10min"),
+            "Fruit1Diameter_Avg": [30.0, 30.3, 121.0, 31.0, 33.0],
+            "LeafTemp1_Avg": [22.0, 22.1, 22.2, 22.3, 22.4],
+        }
+    )
+
+    qc, report = apply_fruit_leaf_qc(
+        frame,
+        fruit_columns=["Fruit1Diameter_Avg"],
+        leaf_columns=["LeafTemp1_Avg"],
+    )
+
+    assert qc.loc[2, "Fruit1Diameter_Avg_qc_reason"] == "outside_20_120_mm"
+    assert qc.loc[4, "Fruit1Diameter_Avg_qc_reason"] == "jump_gt_1_mm"
+    fruit_report = report[report["sensor_column"].eq("Fruit1Diameter_Avg")].iloc[0]
+    assert bool(fruit_report["insufficient_valid_points"]) is True

--- a/tests/test_tomics_haf_radiation_decision_control.py
+++ b/tests/test_tomics_haf_radiation_decision_control.py
@@ -1,0 +1,39 @@
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.pipeline import _radiation_column_for_pipeline
+
+
+def test_pipeline_accepts_dataset1_radiation_selected_for_10min_daynight() -> None:
+    assert (
+        _radiation_column_for_pipeline(
+            {
+                "radiation_daynight_primary_source": "dataset1",
+                "radiation_column_used": "env_inside_radiation_wm2",
+                "selected_for_daynight_10min": True,
+            }
+        )
+        == "env_inside_radiation_wm2"
+    )
+
+
+def test_pipeline_rejects_daily_only_radiation_for_10min_daynight() -> None:
+    with pytest.raises(RuntimeError, match="No radiation source is selected"):
+        _radiation_column_for_pipeline(
+            {
+                "radiation_daynight_primary_source": "",
+                "radiation_column_used": "",
+                "selected_for_daynight_10min": False,
+                "selected_for_daily_summary_only": True,
+            }
+        )
+
+
+def test_pipeline_rejects_non_dataset1_primary_for_canonical_observer_export() -> None:
+    with pytest.raises(RuntimeError, match="requires Dataset1 radiation"):
+        _radiation_column_for_pipeline(
+            {
+                "radiation_daynight_primary_source": "fruit_leaf_temperature_solar_raw_dat",
+                "radiation_column_used": "SolarRad_Avg",
+                "selected_for_daynight_10min": True,
+            }
+        )

--- a/tests/test_tomics_haf_radiation_source_selection.py
+++ b/tests/test_tomics_haf_radiation_source_selection.py
@@ -72,7 +72,7 @@ def test_dataset1_daily_only_radiation_is_not_usable_for_10min_and_raw_dat_is_fa
         },
     )
 
-    chosen = [row for row in rows if row["chosen_primary"]][0]
+    chosen = [row for row in rows if row["selected_for_daily_summary_only"]][0]
     raw_candidate = [
         row
         for row in rows
@@ -80,8 +80,11 @@ def test_dataset1_daily_only_radiation_is_not_usable_for_10min_and_raw_dat_is_fa
         and row["candidate_column"] == "SolarRad_Avg"
     ][0]
     assert chosen["candidate_column"] == "env_inside_radiation_wm2"
+    assert chosen["chosen_primary"] is False
+    assert chosen["selected_for_daynight_10min"] is False
     assert chosen["usable_for_10min_daynight"] is False
     assert chosen["usable_for_daily_summary_only"] is True
+    assert chosen["candidate_rejection_reason"] == "daily_only_not_valid_for_10min_daynight"
     assert metadata["dataset1_radiation_directly_usable"] is False
     assert metadata["dataset1_radiation_grain"] == "daily_only"
     assert metadata["radiation_daynight_primary_source"] == ""

--- a/tests/test_tomics_haf_radiation_source_selection.py
+++ b/tests/test_tomics_haf_radiation_source_selection.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_source import (
+    build_radiation_source_verification,
+)
+
+
+def _audit_row(*, filename: str, resolution: float) -> dict[str, object]:
+    return {
+        "expected_filename": filename,
+        "date_min": "2025-09-01T00:00:00",
+        "date_max": "2025-09-01T00:20:00",
+        "inferred_time_resolution_seconds": resolution,
+    }
+
+
+def test_dataset1_inside_radiation_is_selected_over_lower_ranked_fallbacks() -> None:
+    dataset1 = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=3, freq="10min"),
+            "env_inside_radiation_wm2": [0.0, 50.0, 0.0],
+            "env_radiation_wm2": [0.0, 80.0, 0.0],
+            "env_outside_radiation_wm2": [0.0, 120.0, 0.0],
+        }
+    )
+    raw_dat = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=3, freq="10min"),
+            "SolarRad_Avg": [0.0, 200.0, 0.0],
+        }
+    )
+
+    rows, metadata = build_radiation_source_verification(
+        {"dataset1": dataset1, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
+        {
+            "dataset1": _audit_row(filename="dataset1.parquet", resolution=600),
+            "fruit_leaf_temperature_solar_raw_dat": _audit_row(filename="raw.dat", resolution=600),
+        },
+    )
+
+    chosen = [row for row in rows if row["chosen_primary"]]
+    assert len(chosen) == 1
+    assert chosen[0]["source_file_role"] == "dataset1"
+    assert chosen[0]["candidate_column"] == "env_inside_radiation_wm2"
+    assert metadata["dataset1_radiation_directly_usable"] is True
+    assert metadata["fallback_required"] is False
+    assert metadata["fixed_clock_daynight_primary"] is False
+
+
+def test_dataset1_daily_only_radiation_is_not_usable_for_10min_and_raw_dat_is_fallback() -> None:
+    dataset1 = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-09-01", "2025-09-02"]),
+            "env_inside_radiation_wm2": [120.0, 80.0],
+            "env_radiation_wm2_mean": [118.0, 79.0],
+        }
+    )
+    raw_dat = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=3, freq="10min"),
+            "SolarRad_Avg": [0.0, 250.0, 0.0],
+        }
+    )
+
+    rows, metadata = build_radiation_source_verification(
+        {"dataset1": dataset1, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
+        {
+            "dataset1": _audit_row(filename="dataset1.parquet", resolution=86_400),
+            "fruit_leaf_temperature_solar_raw_dat": _audit_row(filename="raw.dat", resolution=600),
+        },
+    )
+
+    chosen = [row for row in rows if row["chosen_primary"]][0]
+    raw_candidate = [
+        row
+        for row in rows
+        if row["source_file_role"] == "fruit_leaf_temperature_solar_raw_dat"
+        and row["candidate_column"] == "SolarRad_Avg"
+    ][0]
+    assert chosen["candidate_column"] == "env_inside_radiation_wm2"
+    assert chosen["usable_for_10min_daynight"] is False
+    assert chosen["usable_for_daily_summary_only"] is True
+    assert metadata["dataset1_radiation_directly_usable"] is False
+    assert metadata["dataset1_radiation_grain"] == "daily_only"
+    assert metadata["radiation_daynight_primary_source"] == ""
+    assert metadata["radiation_column_used"] == ""
+    assert metadata["fallback_required"] is True
+    assert metadata["fallback_source_if_required"] == "fruit_leaf_temperature_solar_raw_dat:SolarRad_Avg"
+    assert raw_candidate["fallback_reason"] == "10min_daynight_candidate_if_primary_is_daily_or_unusable"
+
+
+def test_raw_dat_remains_fallback_only_when_dataset1_radiation_is_missing() -> None:
+    dataset1 = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=3, freq="10min"),
+            "env_vpd_kpa": [0.5, 0.8, 0.6],
+        }
+    )
+    raw_dat = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-09-01", periods=3, freq="10min"),
+            "SolarRad_Avg": [0.0, 250.0, 0.0],
+        }
+    )
+
+    rows, metadata = build_radiation_source_verification(
+        {"dataset1": dataset1, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
+        {
+            "dataset1": _audit_row(filename="dataset1.parquet", resolution=600),
+            "fruit_leaf_temperature_solar_raw_dat": _audit_row(filename="raw.dat", resolution=600),
+        },
+    )
+
+    raw_candidate = [
+        row
+        for row in rows
+        if row["source_file_role"] == "fruit_leaf_temperature_solar_raw_dat"
+        and row["candidate_column"] == "SolarRad_Avg"
+    ][0]
+    assert [row for row in rows if row["chosen_primary"]] == []
+    assert raw_candidate["chosen_primary"] is False
+    assert metadata["radiation_daynight_primary_source"] == ""
+    assert metadata["radiation_column_used"] == ""
+    assert metadata["dataset1_radiation_directly_usable"] is False
+    assert metadata["fallback_required"] is True
+    assert metadata["fallback_source_if_required"] == "fruit_leaf_temperature_solar_raw_dat:SolarRad_Avg"
+
+
+def test_raw_dat_is_not_primary_when_dataset1_inside_radiation_is_usable() -> None:
+    dataset1 = pd.DataFrame({"env_inside_radiation_wm2": [0.0, 1.0]})
+    raw_dat = pd.DataFrame({"SolarRad_Avg": [0.0, 1000.0]})
+
+    rows, metadata = build_radiation_source_verification(
+        {"dataset1": dataset1, "fruit_leaf_temperature_solar_raw_dat": raw_dat},
+        {
+            "dataset1": _audit_row(filename="dataset1.parquet", resolution=600),
+            "fruit_leaf_temperature_solar_raw_dat": _audit_row(filename="raw.dat", resolution=600),
+        },
+    )
+
+    raw_candidate = [
+        row
+        for row in rows
+        if row["source_file_role"] == "fruit_leaf_temperature_solar_raw_dat"
+        and row["candidate_column"] == "SolarRad_Avg"
+    ][0]
+    assert metadata["radiation_column_used"] == "env_inside_radiation_wm2"
+    assert raw_candidate["chosen_primary"] is False

--- a/tests/test_tomics_haf_radiation_windows.py
+++ b/tests/test_tomics_haf_radiation_windows.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import (
+    add_clock_compatibility_audit,
+    build_photoperiod_table,
+    build_radiation_intervals,
+)
+
+
+def test_radiation_thresholds_define_day_not_clock() -> None:
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2025-12-14 05:59:00",
+                    "2025-12-14 06:01:00",
+                    "2025-12-14 06:11:00",
+                    "2025-12-14 18:01:00",
+                ]
+            ),
+            "loadcell_id": [1, 1, 1, 1],
+            "treatment": ["Control"] * 4,
+            "env_inside_radiation_wm2": [0.0, 0.5, 6.0, 0.0],
+        }
+    )
+
+    intervals = build_radiation_intervals(frame)
+    main = intervals[intervals["threshold_w_m2"].eq(0.0)]
+    threshold_5 = intervals[intervals["threshold_w_m2"].eq(5.0)]
+    photoperiod = build_photoperiod_table(intervals)
+    clock = add_clock_compatibility_audit(frame.rename(columns={"timestamp": "TIMESTAMP"}))
+
+    assert main[main["interval_start"].eq(pd.Timestamp("2025-12-14 06:00"))]["radiation_phase"].iloc[0] == "day"
+    assert threshold_5[threshold_5["interval_start"].eq(pd.Timestamp("2025-12-14 06:00"))]["radiation_phase"].iloc[0] == "night"
+    assert photoperiod["radiation_column_used"].eq("env_inside_radiation_wm2").all()
+    assert clock["fixed_clock_daynight_primary"].eq(False).all()
+

--- a/tests/test_tomics_haf_radiation_windows.py
+++ b/tests/test_tomics_haf_radiation_windows.py
@@ -3,6 +3,7 @@ import pandas as pd
 from stomatal_optimiaztion.domains.tomato.tomics.observers.radiation_windows import (
     add_clock_compatibility_audit,
     build_photoperiod_table,
+    build_radiation_daily_summary,
     build_radiation_intervals,
 )
 
@@ -35,3 +36,20 @@ def test_radiation_thresholds_define_day_not_clock() -> None:
     assert photoperiod["radiation_column_used"].eq("env_inside_radiation_wm2").all()
     assert clock["fixed_clock_daynight_primary"].eq(False).all()
 
+
+def test_radiation_summary_uses_interval_provenance_not_global_default() -> None:
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2025-12-14 06:00:00", "2025-12-14 18:00:00"]),
+            "loadcell_id": [1, 1],
+            "treatment": ["Control", "Control"],
+            "env_radiation_wm2": [100.0, 0.0],
+        }
+    )
+
+    intervals = build_radiation_intervals(frame, radiation_col="env_radiation_wm2")
+    photoperiod = build_photoperiod_table(intervals)
+    daily = build_radiation_daily_summary(intervals)
+
+    assert photoperiod["radiation_column_used"].eq("env_radiation_wm2").all()
+    assert daily["radiation_column_used"].eq("env_radiation_wm2").all()

--- a/tests/test_tomics_haf_rootzone_dataset1_dataset2_reference.py
+++ b/tests/test_tomics_haf_rootzone_dataset1_dataset2_reference.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.rootzone_indices import build_rootzone_indices
+
+
+def test_dataset1_moisture_reference_drives_rzi_while_dataset2_tensiometer_is_drought_only() -> None:
+    dataset1_reference = pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-14", "2025-12-14", "2025-12-14"],
+            "loadcell_id": [1, 2, 4, 5],
+            "treatment": ["Control", "Control", "Drought", "Drought"],
+            "moisture_percent": [80.0, 82.0, 40.0, 42.0],
+            "ec_ds": [2.0, 2.1, 2.8, 2.9],
+        }
+    )
+    dataset2 = pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-14"],
+            "loadcell_id": [4, 5],
+            "treatment": ["Drought", "Drought"],
+            "moisture_percent": [39.0, 41.0],
+            "ec_ds": [2.7, 2.8],
+            "tensiometer_hp": [-20.0, -22.0],
+        }
+    )
+
+    rootzone = build_rootzone_indices(dataset2, dataset1_reference_frame=dataset1_reference)
+    drought_lc4 = rootzone[rootzone["loadcell_id"].eq(4)].iloc[0]
+
+    assert bool(drought_lc4["RZI_main_available"]) is True
+    assert drought_lc4["RZI_main_source"] == "theta_paired_lc4_vs_lc1"
+    assert drought_lc4["RZI_main"] > 0
+    assert drought_lc4["RZI_control_reference_source"] == "dataset1_moisture_lc1_lc6"
+    assert bool(drought_lc4["Dataset2_tensiometer_drought_only"]) is True
+    assert bool(drought_lc4["tensiometer_extrapolated_to_all_loadcells"]) is False

--- a/tests/test_tomics_haf_rootzone_indices.py
+++ b/tests/test_tomics_haf_rootzone_indices.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.rootzone_indices import build_rootzone_indices
+
+
+def test_rzi_sign_and_apparent_conductance_direction() -> None:
+    dataset2 = pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-14"],
+            "loadcell_id": [1, 4],
+            "treatment": ["Control", "Drought"],
+            "moisture_percent": [80.0, 40.0],
+            "ec_ds": [2.0, 3.0],
+            "tensiometer_hp": [1.0, 2.0],
+        }
+    )
+    daily_et = pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-14"],
+            "loadcell_id": [1, 4],
+            "treatment": ["Control", "Drought"],
+            "radiation_total_ET_g": [20.0, 10.0],
+            "env_vpd_kpa_mean": [2.0, 2.0],
+        }
+    )
+
+    rootzone = build_rootzone_indices(dataset2, daily_et)
+    drought = rootzone[rootzone["loadcell_id"].eq(4)].iloc[0]
+
+    assert drought["RZI_theta_paired"] > 0
+    assert drought["RZI_theta_paired"] == 0.50000000000625
+    assert drought["apparent_canopy_conductance"] == pytest.approx(5.0)

--- a/tests/test_tomics_haf_schema_alias_backfill.py
+++ b/tests/test_tomics_haf_schema_alias_backfill.py
@@ -1,0 +1,31 @@
+from stomatal_optimiaztion.domains.tomato.tomics.observers.input_schema_audit import match_semantic_roles
+
+
+def test_actual_observer_columns_are_mapped_to_semantic_roles() -> None:
+    matched = match_semantic_roles(
+        [
+            "moisture_percent",
+            "ec_ds",
+            "tensiometer_hp",
+            "flower_cluster_no",
+            "loadcell_daily_yield_g",
+            "final_dry_yield_g_est_5p6pct",
+            "loadcell_daily_dry_yield_g_est_default_5p6pct",
+        ]
+    )
+
+    assert matched["moisture"] == ["moisture_percent"]
+    assert matched["ec"] == ["ec_ds"]
+    assert matched["tensiometer"] == ["tensiometer_hp"]
+    assert matched["truss_position"] == ["flower_cluster_no"]
+    assert "loadcell_daily_yield_g" in matched["yield_fresh"]
+    assert "final_dry_yield_g_est_5p6pct" in matched["estimated_dry_yield_from_dmc"]
+    assert "loadcell_daily_dry_yield_g_est_default_5p6pct" in matched["estimated_dry_yield_from_dmc"]
+    assert "direct_dry_yield_measured" not in matched
+
+
+def test_measured_and_dmc_estimated_dry_yield_aliases_are_distinct() -> None:
+    matched = match_semantic_roles(["yield_dry_g", "final_dry_yield_g_est_5p6pct"])
+
+    assert matched["direct_dry_yield_measured"] == ["yield_dry_g"]
+    assert matched["estimated_dry_yield_from_dmc"] == ["final_dry_yield_g_est_5p6pct"]

--- a/tests/test_tomics_haf_sensor_mapping_2025_2c.py
+++ b/tests/test_tomics_haf_sensor_mapping_2025_2c.py
@@ -17,4 +17,3 @@ def test_2025_2c_sensor_mapping_contract() -> None:
     policy = fruit_diameter_policy_metadata(mapping)
     assert policy["fruit_diameter_p_values_allowed"] is False
     assert policy["fruit_diameter_allocation_calibration_target"] is False
-

--- a/tests/test_tomics_haf_sensor_mapping_2025_2c.py
+++ b/tests/test_tomics_haf_sensor_mapping_2025_2c.py
@@ -1,0 +1,20 @@
+from stomatal_optimiaztion.domains.tomato.tomics.observers.sensor_mapping import (
+    fruit_diameter_policy_metadata,
+    load_sensor_mapping,
+)
+
+
+def test_2025_2c_sensor_mapping_contract() -> None:
+    mapping = load_sensor_mapping()
+
+    assert mapping["leaf_sensor_map"]["LeafTemp1_Avg"]["loadcell_id"] == 4
+    assert mapping["leaf_sensor_map"]["LeafTemp1_Avg"]["treatment"] == "Drought"
+    assert mapping["leaf_sensor_map"]["LeafTemp2_Avg"]["loadcell_id"] == 1
+    assert mapping["leaf_sensor_map"]["LeafTemp2_Avg"]["treatment"] == "Control"
+    assert mapping["fruit_sensor_map"]["Fruit1Diameter_Avg"]["mapping_status"] == "provisional"
+    assert mapping["fruit_sensor_map"]["Fruit2Diameter_Avg"]["loadcell_id"] == 1
+
+    policy = fruit_diameter_policy_metadata(mapping)
+    assert policy["fruit_diameter_p_values_allowed"] is False
+    assert policy["fruit_diameter_allocation_calibration_target"] is False
+

--- a/tests/test_tomics_haf_stage_metadata_snapshots.py
+++ b/tests/test_tomics_haf_stage_metadata_snapshots.py
@@ -1,0 +1,31 @@
+import json
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import (
+    json_has_case_insensitive_duplicate_keys,
+    write_stage_metadata_snapshot,
+)
+
+
+def test_stage_metadata_snapshot_is_normalized_and_keeps_legacy_keys_nested(tmp_path) -> None:
+    snapshot = tmp_path / "metadata_goal2_5_production_observer.json"
+    write_stage_metadata_snapshot(
+        snapshot,
+        {
+            "LAI_available": False,
+            "lai_available": False,
+            "VPD_available": True,
+            "vpd_available": True,
+            "Dataset3_mapping_confidence": "direct_loadcell_no_date",
+            "dataset3_mapping": "direct_loadcell",
+            "fruit_diameter_p_values_allowed": False,
+            "fruit_diameter_allocation_calibration_target": False,
+            "fruit_diameter_model_promotion_target": False,
+            "shipped_TOMICS_incumbent_changed": False,
+        },
+    )
+
+    data = json.loads(snapshot.read_text(encoding="utf-8"))
+    assert json_has_case_insensitive_duplicate_keys(snapshot) is False
+    assert "lai_available" not in data
+    assert "vpd_available" not in data
+    assert data["legacy_metadata"]["dataset3_mapping"] == "direct_loadcell"

--- a/tests/test_tomics_haf_toa5_parser.py
+++ b/tests/test_tomics_haf_toa5_parser.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.toa5_parser import read_toa5_dat
+
+
+def test_toa5_parser_handles_quoted_headers_and_units(tmp_path: Path) -> None:
+    path = tmp_path / "sensor.dat"
+    path.write_text(
+        "\n".join(
+            [
+                '"TOA5","station","CR1000"',
+                '"TIMESTAMP","RECORD","SolarRad_Avg","LeafTemp1_Avg","Fruit1Diameter_Avg"',
+                '"TS","RN","W/m2","Deg C","mm"',
+                '"","","Avg","Avg","Avg"',
+                '"2025-12-14 06:00:00",1,0,22.5,30.0',
+                '"2025-12-14 06:10:00",2,15,23.0,30.2',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    frame = read_toa5_dat(path)
+
+    assert list(frame.columns) == ["TIMESTAMP", "RECORD", "SolarRad_Avg", "LeafTemp1_Avg", "Fruit1Diameter_Avg"]
+    assert frame["TIMESTAMP"].notna().all()
+    assert frame["SolarRad_Avg"].tolist() == [0, 15]
+

--- a/tests/test_tomics_haf_toa5_parser.py
+++ b/tests/test_tomics_haf_toa5_parser.py
@@ -24,4 +24,3 @@ def test_toa5_parser_handles_quoted_headers_and_units(tmp_path: Path) -> None:
     assert list(frame.columns) == ["TIMESTAMP", "RECORD", "SolarRad_Avg", "LeafTemp1_Avg", "Fruit1Diameter_Avg"]
     assert frame["TIMESTAMP"].notna().all()
     assert frame["SolarRad_Avg"].tolist() == [0, 15]
-

--- a/tests/test_tomics_haf_yield_bridge_dmc_0p056.py
+++ b/tests/test_tomics_haf_yield_bridge_dmc_0p056.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.legacy_v1_3_bridge import legacy_v1_3_config
+from stomatal_optimiaztion.domains.tomato.tomics.observers.yield_bridge import load_legacy_yield_bridge
+
+
+def test_legacy_5p6_columns_map_to_canonical_dmc_outputs_and_6p5_stays_legacy(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    source = archive / "outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2025-12-14"],
+            "loadcell_id": [4],
+            "treatment": ["Drought"],
+            "loadcell_daily_yield_g": [1000.0],
+            "loadcell_daily_dry_yield_g_est_default_5p6pct": [56.0],
+            "loadcell_daily_dry_yield_g_est_6p5pct": [65.0],
+        }
+    ).to_csv(source, index=False)
+    config = legacy_v1_3_config(
+        {
+            "legacy_v1_3": {
+                "enabled": True,
+                "archive_root": str(archive),
+                "allow_legacy_yield_bridge": True,
+                "direct_dry_yield_measured": False,
+            }
+        },
+        repo_root=tmp_path,
+    )
+
+    bridge, _audit, metadata = load_legacy_yield_bridge(config)
+
+    assert bridge["observed_fruit_FW_g_loadcell"].iloc[0] == 1000.0
+    assert bridge["observed_fruit_DW_g_loadcell_dmc_0p056"].iloc[0] == 56.0
+    assert bridge["fresh_yield_source"].iloc[0] == str(source)
+    assert metadata["canonical_fruit_DMC_fraction"] == 0.056
+    assert metadata["DMC_sensitivity_enabled"] is False
+    assert "loadcell_daily_dry_yield_g_est_6p5pct" in metadata["legacy_sensitivity_columns_present"]
+    assert "dmc_0p065" not in bridge.columns
+
+
+def test_canonical_dry_column_fills_rows_with_missing_fresh_yield(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    source = archive / "outputs/derived/integrated_daily_master_radiation_daynight_fresh_dry.csv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2025-12-14", "2025-12-15"],
+            "loadcell_id": [4, 4],
+            "treatment": ["Drought", "Drought"],
+            "loadcell_daily_yield_g": [1000.0, pd.NA],
+            "loadcell_daily_dry_yield_g_est_default_5p6pct": [56.0, 28.0],
+        }
+    ).to_csv(source, index=False)
+    config = legacy_v1_3_config(
+        {
+            "legacy_v1_3": {
+                "enabled": True,
+                "archive_root": str(archive),
+                "allow_legacy_yield_bridge": True,
+                "direct_dry_yield_measured": False,
+            }
+        },
+        repo_root=tmp_path,
+    )
+
+    bridge, _audit, metadata = load_legacy_yield_bridge(config)
+
+    assert bridge["observed_fruit_FW_g_loadcell"].tolist() == [1000.0, 500.0]
+    assert bridge["observed_fruit_DW_g_loadcell_dmc_0p056"].tolist() == [56.0, 28.0]
+    assert bridge["dry_yield_source"].tolist() == [
+        "fresh_yield_times_canonical_DMC_0p056",
+        "legacy_canonical_DMC_0p056_column",
+    ]
+    assert bridge["fresh_yield_source"].tolist() == [str(source), ""]
+    assert metadata["dry_yield_source"] == "fresh_yield_times_canonical_DMC_0p056"


### PR DESCRIPTION
# PR 309 Goal 2.5 + Goal 3A.5 Observer Hardening Summary

Closes #308

## Summary

- Preserves the original #308 daily-harvest diagnostic commit.
- Adds the TOMICS-HAF 2025-2C observer pipeline.
- Adds production-ready chunk aggregation for full Dataset1/Dataset2 observer export.
- Adds Goal 3A.5 observer hardening before harvest-family evaluation.
- Keeps Dataset1 `env_inside_radiation_wm2` radiation-defined day/night as primary.
- Keeps fixed `06:00-18:00` windows compatibility-only.
- Keeps raw `.dat` `SolarRad_Avg` fallback-only for 2025-2C.
- Keeps fruit diameter sensor-level apparent expansion diagnostics only.
- Keeps shipped TOMICS incumbent unchanged.
- Does not run latent allocation, harvest-family factorial, cross-dataset gate, or promotion gate on this PR.

## Goal 3A.5 Observer Hardening

- Backfills observer/schema aliases for actual HAF columns: `moisture_percent`, `ec_ds`, `tensiometer_hp`, `flower_cluster_no`, fresh-yield columns, and DMC-estimated dry-yield columns.
- Adds canonical metadata normalization with no case-insensitive top-level key collisions.
- Adds stage metadata snapshots for schema/radiation, observer, and production observer stages.
- Enforces production hard requirements for chunk aggregation, full Dataset1/Dataset2 processing, row-cap absence, and no large full in-memory load.
- Adds a Dataset3 size guard before full read.
- Uses Dataset1 LC1-LC6 moisture as the RZI control/drought reference when available; Dataset2 LC4/LC5 tensiometer remains drought-only diagnostic support.
- Adds legacy v1.3 event bridge audit/calibration with provenance `legacy_v1_3_derived_output`.
- Adds legacy fresh/dry yield bridge with DMC provenance; DMC dry yield is estimated, not direct destructive dry-mass measurement.
- Adds radiation decision control so interval, photoperiod, and daily summaries carry the selected radiation provenance.
- No `out/` or `artifacts/` files are committed.

## Production Export

- `observer_pipeline_mode = production`.
- `production_export_completed = true`.
- `production_ready_for_latent_allocation = true`.
- `row_cap_applied = false`.
- `chunk_aggregation_used = true`.
- `full_in_memory_large_dataset_used = false`.
- Dataset1 processed: `139,713,462 / 139,713,462` rows.
- Dataset2 processed: `46,571,154 / 46,571,154` rows.
- Dataset3 processed: `252 / 252` rows; size guard passed.
- `RZI_main_available = true`, source `theta_paired_lc4_vs_lc1`, control reference `dataset1_moisture_lc1_lc6`.
- `event_bridged_ET_calibration_status = calibrated_to_legacy_daily_event_total`.
- Legacy event bridge matched rows: `612`; unmatched rows: `0`.
- `fresh_yield_available = true` from legacy v1.3 derived output.
- `dry_yield_available = true`, `dry_yield_is_dmc_estimated = true`, `direct_dry_yield_measured = false`.

## Validation

- Goal 3A.5 observer hardening tests: `16 passed`.
- Existing observer regression tests: `20 passed`.
- Full pytest: `619 passed, 26 skipped, 12 deselected`.
- Ruff: `All checks passed`.
- `git diff --check`: passed with CRLF warnings only.
- Production observer run: succeeded with the full Dataset1/Dataset2 row counts above.

## Safe Interpretation

Goal 2.5 makes the observer feature frame production-ready for later latent allocation; it does not infer allocation.

Legacy v1.3 outputs are provenance-tagged derived outputs, not raw observations.

DMC-derived dry yield is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.

Day/night phases remain radiation-defined from Dataset1 `env_inside_radiation_wm2`, not fixed `06:00-18:00`.

Fruit diameter remains sensor-level apparent expansion diagnostics.

Shipped TOMICS incumbent remains unchanged.

## Unresolved Assumptions

- Fruit1/Fruit2 mapping remains provisional.
- Dataset3 remains `direct_loadcell_no_date` unless verified otherwise.
- Legacy yield and event-bridge inputs are derived-output bridge sources with explicit provenance.
- LAI remains unavailable unless separately verified.
- Harvest-family factorial, cross-dataset gate, and promotion gate remain blocked for later goals.

<!-- goal-3a6-dmc-0p056:start -->
## Goal 3A.6 DMC 0.056 Canonicalization

- Fixes 2025-2C fruit DMC at `0.056` in observer contracts, configs, metadata, and feature-frame yield bridge outputs.
- Disables DMC sensitivity for the current 2025-2C run; prior `0.065` is retained only as `deprecated_previous_default_fruit_DMC_fraction`.
- Keeps dry yield from fresh yield as a DMC-estimated dry-yield basis, not direct destructive dry-mass measurement.
- Preserves legacy v1.3 yield provenance and distinguishes row-level `fresh_yield_times_canonical_DMC_0p056` from dry-only canonical 5.6% legacy columns.
- Regenerated production observer output: Dataset1 `139,713,462 / 139,713,462`, Dataset2 `46,571,154 / 46,571,154`, `row_cap_applied=false`, `production_ready_for_latent_allocation=true`.
- Validation: DMC targeted `5 passed`; observer hardening `16 passed`; observer regression `20 passed`; full pytest `624 passed, 26 skipped, 12 deselected`; Ruff passed; `git diff --check` passed with line-ending warnings only; production observer run exited 0.
- Does not run harvest-family factorial, promotion gate, or cross-dataset gate; shipped TOMICS incumbent remains unchanged.
<!-- goal-3a6-dmc-0p056:end -->
