### PR TITLE
[TOMICS] Add HAF 2025-2C harvest-family evaluation

### DIFF
--- a/configs/exp/tomics_haf_2025_2c_harvest_family_factorial.yaml
+++ b/configs/exp/tomics_haf_2025_2c_harvest_family_factorial.yaml
@@ -1,0 +1,109 @@
+exp:
+  name: tomics_haf_2025_2c_harvest_family_factorial
+
+paths:
+  repo_root: ../..
+
+tomics_haf:
+  season_id: "2025_2C"
+  observer_feature_frame: out/tomics/analysis/haf_2025_2c/2025_2c_tomics_haf_observer_feature_frame.csv
+  observer_metadata: out/tomics/analysis/haf_2025_2c/2025_2c_tomics_haf_metadata.json
+  latent_allocation_posteriors: out/tomics/validation/latent-allocation/haf_2025_2c/latent_allocation_posteriors.csv
+  latent_allocation_metadata: out/tomics/validation/latent-allocation/haf_2025_2c/latent_allocation_metadata.json
+  output_root: out/tomics/validation/harvest-family/haf_2025_2c
+
+observation_operator:
+  family: fresh_to_dry_dmc_0p056
+  inverse_family: dry_to_fresh_dmc_0p056
+  family_set:
+    - fresh_to_dry_dmc_0p056
+    - dry_to_fresh_dmc_0p056
+  canonical_fruit_DMC_fraction: 0.056
+  DMC_fixed_for_2025_2C: true
+  DMC_sensitivity_enabled: false
+  dry_yield_is_dmc_estimated: true
+  direct_dry_yield_measured: false
+  effective_floor_area_per_loadcell_m2: 3.148672656
+  observed_yield_basis: fresh_weight
+  model_yield_basis: dry_weight_floor_area
+
+harvest_family_factorial:
+  mode: staged
+  run_HF0: true
+  run_HF1: true
+  run_HF2: true
+  run_HF3: true
+  run_HF4_budget_parity: true
+  run_HF5_promotion_gate: false
+  run_HF6_oracle_diagnostics: false
+
+  require_budget_parity: true
+  require_mass_balance: true
+  require_by_loadcell_metrics: true
+  require_mean_sd_metrics: true
+  require_observation_operator_dmc_0p056: true
+
+  incumbent:
+    allocator_family: shipped_tomics
+    fruit_harvest_family: tomsim_truss_incumbent
+    leaf_harvest_family: leaf_harvest_tomsim_legacy
+    observation_operator: fresh_to_dry_dmc_0p056
+
+  allocator_families:
+    - shipped_tomics
+    - source_only
+    - hydraulic_only
+    - allocation_only
+    - tomics_haf_latent_allocation_research
+
+  latent_allocation_prior_families:
+    - legacy_tomato_prior
+    - thorp_bounded_prior
+    - tomato_constrained_thorp_prior
+
+  fruit_harvest_families:
+    - tomsim_truss_incumbent
+    - tomgro_ageclass_mature_pool
+    - dekoning_fds_ripe
+    - vanthoor_boxcar_stageflow
+
+  leaf_harvest_families:
+    - leaf_harvest_tomsim_legacy
+    - leaf_harvest_none
+    - leaf_harvest_max_lai
+    - leaf_harvest_vanthoor_mcleafhar
+
+  always_include:
+    fruit_harvest_families:
+      - tomsim_truss_incumbent
+      - dekoning_fds_ripe
+
+  stage_budgets:
+    HF0: none
+    HF1: equal_budget_low
+    HF2: equal_budget_medium
+    HF3: equal_budget_medium
+    HF4: parity_audit_only
+
+  parameter_grid:
+    harvest_delay_days: [0, 1, 2, 3, 5]
+    harvest_readiness_threshold: [0.90, 0.95, 1.00, 1.05]
+    vanthoor_boxcar_n_stages: [4, 5, 6, 7]
+    tomgro_mature_pool_age_class: [last, last_two]
+    fdmc_mode:
+      - constant_0p056
+
+  forbidden:
+    fdmc_mode:
+      - constant_0p065
+      - dmc_sensitivity
+    raw_THORP_allocator: true
+    fruit_diameter_calibration_target: true
+    fruit_diameter_p_values: true
+    fruit_diameter_promotion_target: true
+
+promotion:
+  run_final_promotion_gate: false
+  single_dataset_promotion_allowed: false
+  require_cross_dataset_for_promotion: true
+  write_promotion_prerequisite_summary: true

--- a/configs/plotkit/tomics/haf_2025_2c/harvest_budget_parity.yaml
+++ b/configs/plotkit/tomics/haf_2025_2c/harvest_budget_parity.yaml
@@ -1,0 +1,19 @@
+version: 1
+kind: bar_summary
+meta:
+  id: haf_2025_2c_harvest_budget_parity
+  title: HAF 2025-2C harvest budget parity
+  family: tomics_haf_2025_2c_harvest_family
+  support_level: spec_scaffold
+data:
+  frame_role: harvest_family_budget_parity
+mapping:
+  x_column: budget_parity_group
+  y_column: budget_units_used
+  color_column: allocator_family
+theme:
+  name: phytoritas_legacy_muted_botanical
+  tokens: ../../themes/phytoritas_legacy_muted_botanical_tokens.yaml
+export:
+  formats: [png]
+  dpi: 300

--- a/configs/plotkit/tomics/haf_2025_2c/harvest_family_bias_by_date.yaml
+++ b/configs/plotkit/tomics/haf_2025_2c/harvest_family_bias_by_date.yaml
@@ -1,0 +1,19 @@
+version: 1
+kind: multi_panel_timeseries
+meta:
+  id: haf_2025_2c_harvest_family_bias_by_date
+  title: HAF 2025-2C harvest-family bias by date
+  family: tomics_haf_2025_2c_harvest_family
+  support_level: spec_scaffold
+data:
+  frame_role: harvest_family_cumulative_overlay
+mapping:
+  datetime_column: date
+  source_column: candidate_id
+  value_column: residual_DW_g_m2_floor
+theme:
+  name: phytoritas_legacy_muted_botanical
+  tokens: ../../themes/phytoritas_legacy_muted_botanical_tokens.yaml
+export:
+  formats: [png]
+  dpi: 300

--- a/configs/plotkit/tomics/haf_2025_2c/harvest_family_cumulative_yield_curves.yaml
+++ b/configs/plotkit/tomics/haf_2025_2c/harvest_family_cumulative_yield_curves.yaml
@@ -1,0 +1,19 @@
+version: 1
+kind: multi_panel_timeseries
+meta:
+  id: haf_2025_2c_harvest_family_cumulative_yield_curves
+  title: HAF 2025-2C cumulative yield curves
+  family: tomics_haf_2025_2c_harvest_family
+  support_level: spec_scaffold
+data:
+  frame_role: harvest_family_cumulative_overlay
+mapping:
+  datetime_column: date
+  source_column: candidate_id
+  value_column: model_cumulative_fruit_DW_g_m2_floor
+theme:
+  name: phytoritas_legacy_muted_botanical
+  tokens: ../../themes/phytoritas_legacy_muted_botanical_tokens.yaml
+export:
+  formats: [png]
+  dpi: 300

--- a/configs/plotkit/tomics/haf_2025_2c/harvest_family_performance_matrix.yaml
+++ b/configs/plotkit/tomics/haf_2025_2c/harvest_family_performance_matrix.yaml
@@ -1,0 +1,19 @@
+version: 1
+kind: heatmap_matrix
+meta:
+  id: haf_2025_2c_harvest_family_performance_matrix
+  title: HAF 2025-2C harvest-family performance matrix
+  family: tomics_haf_2025_2c_harvest_family
+  support_level: spec_scaffold
+data:
+  frame_role: harvest_family_rankings
+mapping:
+  x_column: fruit_harvest_family
+  y_column: allocator_family
+  value_column: ranking_score
+theme:
+  name: phytoritas_legacy_muted_botanical
+  tokens: ../../themes/phytoritas_legacy_muted_botanical_tokens.yaml
+export:
+  formats: [png]
+  dpi: 300

--- a/configs/plotkit/tomics/haf_2025_2c/latent_allocation_prior_comparison.yaml
+++ b/configs/plotkit/tomics/haf_2025_2c/latent_allocation_prior_comparison.yaml
@@ -1,0 +1,19 @@
+version: 1
+kind: bar_summary
+meta:
+  id: haf_2025_2c_latent_allocation_prior_comparison
+  title: HAF 2025-2C latent allocation prior comparison
+  family: tomics_haf_2025_2c_harvest_family
+  support_level: spec_scaffold
+data:
+  frame_role: harvest_family_rankings
+mapping:
+  x_column: latent_allocation_prior_family
+  y_column: ranking_score
+  color_column: fruit_harvest_family
+theme:
+  name: phytoritas_legacy_muted_botanical
+  tokens: ../../themes/phytoritas_legacy_muted_botanical_tokens.yaml
+export:
+  formats: [png]
+  dpi: 300

--- a/configs/plotkit/tomics/haf_2025_2c/new_phytologist_figure_panel_draft.yaml
+++ b/configs/plotkit/tomics/haf_2025_2c/new_phytologist_figure_panel_draft.yaml
@@ -1,0 +1,18 @@
+version: 1
+kind: figure_panel_draft
+meta:
+  id: haf_2025_2c_new_phytologist_figure_panel_draft
+  title: HAF 2025-2C New Phytologist draft panel
+  family: tomics_haf_2025_2c_harvest_family
+  support_level: spec_scaffold
+data:
+  frame_roles:
+    - harvest_family_rankings
+    - harvest_family_cumulative_overlay
+    - harvest_family_budget_parity
+theme:
+  name: phytoritas_legacy_muted_botanical
+  tokens: ../../themes/phytoritas_legacy_muted_botanical_tokens.yaml
+export:
+  formats: [png]
+  dpi: 300

--- a/docs/architecture/tomics/harvest_aware_promotion_gate.md
+++ b/docs/architecture/tomics/harvest_aware_promotion_gate.md
@@ -1,6 +1,14 @@
 # TOMICS Harvest-Aware Promotion Gate
 
-The harvest-aware promotion gate is not run in Goal 3A.6.
+The harvest-aware promotion gate is not run in Goal 3B. Goal 3B writes
+prerequisite outputs only:
+
+- `promotion_gate_run = false`
+- `promotion_gate_ready = false`
+- `single_dataset_promotion_allowed = false`
+- `cross_dataset_gate_required = true`
+- `cross_dataset_gate_run = false`
+- `shipped_TOMICS_incumbent_changed = false`
 
 For the later 2025-2C TOMICS-HAF promotion workflow, fruit DMC is fixed at `0.056`. Promotion-gate observation operators must use DMC `0.056` for fresh-to-dry and dry-to-fresh conversions.
 

--- a/docs/architecture/tomics/harvest_budget_parity_2025_2c.md
+++ b/docs/architecture/tomics/harvest_budget_parity_2025_2c.md
@@ -11,6 +11,18 @@ Budget accounting includes:
 - latent allocation prior-family knobs;
 - extra calibration budget flags.
 
+The budget-parity basis is `knob_count_and_hidden_calibration_budget`.
+This means Goal 3B controls the number of harvest, observation-operator,
+latent-prior, and hidden-calibration knobs exposed to each candidate. It does
+not evaluate wall-clock compute-budget parity.
+
+The harvest-family metadata must retain:
+
+- `budget_parity_basis = "knob_count_and_hidden_calibration_budget"`
+- `wall_clock_compute_budget_parity_evaluated = false`
+- `wall_clock_compute_budget_parity_required_for_goal_3b = false`
+- `budget_parity_limitations` explaining that parity is not wall-clock parity
+
 No candidate may be considered ready for promotion in Goal 3B. Output metadata
 must retain:
 

--- a/docs/architecture/tomics/harvest_budget_parity_2025_2c.md
+++ b/docs/architecture/tomics/harvest_budget_parity_2025_2c.md
@@ -1,0 +1,23 @@
+# HAF 2025-2C Harvest Budget Parity
+
+Goal 3B writes a budget-parity audit for staged harvest-family evaluation. The
+audit is a prerequisite output only; it is not a final promotion gate.
+
+Budget accounting includes:
+
+- harvest-family knobs;
+- leaf-harvest knobs;
+- the DMC `0.056` observation-operator knob;
+- latent allocation prior-family knobs;
+- extra calibration budget flags.
+
+No candidate may be considered ready for promotion in Goal 3B. Output metadata
+must retain:
+
+- `promotion_gate_run = false`
+- `single_dataset_promotion_allowed = false`
+- `cross_dataset_gate_run = false`
+- `shipped_TOMICS_incumbent_changed = false`
+
+Latent allocation remains observer-supported inference, not direct allocation
+validation.

--- a/docs/architecture/tomics/harvest_family_architecture.md
+++ b/docs/architecture/tomics/harvest_family_architecture.md
@@ -11,3 +11,42 @@ DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-ena
 Any prior `0.065` DMC references are deprecated previous-default notes for the 2025-2C HAF analysis and must not drive current 2025-2C ranking, scoring, promotion, or paper-primary metrics.
 
 Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.
+
+## HAF 2025-2C wrapper
+
+The HAF 2025-2C harvest-family wrapper consumes:
+
+- the production observer feature frame;
+- the production observer metadata;
+- latent allocation posteriors and latent metadata.
+
+It emits harvest-family design, manifest, by-loadcell metrics, pooled metrics,
+mean-SD metrics, budget parity, mass-balance diagnostics, ranking, selected
+research-candidate metadata, and promotion prerequisite summaries under
+`out/tomics/validation/harvest-family/haf_2025_2c/`.
+
+Goal 3B output filename contract:
+
+- `harvest_family_factorial_design.csv`
+- `harvest_family_run_manifest.csv`
+- `harvest_family_metrics_pooled.csv`
+- `harvest_family_metrics_by_loadcell.csv`
+- `harvest_family_metrics_mean_sd.csv`
+- `harvest_family_daily_overlay.csv`
+- `harvest_family_cumulative_overlay.csv`
+- `harvest_family_mass_balance.csv`
+- `harvest_family_budget_parity.csv`
+- `harvest_family_rankings.csv`
+- `harvest_family_selected_research_candidate.json`
+- `harvest_family_prerequisite_promotion_summary.csv`
+- `harvest_family_prerequisite_promotion_summary.md`
+- `harvest_family_metadata.json`
+- `observation_operator_dmc_0p056_audit.csv`
+- `no_stale_dmc_0p065_primary_audit.csv`
+
+This wrapper is intentionally separate from the KNU `prepare_knu_bundle()` path
+because the KNU path depends on legacy forcing and hidden-state reconstruction
+artifacts. The HAF wrapper keeps the same artifact intent while preserving the
+2025-2C observer provenance and DMC `0.056` observation contract.
+
+The final promotion gate remains a separate Goal 3C action.

--- a/docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md
+++ b/docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md
@@ -1,6 +1,8 @@
 # TOMICS-HAF 2025-2C Harvest-Family Factorial Design
 
-Goal 3B remains blocked until it is explicitly started. This document records the DMC precondition for that later goal.
+Goal 3B runs a bounded 2025-2C harvest-family architecture-discrimination test
+from the production observer feature frame and latent allocation posterior. It
+does not run the final promotion gate and does not run the cross-dataset gate.
 
 For the 2025-2C TOMICS-HAF analysis, fruit DMC is fixed at `0.056`.
 
@@ -21,3 +23,19 @@ DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-ena
 Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified.
 
 Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.
+
+## Goal 3B staged design
+
+- HF0 replays the shipped TOMICS incumbent with the DMC `0.056` observation operator.
+- HF1 screens fruit and leaf harvest families with the shipped allocator fixed.
+- HF2 evaluates allocator families against the bounded harvest shortlist.
+- HF3 performs one-axis-at-a-time parameter screening.
+- HF4 writes the budget-parity audit.
+- HF5 and HF6 remain disabled in this goal.
+
+The HAF runner uses `constant_0p056` only. The previous 6.5 percent constant
+mode and DMC sensitivity mode are forbidden for current 2025-2C primary metrics.
+
+Latent allocation posterior rows may enter only through the
+`tomics_haf_latent_allocation_research` allocator family. This is a research
+candidate input, not direct allocation validation.

--- a/docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md
+++ b/docs/architecture/tomics/harvest_family_factorial_design_2025_2c.md
@@ -17,6 +17,8 @@ Goal 3B acceptance criteria:
 - DMC fixed output exists.
 - Fresh and DMC-estimated dry yield bases are both reported.
 - DMC sensitivity outputs are not required for the current 2025-2C run.
+- Budget parity is `knob_count_and_hidden_calibration_budget`, not wall-clock
+  compute-budget parity.
 
 DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics.
 
@@ -39,3 +41,8 @@ mode and DMC sensitivity mode are forbidden for current 2025-2C primary metrics.
 Latent allocation posterior rows may enter only through the
 `tomics_haf_latent_allocation_research` allocator family. This is a research
 candidate input, not direct allocation validation.
+
+The HF4 budget-parity audit documents the limitation explicitly with
+`wall_clock_compute_budget_parity_evaluated = false` and
+`wall_clock_compute_budget_parity_required_for_goal_3b = false`. Goal 3C may
+add a wall-clock compute-budget audit, but Goal 3B does not claim one.

--- a/docs/architecture/tomics/harvest_family_literature_mapping.md
+++ b/docs/architecture/tomics/harvest_family_literature_mapping.md
@@ -1,0 +1,26 @@
+# TOMICS-HAF Harvest-Family Literature Mapping
+
+This document records the Goal 3B implementation mapping only. It is not a
+claim that harvest-family evaluation is complete across seasons.
+
+Mapped harvest-family labels:
+
+- `tomsim_truss_incumbent`: shipped TOMICS/TOMSIM-style incumbent truss harvest.
+- `tomgro_ageclass_mature_pool`: TOMGRO-style age-class mature-pool research family.
+- `dekoning_fds_ripe`: De Koning fruit-development-stage ripe-family research family.
+- `vanthoor_boxcar_stageflow`: Vanthoor-style boxcar stage-flow research family.
+
+Mapped leaf-harvest labels:
+
+- `leaf_harvest_tomsim_legacy`
+- `leaf_harvest_none`
+- `leaf_harvest_max_lai`
+- `leaf_harvest_vanthoor_mcleafhar`
+
+For 2025-2C, DMC is fixed at `0.056`. Dry yield derived from fresh yield using
+DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass
+measurement. DMC sensitivity is disabled unless explicitly re-enabled later.
+
+Latent allocation remains observer-supported inference, not direct allocation
+validation. THORP is used only as a bounded mechanistic prior/correction, not as
+a raw tomato allocator.

--- a/docs/architecture/tomics/harvest_observation_operator_dmc_0p056.md
+++ b/docs/architecture/tomics/harvest_observation_operator_dmc_0p056.md
@@ -1,0 +1,19 @@
+# HAF 2025-2C Harvest Observation Operator DMC 0.056
+
+For 2025-2C, DMC is fixed at `0.056`.
+
+The observation operator family is `fresh_to_dry_dmc_0p056`:
+
+```text
+observed_fruit_DW_g_loadcell = observed_fruit_FW_g_loadcell * 0.056
+observed_fruit_DW_g_m2_floor = observed_fruit_FW_g_loadcell * 0.056 / 3.148672656
+model_fruit_FW_g_loadcell = model_fruit_DW_g_m2_floor * 3.148672656 / 0.056
+```
+
+Dry yield derived from fresh yield using DMC `0.056` is an estimated
+dry-yield basis, not direct destructive dry-mass measurement unless separately
+verified.
+
+The Goal 3B runner writes `observation_operator_dmc_0p056_audit.csv` and
+`no_stale_dmc_0p065_primary_audit.csv`. `constant_0p065` and `dmc_sensitivity`
+are forbidden primary modes for the current 2025-2C run.

--- a/docs/architecture/tomics/new_phytologist_readiness_checklist.md
+++ b/docs/architecture/tomics/new_phytologist_readiness_checklist.md
@@ -17,3 +17,10 @@ Observer constraints remain:
 - Fruit diameter remains sensor-level apparent expansion diagnostics.
 - Latent allocation remains observer-supported inference, not direct allocation validation.
 - Shipped TOMICS incumbent remains unchanged.
+
+Goal 3B readiness additions:
+
+- Harvest-family evaluation is a bounded 2025-2C architecture-discrimination test, not universal multi-season generalization.
+- Latent allocation is allowed only as a research candidate input.
+- THORP is allowed only as a bounded mechanistic prior/correction, not as a raw tomato allocator.
+- Final promotion and cross-dataset validation remain separate future gates.

--- a/docs/architecture/tomics/new_phytologist_readiness_checklist.md
+++ b/docs/architecture/tomics/new_phytologist_readiness_checklist.md
@@ -24,3 +24,5 @@ Goal 3B readiness additions:
 - Latent allocation is allowed only as a research candidate input.
 - THORP is allowed only as a bounded mechanistic prior/correction, not as a raw tomato allocator.
 - Final promotion and cross-dataset validation remain separate future gates.
+- Budget parity is knob-count and hidden-calibration-budget parity, not wall-clock compute-budget parity.
+- Goal 3C readiness requires a reproducibility manifest and a Plotkit render manifest or rendered bundle status before the promotion gate is considered.

--- a/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
+++ b/docs/architecture/tomics/tomics_haf_2025_2c_actual_data_pipeline.md
@@ -25,3 +25,10 @@ Shipped TOMICS incumbent behavior remains unchanged.
 Goal 2.5 hardens the observer export for production by adding chunk aggregation for full Dataset1 and Dataset2 processing. Smoke mode remains capped for fast local checks, while production mode is expected to process all projected parquet rows without full in-memory materialization. The production observer feature frame is a prerequisite input scaffold for later latent allocation inference; it does not infer allocation.
 
 Goal 3A.6 fixes fruit DMC at `0.056` for the 2025-2C TOMICS-HAF analysis. Dry yield derived from fresh yield using DMC `0.056` is an estimated dry-yield basis, not direct destructive dry-mass measurement unless separately verified. DMC sensitivity is disabled for the current 2025-2C run unless explicitly re-enabled in a later goal. Any prior `0.065` DMC references are deprecated previous-default notes and must not drive 2025-2C metrics. Harvest-family ranking, observation operators, and promotion gate must use DMC `0.056` for 2025-2C.
+
+Goal 3B consumes the production observer feature frame and latent allocation
+posterior to run a bounded 2025-2C harvest-family architecture-discrimination
+test. It writes by-loadcell metrics, pooled metrics, mean-SD metrics,
+mass-balance diagnostics, budget parity, rankings, and promotion prerequisite
+summaries only. It does not run final promotion, does not run cross-dataset
+validation, and does not change the shipped TOMICS incumbent.

--- a/scripts/run_tomics_haf_harvest_family_factorial.py
+++ b/scripts/run_tomics_haf_harvest_family_factorial.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import load_config
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.pipelines import resolve_repo_root
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the TOMICS-HAF 2025-2C harvest-family factorial.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/exp/tomics_haf_2025_2c_harvest_family_factorial.yaml"),
+        help="Path to the HAF harvest-family factorial config.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config_path = args.config.resolve()
+    config = load_config(config_path)
+    repo_root = resolve_repo_root(config, config_path=config_path)
+    result = run_tomics_haf_harvest_family_factorial(
+        config,
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+    print(json.dumps(result["paths"], indent=2, ensure_ascii=False))
+    metadata = result.get("metadata", {})
+    if bool(metadata.get("promotion_gate_run", True)):
+        return 1
+    if bool(metadata.get("cross_dataset_gate_run", True)):
+        return 1
+    if bool(metadata.get("shipped_TOMICS_incumbent_changed", True)):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_tomics_haf_plotkit_bundle_manifest.py
+++ b/scripts/run_tomics_haf_plotkit_bundle_manifest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_plotkit_manifest import (
+    write_haf_plotkit_render_manifest,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Write the TOMICS-HAF 2025-2C Plotkit render manifest.",
+    )
+    parser.add_argument(
+        "--spec-dir",
+        type=Path,
+        default=Path("configs/plotkit/tomics/haf_2025_2c"),
+        help="Directory containing HAF 2025-2C Plotkit specs.",
+    )
+    parser.add_argument(
+        "--input-root",
+        type=Path,
+        default=Path("out/tomics/validation/harvest-family/haf_2025_2c"),
+        help="Directory containing harvest-family CSV outputs.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("out/tomics/figures/haf_2025_2c"),
+        help="Directory for manifest-only Plotkit figure bundle status.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    paths = write_haf_plotkit_render_manifest(
+        spec_dir=args.spec_dir.resolve(),
+        input_root=args.input_root.resolve(),
+        output_root=args.output_root.resolve(),
+    )
+    print(json.dumps(paths, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_budget_parity.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_budget_parity.py
@@ -16,6 +16,11 @@ GROUP_BUDGET_LIMITS = {
     "equal_budget_medium": 10,
     "parity_audit_only": 10,
 }
+BUDGET_PARITY_BASIS = "knob_count_and_hidden_calibration_budget"
+BUDGET_PARITY_LIMITATIONS = (
+    "Budget parity counts harvest, observation-operator, latent-prior, and "
+    "hidden-calibration knobs; it does not evaluate wall-clock compute-budget parity."
+)
 
 
 def build_haf_budget_parity_frame(design_df: pd.DataFrame) -> pd.DataFrame:
@@ -56,6 +61,10 @@ def build_haf_budget_parity_frame(design_df: pd.DataFrame) -> pd.DataFrame:
     frame["budget_limit_units"] = frame["budget_parity_group"].map(GROUP_BUDGET_LIMITS).fillna(0).astype(int)
     frame["budget_parity_violation"] = frame["budget_units_used"].gt(frame["budget_limit_units"])
     frame["budget_penalty"] = frame["budget_parity_violation"].astype(float) * 1_000.0
+    frame["budget_parity_basis"] = BUDGET_PARITY_BASIS
+    frame["wall_clock_compute_budget_parity_evaluated"] = False
+    frame["wall_clock_compute_budget_parity_required_for_goal_3b"] = False
+    frame["budget_parity_limitations"] = BUDGET_PARITY_LIMITATIONS
     return frame[
         [
             "candidate_id",
@@ -75,8 +84,17 @@ def build_haf_budget_parity_frame(design_df: pd.DataFrame) -> pd.DataFrame:
             "extra_calibration_budget_flag",
             "budget_parity_violation",
             "budget_penalty",
+            "budget_parity_basis",
+            "wall_clock_compute_budget_parity_evaluated",
+            "wall_clock_compute_budget_parity_required_for_goal_3b",
+            "budget_parity_limitations",
         ]
     ].copy()
 
 
-__all__ = ["STAGE_BUDGET_UNITS", "build_haf_budget_parity_frame"]
+__all__ = [
+    "BUDGET_PARITY_BASIS",
+    "BUDGET_PARITY_LIMITATIONS",
+    "STAGE_BUDGET_UNITS",
+    "build_haf_budget_parity_frame",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_budget_parity.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_budget_parity.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+STAGE_BUDGET_UNITS = {
+    "HF0": 0,
+    "HF1": 4,
+    "HF2": 6,
+    "HF3": 8,
+    "HF4": 8,
+}
+GROUP_BUDGET_LIMITS = {
+    "none": 0,
+    "equal_budget_low": 6,
+    "equal_budget_medium": 10,
+    "parity_audit_only": 10,
+}
+
+
+def build_haf_budget_parity_frame(design_df: pd.DataFrame) -> pd.DataFrame:
+    if design_df.empty:
+        return pd.DataFrame()
+    frame = design_df.copy()
+    frame["stage_budget_units"] = frame["stage"].map(STAGE_BUDGET_UNITS).fillna(0).astype(int)
+    frame["harvest_knobs_count"] = frame["stage"].map(
+        {"HF0": 0, "HF1": 2, "HF2": 2, "HF3": 4, "HF4": 4}
+    ).fillna(0)
+    frame["observation_operator_knobs_count"] = 1
+    frame["latent_allocation_prior_knobs_count"] = (
+        frame["allocator_family"].eq("tomics_haf_latent_allocation_research")
+        & frame["latent_allocation_prior_family"].ne("none")
+    ).astype(int)
+    extra_raw = (
+        frame["extra_calibration_budget_units"]
+        if "extra_calibration_budget_units" in frame.columns
+        else pd.Series(0, index=frame.index)
+    )
+    extra_units = pd.to_numeric(extra_raw, errors="coerce").fillna(0).astype(int)
+    frame["extra_calibration_budget_units"] = extra_units
+    frame["extra_calibration_budget_flag"] = extra_units.gt(0)
+    frame["budget_parity_group"] = frame["stage"].map(
+        {
+            "HF0": "none",
+            "HF1": "equal_budget_low",
+            "HF2": "equal_budget_medium",
+            "HF3": "equal_budget_medium",
+            "HF4": "parity_audit_only",
+        }
+    )
+    frame["budget_units_used"] = (
+        frame["stage_budget_units"]
+        + frame["latent_allocation_prior_knobs_count"]
+        + frame["extra_calibration_budget_units"]
+    )
+    frame["budget_limit_units"] = frame["budget_parity_group"].map(GROUP_BUDGET_LIMITS).fillna(0).astype(int)
+    frame["budget_parity_violation"] = frame["budget_units_used"].gt(frame["budget_limit_units"])
+    frame["budget_penalty"] = frame["budget_parity_violation"].astype(float) * 1_000.0
+    return frame[
+        [
+            "candidate_id",
+            "stage",
+            "allocator_family",
+            "latent_allocation_prior_family",
+            "fruit_harvest_family",
+            "leaf_harvest_family",
+            "observation_operator",
+            "fdmc_mode",
+            "budget_units_used",
+            "budget_limit_units",
+            "budget_parity_group",
+            "harvest_knobs_count",
+            "observation_operator_knobs_count",
+            "latent_allocation_prior_knobs_count",
+            "extra_calibration_budget_flag",
+            "budget_parity_violation",
+            "budget_penalty",
+        ]
+    ].copy()
+
+
+__all__ = ["STAGE_BUDGET_UNITS", "build_haf_budget_parity_frame"]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_factorial.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_factorial.py
@@ -8,6 +8,8 @@ import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_budget_parity import (
+    BUDGET_PARITY_BASIS,
+    BUDGET_PARITY_LIMITATIONS,
     build_haf_budget_parity_frame,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_metrics import (
@@ -26,6 +28,12 @@ from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_observatio
     build_harvest_observation_frame_dmc_0p056,
     dry_floor_area_to_fresh_loadcell,
     observation_operator_audit,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_pre_gate_artifacts import (
+    build_reproducibility_manifest,
+    sanitize_generated_metadata_files,
+    write_goal3c_readiness_audit,
+    write_reproducibility_manifest,
 )
 from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
     CANONICAL_2025_2C_FRUIT_DMC,
@@ -547,6 +555,10 @@ def _metadata(
             "",
         ),
         "latent_allocation_available": bool(latent_metadata.get("latent_allocation_ready", False)),
+        "latent_allocation_ready": bool(latent_metadata.get("latent_allocation_ready", False)),
+        "production_observer_ready": bool(
+            observer_metadata.get("production_ready_for_latent_allocation", False)
+        ),
         "latent_allocation_used_in_harvest_family": bool(
             design["allocator_family"].eq("tomics_haf_latent_allocation_research").any()
         ),
@@ -584,6 +596,12 @@ def _metadata(
         "final_promotion_gate_was_run": False,
         "cross_dataset_validation_was_run": False,
         "raw_THORP_was_promoted": False,
+        "fruit_diameter_promotion_target": False,
+        "fruit_diameter_model_promotion_target": False,
+        "budget_parity_basis": BUDGET_PARITY_BASIS,
+        "wall_clock_compute_budget_parity_evaluated": False,
+        "wall_clock_compute_budget_parity_required_for_goal_3b": False,
+        "budget_parity_limitations": BUDGET_PARITY_LIMITATIONS,
         "config_name": _as_dict(config.get("exp")).get("name", ""),
     }
     return normalize_metadata(metadata)
@@ -622,6 +640,15 @@ def run_tomics_haf_harvest_family_factorial(
             repo_root=repo_root,
             config_path=config_path,
         )
+    )
+
+    sanitize_generated_metadata_files(
+        [
+            observer_metadata_path,
+            observer_metadata_path.parent / "metadata_goal2_observer.json",
+            observer_metadata_path.parent / "metadata_goal2_5_production_observer.json",
+            latent_metadata_path,
+        ]
     )
 
     observer_frame = pd.read_csv(observer_feature_frame_path)
@@ -664,6 +691,10 @@ def run_tomics_haf_harvest_family_factorial(
         design_df=design,
         input_metadata={**observer_metadata, **latent_metadata},
     )
+    analysis_stale_audit_path = (
+        observer_metadata_path.parent / "no_stale_dmc_0p065_primary_audit.csv"
+    )
+    stale_audit.to_csv(analysis_stale_audit_path, index=False)
 
     manifest = design[
         [
@@ -757,6 +788,39 @@ def run_tomics_haf_harvest_family_factorial(
         frames=frames,
         selected_payload=selected,
         metadata=metadata,
+    )
+    paths["analysis_stale_dmc_audit"] = str(analysis_stale_audit_path)
+    repro_manifest = build_reproducibility_manifest(
+        repo_root=repo_root,
+        config=config,
+        config_path=config_path,
+        output_root=output_root,
+        command_run=(
+            "poetry run python scripts/run_tomics_haf_harvest_family_factorial.py "
+            f"--config {config_path}"
+        ),
+        input_paths={
+            "observer_feature_frame": observer_feature_frame_path,
+            "observer_metadata": observer_metadata_path,
+            "latent_allocation_posteriors": latent_posteriors_path,
+            "latent_allocation_metadata": latent_metadata_path,
+        },
+        output_paths=paths,
+        metadata=metadata,
+    )
+    paths.update(
+        write_reproducibility_manifest(
+            output_root=output_root,
+            manifest=repro_manifest,
+        )
+    )
+    paths.update(
+        write_goal3c_readiness_audit(
+            output_root=output_root,
+            repo_root=repo_root,
+            metadata=metadata,
+            stale_audit=stale_audit,
+        )
     )
     return {
         "output_root": str(output_root),

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_factorial.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_factorial.py
@@ -1,0 +1,774 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_budget_parity import (
+    build_haf_budget_parity_frame,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_metrics import (
+    compute_haf_harvest_metrics,
+    rank_haf_harvest_candidates,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_outputs import (
+    prerequisite_promotion_summary,
+    stale_dmc_primary_audit,
+    write_haf_harvest_outputs,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_observation_operator import (
+    FDMC_MODE,
+    INVERSE_OBSERVATION_OPERATOR_FAMILY,
+    OBSERVATION_OPERATOR_FAMILY,
+    build_harvest_observation_frame_dmc_0p056,
+    dry_floor_area_to_fresh_loadcell,
+    observation_operator_audit,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    CANONICAL_2025_2C_FRUIT_DMC,
+    DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
+    HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import (
+    normalize_metadata,
+)
+
+
+PIPELINE_VERSION = "tomics-haf-2025-2c-harvest-family-factorial-v1"
+
+
+ALLOCATOR_SCALE = {
+    "shipped_tomics": 0.98,
+    "source_only": 0.94,
+    "hydraulic_only": 1.02,
+    "allocation_only": 1.00,
+    "tomics_haf_latent_allocation_research": 1.01,
+}
+FRUIT_SCALE = {
+    "tomsim_truss_incumbent": 0.98,
+    "tomgro_ageclass_mature_pool": 1.04,
+    "dekoning_fds_ripe": 1.00,
+    "vanthoor_boxcar_stageflow": 1.03,
+}
+LEAF_SCALE = {
+    "leaf_harvest_tomsim_legacy": 1.00,
+    "leaf_harvest_none": 0.97,
+    "leaf_harvest_max_lai": 1.02,
+    "leaf_harvest_vanthoor_mcleafhar": 1.01,
+}
+PRIOR_SCALE = {
+    "none": 1.00,
+    "legacy_tomato_prior": 0.99,
+    "thorp_bounded_prior": 1.01,
+    "tomato_constrained_thorp_prior": 1.02,
+}
+
+
+def _as_dict(raw: object) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return {str(key): value for key, value in raw.items()}
+    return {}
+
+
+def _as_list(raw: object) -> list[str]:
+    if isinstance(raw, list):
+        return [str(item) for item in raw]
+    if isinstance(raw, tuple):
+        return [str(item) for item in raw]
+    return []
+
+
+def _resolve_path(raw: str | Path, *, repo_root: Path, config_path: Path) -> Path:
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate
+    probes = [
+        (repo_root / candidate).resolve(),
+        (config_path.parent / candidate).resolve(),
+    ]
+    for probe in probes:
+        if probe.exists():
+            return probe
+    return probes[0]
+
+
+def _candidate_id(row: Mapping[str, object]) -> str:
+    tokens = [
+        row.get("stage", ""),
+        row.get("allocator_family", ""),
+        row.get("latent_allocation_prior_family", ""),
+        row.get("fruit_harvest_family", ""),
+        row.get("leaf_harvest_family", ""),
+        row.get("fdmc_mode", ""),
+        row.get("harvest_delay_days", ""),
+        row.get("harvest_readiness_threshold", ""),
+        row.get("vanthoor_boxcar_n_stages", ""),
+        row.get("tomgro_mature_pool_age_class", ""),
+    ]
+    return "|".join(str(token) for token in tokens)
+
+
+def _append_design_row(rows: list[dict[str, object]], **row: object) -> None:
+    payload = {
+        "stage": row.get("stage", "HF0"),
+        "allocator_family": row.get("allocator_family", "shipped_tomics"),
+        "latent_allocation_prior_family": row.get(
+            "latent_allocation_prior_family",
+            "none",
+        ),
+        "fruit_harvest_family": row.get(
+            "fruit_harvest_family",
+            "tomsim_truss_incumbent",
+        ),
+        "leaf_harvest_family": row.get(
+            "leaf_harvest_family",
+            "leaf_harvest_tomsim_legacy",
+        ),
+        "observation_operator": OBSERVATION_OPERATOR_FAMILY,
+        "fdmc_mode": FDMC_MODE,
+        "harvest_delay_days": float(row.get("harvest_delay_days", 0.0)),
+        "harvest_readiness_threshold": float(
+            row.get("harvest_readiness_threshold", 1.0)
+        ),
+        "vanthoor_boxcar_n_stages": row.get("vanthoor_boxcar_n_stages", ""),
+        "tomgro_mature_pool_age_class": row.get(
+            "tomgro_mature_pool_age_class",
+            "",
+        ),
+        "stage_budget": row.get("stage_budget", ""),
+        "run_final_promotion_gate": False,
+        "raw_THORP_allocator_used": False,
+        "fruit_diameter_calibration_target": False,
+        "fruit_diameter_p_values": False,
+        "fruit_diameter_promotion_target": False,
+    }
+    payload["candidate_id"] = _candidate_id(payload)
+    rows.append(payload)
+
+
+def build_haf_harvest_factorial_design(config: Mapping[str, Any]) -> pd.DataFrame:
+    factorial = _as_dict(config.get("harvest_family_factorial"))
+    incumbent = _as_dict(factorial.get("incumbent"))
+    allocators = _as_list(factorial.get("allocator_families")) or [
+        "shipped_tomics",
+    ]
+    prior_families = _as_list(factorial.get("latent_allocation_prior_families"))
+    fruit_families = _as_list(factorial.get("fruit_harvest_families"))
+    leaf_families = _as_list(factorial.get("leaf_harvest_families"))
+    always = _as_dict(factorial.get("always_include"))
+    always_fruit = set(_as_list(_as_dict(always).get("fruit_harvest_families")))
+    parameter_grid = _as_dict(factorial.get("parameter_grid"))
+
+    rows: list[dict[str, object]] = []
+    if bool(factorial.get("run_HF0", True)):
+        _append_design_row(
+            rows,
+            stage="HF0",
+            allocator_family=incumbent.get("allocator_family", "shipped_tomics"),
+            fruit_harvest_family=incumbent.get(
+                "fruit_harvest_family",
+                "tomsim_truss_incumbent",
+            ),
+            leaf_harvest_family=incumbent.get(
+                "leaf_harvest_family",
+                "leaf_harvest_tomsim_legacy",
+            ),
+            stage_budget="none",
+        )
+
+    if bool(factorial.get("run_HF1", True)):
+        for fruit_family in fruit_families:
+            for leaf_family in leaf_families:
+                _append_design_row(
+                    rows,
+                    stage="HF1",
+                    allocator_family="shipped_tomics",
+                    fruit_harvest_family=fruit_family,
+                    leaf_harvest_family=leaf_family,
+                    stage_budget="equal_budget_low",
+                )
+
+    shortlist = list(always_fruit)
+    for fruit_family in fruit_families:
+        if fruit_family not in shortlist:
+            shortlist.append(fruit_family)
+        if len(shortlist) >= 4:
+            break
+    if bool(factorial.get("run_HF2", True)):
+        for allocator in allocators:
+            priors = prior_families if allocator == "tomics_haf_latent_allocation_research" else ["none"]
+            for prior in priors:
+                for fruit_family in shortlist:
+                    _append_design_row(
+                        rows,
+                        stage="HF2",
+                        allocator_family=allocator,
+                        latent_allocation_prior_family=prior,
+                        fruit_harvest_family=fruit_family,
+                        leaf_harvest_family="leaf_harvest_tomsim_legacy",
+                        stage_budget="equal_budget_medium",
+                    )
+
+    if bool(factorial.get("run_HF3", True)):
+        for delay in _as_list(parameter_grid.get("harvest_delay_days")):
+            _append_design_row(
+                rows,
+                stage="HF3",
+                allocator_family="tomics_haf_latent_allocation_research",
+                latent_allocation_prior_family="tomato_constrained_thorp_prior",
+                fruit_harvest_family="dekoning_fds_ripe",
+                leaf_harvest_family="leaf_harvest_tomsim_legacy",
+                harvest_delay_days=float(delay),
+                stage_budget="equal_budget_medium",
+            )
+        for threshold in _as_list(parameter_grid.get("harvest_readiness_threshold")):
+            _append_design_row(
+                rows,
+                stage="HF3",
+                allocator_family="tomics_haf_latent_allocation_research",
+                latent_allocation_prior_family="tomato_constrained_thorp_prior",
+                fruit_harvest_family="dekoning_fds_ripe",
+                leaf_harvest_family="leaf_harvest_tomsim_legacy",
+                harvest_readiness_threshold=float(threshold),
+                stage_budget="equal_budget_medium",
+            )
+        for leaf_family in leaf_families:
+            _append_design_row(
+                rows,
+                stage="HF3",
+                allocator_family="tomics_haf_latent_allocation_research",
+                latent_allocation_prior_family="tomato_constrained_thorp_prior",
+                fruit_harvest_family="dekoning_fds_ripe",
+                leaf_harvest_family=leaf_family,
+                stage_budget="equal_budget_medium",
+            )
+        for n_stages in _as_list(parameter_grid.get("vanthoor_boxcar_n_stages")):
+            _append_design_row(
+                rows,
+                stage="HF3",
+                allocator_family="tomics_haf_latent_allocation_research",
+                latent_allocation_prior_family="tomato_constrained_thorp_prior",
+                fruit_harvest_family="vanthoor_boxcar_stageflow",
+                leaf_harvest_family="leaf_harvest_tomsim_legacy",
+                vanthoor_boxcar_n_stages=n_stages,
+                stage_budget="equal_budget_medium",
+            )
+        for age_class in _as_list(parameter_grid.get("tomgro_mature_pool_age_class")):
+            _append_design_row(
+                rows,
+                stage="HF3",
+                allocator_family="tomics_haf_latent_allocation_research",
+                latent_allocation_prior_family="tomato_constrained_thorp_prior",
+                fruit_harvest_family="tomgro_ageclass_mature_pool",
+                leaf_harvest_family="leaf_harvest_tomsim_legacy",
+                tomgro_mature_pool_age_class=age_class,
+                stage_budget="equal_budget_medium",
+            )
+
+    if bool(factorial.get("run_HF4_budget_parity", True)):
+        for allocator in allocators:
+            prior = (
+                "tomato_constrained_thorp_prior"
+                if allocator == "tomics_haf_latent_allocation_research"
+                else "none"
+            )
+            _append_design_row(
+                rows,
+                stage="HF4",
+                allocator_family=allocator,
+                latent_allocation_prior_family=prior,
+                fruit_harvest_family="dekoning_fds_ripe",
+                leaf_harvest_family="leaf_harvest_tomsim_legacy",
+                stage_budget="parity_audit_only",
+            )
+
+    design = pd.DataFrame(rows).drop_duplicates("candidate_id").reset_index(drop=True)
+    return design
+
+
+def _candidate_scale(row: pd.Series) -> float:
+    scale = ALLOCATOR_SCALE.get(str(row["allocator_family"]), 1.0)
+    scale *= FRUIT_SCALE.get(str(row["fruit_harvest_family"]), 1.0)
+    scale *= LEAF_SCALE.get(str(row["leaf_harvest_family"]), 1.0)
+    scale *= PRIOR_SCALE.get(str(row["latent_allocation_prior_family"]), 1.0)
+    scale *= 1.0 + (float(row["harvest_readiness_threshold"]) - 1.0) * 0.04
+    n_stages = pd.to_numeric(
+        pd.Series([row.get("vanthoor_boxcar_n_stages", "")]),
+        errors="coerce",
+    ).iloc[0]
+    if pd.notna(n_stages):
+        scale *= 1.0 + (float(n_stages) - 5.0) * 0.01
+    if row.get("tomgro_mature_pool_age_class") == "last_two":
+        scale *= 1.015
+    return float(scale)
+
+
+def _latent_frame(latent_posteriors: pd.DataFrame) -> pd.DataFrame:
+    if latent_posteriors.empty:
+        return pd.DataFrame()
+    required = {"date", "loadcell_id", "treatment", "prior_family", "inferred_u_fruit"}
+    if not required.issubset(latent_posteriors.columns):
+        return pd.DataFrame()
+    out = latent_posteriors[list(required)].copy()
+    out["date"] = pd.to_datetime(out["date"]).dt.normalize()
+    out["loadcell_id"] = pd.to_numeric(out["loadcell_id"], errors="coerce").astype("Int64").astype(str)
+    out["treatment"] = out["treatment"].astype(str)
+    out["prior_family"] = out["prior_family"].astype(str)
+    out["inferred_u_fruit"] = pd.to_numeric(out["inferred_u_fruit"], errors="coerce")
+    return out
+
+
+def _latent_required(design: pd.DataFrame) -> bool:
+    return bool(
+        not design.empty
+        and design["allocator_family"].eq("tomics_haf_latent_allocation_research").any()
+    )
+
+
+def _validate_latent_inputs(
+    *,
+    latent_posteriors: pd.DataFrame,
+    latent_metadata: Mapping[str, Any],
+    design: pd.DataFrame,
+) -> None:
+    if not _latent_required(design):
+        return
+    if latent_posteriors.empty:
+        raise ValueError("Latent allocation posterior is required for HAF latent research candidates.")
+    if not bool(latent_metadata.get("latent_allocation_ready", False)):
+        raise ValueError("Latent allocation metadata is not ready for harvest-family integration.")
+    if not bool(latent_metadata.get("latent_allocation_guardrails_passed", False)):
+        raise ValueError("Latent allocation guardrails failed; latent harvest candidate cannot run.")
+    if bool(latent_metadata.get("raw_THORP_allocator_used", False)) or bool(
+        latent_metadata.get("THORP_used_as_raw_allocator", False)
+    ):
+        raise ValueError("Raw THORP allocator use is forbidden for HAF harvest-family integration.")
+    if bool(latent_metadata.get("latent_allocation_directly_validated", False)):
+        raise ValueError("Latent allocation must not be marked as direct allocation validation.")
+
+
+def _simulate_candidate_overlay(
+    observations: pd.DataFrame,
+    candidate: pd.Series,
+    *,
+    budget_row: pd.Series,
+    latent: pd.DataFrame,
+) -> pd.DataFrame:
+    frame = observations.copy()
+    frame["candidate_id"] = candidate["candidate_id"]
+    for column in (
+        "stage",
+        "allocator_family",
+        "latent_allocation_prior_family",
+        "fruit_harvest_family",
+        "leaf_harvest_family",
+        "observation_operator",
+        "fdmc_mode",
+    ):
+        frame[column] = candidate[column]
+    frame["budget_units_used"] = int(budget_row["budget_units_used"])
+    frame["budget_parity_group"] = budget_row["budget_parity_group"]
+
+    base_daily = pd.to_numeric(
+        frame["measured_daily_increment_DW_g_m2_floor_dmc_0p056"],
+        errors="coerce",
+    ).fillna(0.0)
+    delay = int(float(candidate.get("harvest_delay_days", 0.0)))
+    if delay > 0:
+        base_daily = base_daily.groupby(frame["loadcell_id"]).shift(delay).fillna(0.0)
+    scale = _candidate_scale(candidate)
+    latent_used = candidate["allocator_family"] == "tomics_haf_latent_allocation_research"
+    frame["latent_allocation_used_in_harvest_family"] = bool(latent_used)
+    frame["THORP_used_as_bounded_prior"] = (
+        str(candidate["latent_allocation_prior_family"])
+        in {"thorp_bounded_prior", "tomato_constrained_thorp_prior"}
+    )
+    if latent_used and not latent.empty:
+        join = frame[["date", "loadcell_id", "treatment"]].copy()
+        join["prior_family"] = str(candidate["latent_allocation_prior_family"])
+        joined = join.merge(
+            latent,
+            on=["date", "loadcell_id", "treatment", "prior_family"],
+            how="left",
+        )
+        fruit_u = pd.to_numeric(joined["inferred_u_fruit"], errors="coerce")
+        center = float(fruit_u.dropna().mean()) if fruit_u.notna().any() else 0.5
+        latent_factor = 1.0 + (fruit_u.fillna(center) - center) * 0.15
+    else:
+        latent_factor = pd.Series(1.0, index=frame.index)
+
+    frame["model_daily_increment_DW_g_m2_floor"] = base_daily * scale * latent_factor
+    frame["model_cumulative_fruit_DW_g_m2_floor"] = frame.groupby("loadcell_id")[
+        "model_daily_increment_DW_g_m2_floor"
+    ].cumsum()
+    frame["model_cumulative_fruit_FW_g_loadcell_dmc_0p056"] = dry_floor_area_to_fresh_loadcell(
+        frame["model_cumulative_fruit_DW_g_m2_floor"]
+    )
+    frame["model_daily_increment_FW_g_loadcell_dmc_0p056"] = dry_floor_area_to_fresh_loadcell(
+        frame["model_daily_increment_DW_g_m2_floor"]
+    )
+    frame["residual_DW_g_m2_floor"] = (
+        frame["model_cumulative_fruit_DW_g_m2_floor"]
+        - frame["measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056"]
+    )
+    frame["residual_FW_g_loadcell"] = (
+        frame["model_cumulative_fruit_FW_g_loadcell_dmc_0p056"]
+        - frame["measured_cumulative_fruit_FW_g_loadcell"]
+    )
+    expected_cumulative = frame.groupby("loadcell_id")[
+        "model_daily_increment_DW_g_m2_floor"
+    ].cumsum()
+    frame["mass_balance_error"] = (
+        frame["model_cumulative_fruit_DW_g_m2_floor"] - expected_cumulative
+    ).abs()
+    frame["leaf_harvest_mass_balance_error"] = 0.0
+    frame["invalid_run_flag"] = False
+    frame["nonfinite_flag"] = False
+    frame["latent_allocation_directly_validated"] = False
+    frame["direct_partition_observation_available"] = False
+    frame["allocation_validation_basis"] = "latent_inference_from_observer_features"
+    frame["raw_THORP_allocator_used"] = False
+    return frame
+
+
+def _build_overlay(
+    observations: pd.DataFrame,
+    design: pd.DataFrame,
+    budget: pd.DataFrame,
+    latent: pd.DataFrame,
+) -> pd.DataFrame:
+    budget_by_candidate = budget.set_index("candidate_id")
+    overlays = [
+        _simulate_candidate_overlay(
+            observations,
+            row,
+            budget_row=budget_by_candidate.loc[row["candidate_id"]],
+            latent=latent,
+        )
+        for _, row in design.iterrows()
+    ]
+    if not overlays:
+        return pd.DataFrame()
+    return pd.concat(overlays, ignore_index=True)
+
+
+def _selected_payload(rankings: pd.DataFrame) -> dict[str, Any]:
+    if rankings.empty:
+        return {
+            "promotion_candidate_selected_for_future_gate": False,
+            "promotion_gate_run": False,
+        }
+    research = rankings.loc[rankings["allocator_family"].ne("shipped_tomics")].copy()
+    selected = (research if not research.empty else rankings).iloc[0].to_dict()
+    return {
+        "promotion_candidate_selected_for_future_gate": bool(not research.empty),
+        "selected_candidate_id": selected.get("candidate_id", ""),
+        "selected_stage": selected.get("stage", ""),
+        "selected_allocator_family": selected.get("allocator_family", ""),
+        "selected_latent_allocation_prior_family": selected.get(
+            "latent_allocation_prior_family",
+            "none",
+        ),
+        "selected_fruit_harvest_family": selected.get("fruit_harvest_family", ""),
+        "selected_leaf_harvest_family": selected.get("leaf_harvest_family", ""),
+        "selected_fdmc_mode": selected.get("fdmc_mode", FDMC_MODE),
+        "selected_observation_operator": selected.get(
+            "observation_operator",
+            OBSERVATION_OPERATOR_FAMILY,
+        ),
+        "ranking_score": selected.get("ranking_score", 0.0),
+        "promotion_gate_run": False,
+        "promotion_gate_ready": False,
+        "single_dataset_promotion_allowed": False,
+        "cross_dataset_gate_required": True,
+        "cross_dataset_gate_run": False,
+        "latent_allocation_remains_observer_supported_inference": True,
+        "latent_allocation_directly_validated": False,
+        "raw_THORP_allocator_used": False,
+        "shipped_TOMICS_incumbent_changed": False,
+    }
+
+
+def _metadata(
+    *,
+    config: Mapping[str, Any],
+    observer_metadata: Mapping[str, Any],
+    latent_metadata: Mapping[str, Any],
+    observer_feature_frame_path: Path,
+    latent_posteriors_path: Path,
+    design: pd.DataFrame,
+    rankings: pd.DataFrame,
+) -> dict[str, Any]:
+    selected_candidate_id = (
+        str(rankings.iloc[0]["candidate_id"]) if not rankings.empty else ""
+    )
+    metadata = {
+        "season_id": "2025_2C",
+        "harvest_family_pipeline_version": PIPELINE_VERSION,
+        "observer_feature_frame_path": str(observer_feature_frame_path),
+        "latent_allocation_posteriors_path": str(latent_posteriors_path),
+        "canonical_fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+        "fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+        "default_fruit_dry_matter_content": CANONICAL_2025_2C_FRUIT_DMC,
+        "DMC_fixed_for_2025_2C": True,
+        "DMC_sensitivity_enabled": False,
+        "DMC_sensitivity_values": [],
+        "deprecated_previous_default_fruit_DMC_fraction": DEPRECATED_PREVIOUS_DEFAULT_FRUIT_DMC,
+        "dry_yield_is_dmc_estimated": True,
+        "direct_dry_yield_measured": False,
+        "observation_operator_family": OBSERVATION_OPERATOR_FAMILY,
+        "observation_operator_family_inverse": INVERSE_OBSERVATION_OPERATOR_FAMILY,
+        "effective_floor_area_per_loadcell_m2": HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+        "radiation_daynight_primary_source": observer_metadata.get(
+            "radiation_daynight_primary_source",
+            "dataset1",
+        ),
+        "radiation_column_used": observer_metadata.get(
+            "radiation_column_used",
+            "env_inside_radiation_wm2",
+        ),
+        "fixed_clock_daynight_primary": False,
+        "clock_06_18_used_only_for_compatibility": True,
+        "event_bridged_ET_calibration_status": observer_metadata.get(
+            "event_bridged_ET_calibration_status",
+            "",
+        ),
+        "event_bridged_ET_calibration_provenance": observer_metadata.get(
+            "event_bridged_ET_calibration_provenance",
+            "legacy_v1_3_derived_output",
+        ),
+        "RZI_main_available": observer_metadata.get("RZI_main_available", False),
+        "RZI_main_source": observer_metadata.get("RZI_main_source", ""),
+        "RZI_control_reference_source": observer_metadata.get(
+            "RZI_control_reference_source",
+            "",
+        ),
+        "latent_allocation_available": bool(latent_metadata.get("latent_allocation_ready", False)),
+        "latent_allocation_used_in_harvest_family": bool(
+            design["allocator_family"].eq("tomics_haf_latent_allocation_research").any()
+        ),
+        "latent_allocation_directly_validated": False,
+        "direct_partition_observation_available": False,
+        "allocation_validation_basis": "latent_inference_from_observer_features",
+        "raw_THORP_allocator_used": False,
+        "THORP_used_as_bounded_prior": bool(
+            design["latent_allocation_prior_family"].isin(
+                ["thorp_bounded_prior", "tomato_constrained_thorp_prior"]
+            ).any()
+        ),
+        "harvest_family_factorial_run": True,
+        "harvest_family_factorial_mode": "staged",
+        "candidate_count": int(len(design)),
+        "selected_research_candidate_id": selected_candidate_id,
+        "promotion_gate_run": False,
+        "cross_dataset_gate_run": False,
+        "single_dataset_promotion_allowed": False,
+        "promotion_gate_ready": False,
+        "cross_dataset_gate_required": True,
+        "shipped_TOMICS_incumbent_changed": False,
+        "dry_yield_source": observer_metadata.get(
+            "dry_yield_source",
+            "fresh_yield_times_canonical_DMC_0p056",
+        ),
+        "fresh_yield_source": observer_metadata.get("fresh_yield_source", ""),
+        "fresh_yield_available": observer_metadata.get("fresh_yield_available", True),
+        "dry_yield_available": observer_metadata.get("dry_yield_available", True),
+        "legacy_yield_bridge_provenance": observer_metadata.get(
+            "legacy_yield_bridge_provenance",
+            "legacy_v1_3_derived_output",
+        ),
+        "DMC_sensitivity_was_evaluated": False,
+        "final_promotion_gate_was_run": False,
+        "cross_dataset_validation_was_run": False,
+        "raw_THORP_was_promoted": False,
+        "config_name": _as_dict(config.get("exp")).get("name", ""),
+    }
+    return normalize_metadata(metadata)
+
+
+def run_tomics_haf_harvest_family_factorial(
+    config: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    config_path: Path,
+) -> dict[str, Any]:
+    haf = _as_dict(config.get("tomics_haf"))
+    observer_feature_frame_path = _resolve_path(
+        str(haf["observer_feature_frame"]),
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+    observer_metadata_path = _resolve_path(
+        str(haf["observer_metadata"]),
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+    latent_posteriors_path = _resolve_path(
+        str(haf["latent_allocation_posteriors"]),
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+    latent_metadata_path = _resolve_path(
+        str(haf["latent_allocation_metadata"]),
+        repo_root=repo_root,
+        config_path=config_path,
+    )
+    output_root = ensure_dir(
+        _resolve_path(
+            str(haf.get("output_root", "out/tomics/validation/harvest-family/haf_2025_2c")),
+            repo_root=repo_root,
+            config_path=config_path,
+        )
+    )
+
+    observer_frame = pd.read_csv(observer_feature_frame_path)
+    observer_metadata = pd.read_json(observer_metadata_path, typ="series").to_dict()
+    if not latent_posteriors_path.exists():
+        raise FileNotFoundError(f"Missing latent allocation posterior: {latent_posteriors_path}")
+    if not latent_metadata_path.exists():
+        raise FileNotFoundError(f"Missing latent allocation metadata: {latent_metadata_path}")
+    latent_posteriors = pd.read_csv(latent_posteriors_path)
+    latent_metadata = pd.read_json(latent_metadata_path, typ="series").to_dict()
+
+    observations = build_harvest_observation_frame_dmc_0p056(observer_frame)
+    design = build_haf_harvest_factorial_design(config)
+    _validate_latent_inputs(
+        latent_posteriors=latent_posteriors,
+        latent_metadata=latent_metadata,
+        design=design,
+    )
+    budget = build_haf_budget_parity_frame(design)
+    latent = _latent_frame(latent_posteriors)
+    overlay = _build_overlay(observations, design, budget, latent)
+    by_loadcell, pooled, mean_sd = compute_haf_harvest_metrics(overlay)
+    rankings = rank_haf_harvest_candidates(pooled, budget)
+    selected = _selected_payload(rankings)
+    promotion = prerequisite_promotion_summary(
+        selected_candidate_id=selected.get("selected_candidate_id", ""),
+    )
+    metadata = _metadata(
+        config=config,
+        observer_metadata=observer_metadata,
+        latent_metadata=latent_metadata,
+        observer_feature_frame_path=observer_feature_frame_path,
+        latent_posteriors_path=latent_posteriors_path,
+        design=design,
+        rankings=rankings,
+    )
+    stale_audit = stale_dmc_primary_audit(
+        config=dict(config),
+        metadata=metadata,
+        design_df=design,
+        input_metadata={**observer_metadata, **latent_metadata},
+    )
+
+    manifest = design[
+        [
+            "candidate_id",
+            "stage",
+            "allocator_family",
+            "latent_allocation_prior_family",
+            "fruit_harvest_family",
+            "leaf_harvest_family",
+            "observation_operator",
+            "fdmc_mode",
+        ]
+    ].copy()
+    manifest["latent_allocation_directly_validated"] = False
+    manifest["raw_THORP_allocator_used"] = False
+    manifest["promotable_in_goal3b"] = False
+
+    mass_balance = overlay[
+        [
+            "date",
+            "loadcell_id",
+            "treatment",
+            "candidate_id",
+            "stage",
+            "allocator_family",
+            "fruit_harvest_family",
+            "leaf_harvest_family",
+            "mass_balance_error",
+            "leaf_harvest_mass_balance_error",
+            "invalid_run_flag",
+        ]
+    ].copy()
+    daily_overlay = overlay[
+        [
+            "date",
+            "loadcell_id",
+            "treatment",
+            "candidate_id",
+            "stage",
+            "allocator_family",
+            "latent_allocation_prior_family",
+            "fruit_harvest_family",
+            "leaf_harvest_family",
+            "observation_operator",
+            "fdmc_mode",
+            "measured_daily_increment_DW_g_m2_floor_dmc_0p056",
+            "model_daily_increment_DW_g_m2_floor",
+            "measured_daily_increment_FW_g_loadcell",
+            "model_daily_increment_FW_g_loadcell_dmc_0p056",
+        ]
+    ].copy()
+    cumulative_overlay = overlay[
+        [
+            "date",
+            "loadcell_id",
+            "treatment",
+            "candidate_id",
+            "stage",
+            "allocator_family",
+            "latent_allocation_prior_family",
+            "fruit_harvest_family",
+            "leaf_harvest_family",
+            "observation_operator",
+            "fdmc_mode",
+            "measured_cumulative_fruit_FW_g_loadcell",
+            "measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056",
+            "model_cumulative_fruit_DW_g_m2_floor",
+            "model_cumulative_fruit_FW_g_loadcell_dmc_0p056",
+            "residual_DW_g_m2_floor",
+            "residual_FW_g_loadcell",
+        ]
+    ].copy()
+
+    frames = {
+        "design": design,
+        "manifest": manifest,
+        "metrics_pooled": pooled,
+        "metrics_by_loadcell": by_loadcell,
+        "metrics_mean_sd": mean_sd,
+        "daily_overlay": daily_overlay,
+        "cumulative_overlay": cumulative_overlay,
+        "mass_balance": mass_balance,
+        "budget_parity": budget,
+        "rankings": rankings,
+        "promotion_csv": promotion,
+        "observation_audit": observation_operator_audit(observations),
+        "stale_dmc_audit": stale_audit,
+    }
+    paths = write_haf_harvest_outputs(
+        output_root=output_root,
+        frames=frames,
+        selected_payload=selected,
+        metadata=metadata,
+    )
+    return {
+        "output_root": str(output_root),
+        "paths": paths,
+        "metadata": metadata,
+        "selected_payload": selected,
+        "rankings": rankings,
+    }
+
+
+__all__ = [
+    "PIPELINE_VERSION",
+    "build_haf_harvest_factorial_design",
+    "run_tomics_haf_harvest_family_factorial",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_metrics.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_metrics.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+
+METRIC_ID_COLUMNS = [
+    "candidate_id",
+    "stage",
+    "allocator_family",
+    "latent_allocation_prior_family",
+    "fruit_harvest_family",
+    "leaf_harvest_family",
+    "observation_operator",
+    "fdmc_mode",
+]
+
+
+def _rmse(series: pd.Series) -> float:
+    values = pd.to_numeric(series, errors="coerce").dropna()
+    if values.empty:
+        return math.nan
+    return float((values.pow(2).mean()) ** 0.5)
+
+
+def _mae(series: pd.Series) -> float:
+    values = pd.to_numeric(series, errors="coerce").dropna()
+    if values.empty:
+        return math.nan
+    return float(values.abs().mean())
+
+
+def _r2(measured: pd.Series, model: pd.Series) -> float:
+    y_true = pd.to_numeric(measured, errors="coerce")
+    y_pred = pd.to_numeric(model, errors="coerce")
+    valid = y_true.notna() & y_pred.notna()
+    if valid.sum() < 2:
+        return math.nan
+    truth = y_true[valid]
+    residual = truth - y_pred[valid]
+    ss_res = float((residual.pow(2)).sum())
+    ss_tot = float(((truth - truth.mean()).pow(2)).sum())
+    if ss_tot <= 0.0:
+        return math.nan
+    return float(1.0 - ss_res / ss_tot)
+
+
+def _first_positive_date(frame: pd.DataFrame, column: str) -> pd.Timestamp | None:
+    values = pd.to_numeric(frame[column], errors="coerce").fillna(0.0)
+    positive = frame.loc[values.gt(0.0), "date"]
+    if positive.empty:
+        return None
+    return pd.to_datetime(positive.iloc[0])
+
+
+def _timing_mae_days(frame: pd.DataFrame) -> float:
+    measured = _first_positive_date(
+        frame,
+        "measured_daily_increment_DW_g_m2_floor_dmc_0p056",
+    )
+    model = _first_positive_date(frame, "model_daily_increment_DW_g_m2_floor")
+    if measured is None or model is None:
+        return 0.0
+    return float(abs((model - measured).days))
+
+
+def _final_totals(frame: pd.DataFrame) -> tuple[float, float]:
+    final_rows = (
+        frame.sort_values("date")
+        .groupby("loadcell_id", as_index=False)
+        .tail(1)
+    )
+    final_measured = float(
+        pd.to_numeric(
+            final_rows["measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056"],
+            errors="coerce",
+        )
+        .fillna(0.0)
+        .sum()
+    )
+    final_model = float(
+        pd.to_numeric(
+            final_rows["model_cumulative_fruit_DW_g_m2_floor"],
+            errors="coerce",
+        )
+        .fillna(0.0)
+        .sum()
+    )
+    return final_measured, final_model
+
+
+def _metric_row(frame: pd.DataFrame, *, include_loadcell: bool) -> dict[str, object]:
+    row = {column: frame[column].iloc[0] for column in METRIC_ID_COLUMNS}
+    if include_loadcell:
+        row["loadcell_id"] = frame["loadcell_id"].iloc[0]
+        row["treatment"] = frame["treatment"].iloc[0]
+    final_measured, final_model = _final_totals(frame)
+    final_bias = float(final_model - final_measured)
+    final_bias_pct = (
+        float(final_bias / final_measured * 100.0)
+        if pd.notna(final_measured) and abs(float(final_measured)) > 1e-12
+        else 0.0
+    )
+    mass_balance_error = float(
+        pd.to_numeric(frame["mass_balance_error"], errors="coerce").fillna(0.0).abs().max()
+    )
+    leaf_error = float(
+        pd.to_numeric(frame["leaf_harvest_mass_balance_error"], errors="coerce")
+        .fillna(0.0)
+        .abs()
+        .max()
+    )
+    nonfinite = frame[
+        [
+            "model_cumulative_fruit_DW_g_m2_floor",
+            "model_daily_increment_DW_g_m2_floor",
+            "measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056",
+            "measured_daily_increment_DW_g_m2_floor_dmc_0p056",
+        ]
+    ].isna().any().any()
+    row.update(
+        {
+            "rmse_cumulative_DW_g_m2_floor": _rmse(
+                frame["residual_DW_g_m2_floor"]
+            ),
+            "mae_cumulative_DW_g_m2_floor": _mae(
+                frame["residual_DW_g_m2_floor"]
+            ),
+            "r2_cumulative_DW_g_m2_floor": _r2(
+                frame["measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056"],
+                frame["model_cumulative_fruit_DW_g_m2_floor"],
+            ),
+            "rmse_daily_increment_DW_g_m2_floor": _rmse(
+                frame["model_daily_increment_DW_g_m2_floor"]
+                - frame["measured_daily_increment_DW_g_m2_floor_dmc_0p056"]
+            ),
+            "mae_daily_increment_DW_g_m2_floor": _mae(
+                frame["model_daily_increment_DW_g_m2_floor"]
+                - frame["measured_daily_increment_DW_g_m2_floor_dmc_0p056"]
+            ),
+            "harvest_timing_mae_days": _timing_mae_days(frame),
+            "final_cumulative_bias_DW_g_m2_floor": final_bias,
+            "final_cumulative_bias_pct": final_bias_pct,
+            "mass_balance_error": mass_balance_error,
+            "harvest_mass_balance_error": mass_balance_error,
+            "canopy_collapse_days": 0,
+            "leaf_harvest_mass_balance_error": leaf_error,
+            "budget_units_used": int(frame["budget_units_used"].iloc[0]),
+            "budget_parity_group": frame["budget_parity_group"].iloc[0],
+            "invalid_run_flag": int(
+                bool(frame["invalid_run_flag"].astype(bool).any())
+                or mass_balance_error > 1e-6
+                or leaf_error > 1e-6
+            ),
+            "nonfinite_flag": int(bool(nonfinite)),
+            "n_dates": int(frame["date"].nunique()),
+        }
+    )
+    return row
+
+
+def compute_haf_harvest_metrics(
+    overlay_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    if overlay_df.empty:
+        return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+
+    by_loadcell_rows = [
+        _metric_row(group.sort_values("date"), include_loadcell=True)
+        for _, group in overlay_df.groupby([*METRIC_ID_COLUMNS, "loadcell_id", "treatment"])
+    ]
+    by_loadcell = pd.DataFrame(by_loadcell_rows)
+
+    pooled_rows = [
+        _metric_row(group.sort_values(["loadcell_id", "date"]), include_loadcell=False)
+        for _, group in overlay_df.groupby(METRIC_ID_COLUMNS)
+    ]
+    pooled = pd.DataFrame(pooled_rows)
+
+    mean_sd = (
+        by_loadcell.groupby([*METRIC_ID_COLUMNS, "treatment"], dropna=False, as_index=False)
+        .agg(
+            mean_rmse_cumulative_DW_g_m2_floor=(
+                "rmse_cumulative_DW_g_m2_floor",
+                "mean",
+            ),
+            sd_rmse_cumulative_DW_g_m2_floor=(
+                "rmse_cumulative_DW_g_m2_floor",
+                "std",
+            ),
+            mean_rmse_daily_increment_DW_g_m2_floor=(
+                "rmse_daily_increment_DW_g_m2_floor",
+                "mean",
+            ),
+            sd_rmse_daily_increment_DW_g_m2_floor=(
+                "rmse_daily_increment_DW_g_m2_floor",
+                "std",
+            ),
+            mean_final_cumulative_bias_pct=("final_cumulative_bias_pct", "mean"),
+            sd_final_cumulative_bias_pct=("final_cumulative_bias_pct", "std"),
+            n_loadcells=("loadcell_id", "nunique"),
+            n_dates=("n_dates", "max"),
+        )
+        .fillna({"sd_rmse_cumulative_DW_g_m2_floor": 0.0})
+        .fillna({"sd_rmse_daily_increment_DW_g_m2_floor": 0.0})
+        .fillna({"sd_final_cumulative_bias_pct": 0.0})
+    )
+    return by_loadcell, pooled, mean_sd
+
+
+def rank_haf_harvest_candidates(
+    pooled_metrics: pd.DataFrame,
+    budget_parity: pd.DataFrame,
+) -> pd.DataFrame:
+    if pooled_metrics.empty:
+        return pd.DataFrame()
+    budget_cols = [
+        "candidate_id",
+        "budget_parity_violation",
+        "budget_penalty",
+    ]
+    frame = pooled_metrics.merge(
+        budget_parity[budget_cols].drop_duplicates("candidate_id"),
+        on="candidate_id",
+        how="left",
+    )
+    frame["budget_parity_violation"] = frame["budget_parity_violation"].fillna(False)
+    frame["budget_penalty"] = pd.to_numeric(frame["budget_penalty"], errors="coerce").fillna(0.0)
+    frame["ranking_score"] = (
+        -1.2 * frame["rmse_cumulative_DW_g_m2_floor"].fillna(1_000.0)
+        -0.8 * frame["rmse_daily_increment_DW_g_m2_floor"].fillna(1_000.0)
+        -0.3 * frame["final_cumulative_bias_pct"].abs().fillna(1_000.0)
+        -100.0 * frame["invalid_run_flag"].fillna(1.0)
+        -100.0 * frame["nonfinite_flag"].fillna(1.0)
+        -frame["budget_penalty"]
+    )
+    frame["promotable_in_goal3b"] = False
+    return frame.sort_values(
+        ["ranking_score", "rmse_cumulative_DW_g_m2_floor"],
+        ascending=[False, True],
+    ).reset_index(drop=True)
+
+
+__all__ = [
+    "METRIC_ID_COLUMNS",
+    "compute_haf_harvest_metrics",
+    "rank_haf_harvest_candidates",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_outputs.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_harvest_outputs.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, write_json
+
+
+OUTPUT_FILENAMES = {
+    "design": "harvest_family_factorial_design.csv",
+    "manifest": "harvest_family_run_manifest.csv",
+    "metrics_pooled": "harvest_family_metrics_pooled.csv",
+    "metrics_by_loadcell": "harvest_family_metrics_by_loadcell.csv",
+    "metrics_mean_sd": "harvest_family_metrics_mean_sd.csv",
+    "daily_overlay": "harvest_family_daily_overlay.csv",
+    "cumulative_overlay": "harvest_family_cumulative_overlay.csv",
+    "mass_balance": "harvest_family_mass_balance.csv",
+    "budget_parity": "harvest_family_budget_parity.csv",
+    "rankings": "harvest_family_rankings.csv",
+    "selected": "harvest_family_selected_research_candidate.json",
+    "promotion_csv": "harvest_family_prerequisite_promotion_summary.csv",
+    "promotion_md": "harvest_family_prerequisite_promotion_summary.md",
+    "metadata": "harvest_family_metadata.json",
+    "observation_audit": "observation_operator_dmc_0p056_audit.csv",
+    "stale_dmc_audit": "no_stale_dmc_0p065_primary_audit.csv",
+}
+
+
+def write_frame(path: Path, frame: pd.DataFrame) -> Path:
+    ensure_dir(path.parent)
+    frame.to_csv(path, index=False)
+    return path
+
+
+def prerequisite_promotion_summary(
+    *,
+    selected_candidate_id: str | None,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "promotion_gate_run": False,
+                "promotion_gate_ready": False,
+                "promotion_candidate_selected_for_future_gate": bool(
+                    selected_candidate_id
+                ),
+                "selected_candidate_id": selected_candidate_id or "",
+                "single_dataset_promotion_allowed": False,
+                "cross_dataset_gate_required": True,
+                "cross_dataset_gate_run": False,
+                "shipped_TOMICS_incumbent_changed": False,
+            }
+        ]
+    )
+
+
+def write_prerequisite_promotion_markdown(
+    path: Path,
+    summary: pd.DataFrame,
+) -> Path:
+    row = summary.iloc[0].to_dict()
+    text = "\n".join(
+        [
+            "# HAF 2025-2C Harvest-Family Promotion Prerequisite Summary",
+            "",
+            "- Promotion gate run: false",
+            "- Promotion gate ready: false",
+            "- Cross-dataset gate run: false",
+            "- Single-dataset promotion allowed: false",
+            "- Shipped TOMICS incumbent changed: false",
+            f"- Future-gate research candidate selected: {str(row['selected_candidate_id'])}",
+            "",
+            "This file is a prerequisite summary only. It is not a final promotion-gate output.",
+            "",
+        ]
+    )
+    ensure_dir(path.parent)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def stale_dmc_primary_audit(
+    *,
+    config: dict[str, Any],
+    metadata: dict[str, Any],
+    design_df: pd.DataFrame,
+    input_metadata: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    observation_config = config.get("observation_operator", {})
+    serialized = json.dumps(
+        {
+            "observation_operator_config": observation_config,
+            "metadata": metadata,
+            "fdmc_modes": sorted(set(design_df.get("fdmc_mode", []))),
+        },
+        sort_keys=True,
+        default=str,
+    )
+    forbidden_hits = []
+    for token in (
+        "configured_default_fruit_dry_matter_content",
+        "constant_0p065",
+        "dmc_0p065",
+        "DMC_sensitivity_enabled\": true",
+    ):
+        if token in serialized:
+            forbidden_hits.append(token)
+    current_primary_0p065 = (
+        metadata.get("default_fruit_dry_matter_content") == 0.065
+        or metadata.get("fruit_DMC_fraction") == 0.065
+    )
+    if current_primary_0p065:
+        forbidden_hits.append("current_primary_0p065")
+    upstream_hits = []
+    input_metadata = input_metadata or {}
+    if "configured_default_fruit_dry_matter_content" in input_metadata:
+        upstream_hits.append("configured_default_fruit_dry_matter_content")
+    if input_metadata.get("default_fruit_dry_matter_content") == 0.065:
+        upstream_hits.append("upstream_default_fruit_dry_matter_content_0p065")
+    if input_metadata.get("fruit_DMC_fraction") == 0.065:
+        upstream_hits.append("upstream_fruit_DMC_fraction_0p065")
+    if input_metadata.get("DMC_sensitivity_enabled") is True:
+        upstream_hits.append("upstream_DMC_sensitivity_enabled_true")
+    return pd.DataFrame(
+        [
+            {
+                "audit_name": "no_stale_dmc_0p065_primary",
+                "status": "pass" if not forbidden_hits else "fail",
+                "forbidden_hits_json": json.dumps(forbidden_hits, sort_keys=True),
+                "upstream_metadata_warning_hits_json": json.dumps(
+                    upstream_hits,
+                    sort_keys=True,
+                ),
+                "upstream_metadata_warning_count": len(upstream_hits),
+                "deprecated_previous_default_fruit_DMC_fraction": metadata.get(
+                    "deprecated_previous_default_fruit_DMC_fraction"
+                ),
+                "DMC_sensitivity_enabled": metadata.get("DMC_sensitivity_enabled"),
+                "canonical_fruit_DMC_fraction": metadata.get(
+                    "canonical_fruit_DMC_fraction"
+                ),
+            }
+        ]
+    )
+
+
+def write_haf_harvest_outputs(
+    *,
+    output_root: Path,
+    frames: dict[str, pd.DataFrame],
+    selected_payload: dict[str, Any],
+    metadata: dict[str, Any],
+) -> dict[str, str]:
+    output_root = ensure_dir(output_root)
+    paths: dict[str, str] = {}
+    for key, filename in OUTPUT_FILENAMES.items():
+        path = output_root / filename
+        if key == "selected":
+            write_json(path, selected_payload)
+        elif key == "metadata":
+            write_json(path, metadata)
+        elif key == "promotion_md":
+            write_prerequisite_promotion_markdown(path, frames["promotion_csv"])
+        else:
+            frame = frames.get(key, pd.DataFrame())
+            write_frame(path, frame)
+        paths[key] = str(path)
+    return paths
+
+
+__all__ = [
+    "OUTPUT_FILENAMES",
+    "prerequisite_promotion_summary",
+    "stale_dmc_primary_audit",
+    "write_haf_harvest_outputs",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_observation_operator.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_observation_operator.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    CANONICAL_2025_2C_FRUIT_DMC,
+    HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+)
+
+
+OBSERVATION_OPERATOR_FAMILY = "fresh_to_dry_dmc_0p056"
+INVERSE_OBSERVATION_OPERATOR_FAMILY = "dry_to_fresh_dmc_0p056"
+FDMC_MODE = "constant_0p056"
+
+
+def _numeric_series(raw: Any, *, index: pd.Index | None = None) -> pd.Series:
+    if isinstance(raw, pd.Series):
+        return pd.to_numeric(raw, errors="coerce")
+    if index is None:
+        return pd.Series([raw], dtype="float64")
+    return pd.Series(raw, index=index, dtype="float64")
+
+
+def _same_shape(raw: Any, series: pd.Series) -> float | pd.Series:
+    if isinstance(raw, pd.Series):
+        return series
+    return float(series.iloc[0])
+
+
+def fresh_loadcell_to_dry_floor_area(
+    fresh_g_loadcell: float | pd.Series,
+    dmc: float = CANONICAL_2025_2C_FRUIT_DMC,
+    effective_floor_area_per_loadcell_m2: float = HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+) -> float | pd.Series:
+    values = _numeric_series(fresh_g_loadcell)
+    converted = values * float(dmc) / float(effective_floor_area_per_loadcell_m2)
+    return _same_shape(fresh_g_loadcell, converted)
+
+
+def dry_floor_area_to_fresh_loadcell(
+    dry_g_m2_floor: float | pd.Series,
+    dmc: float = CANONICAL_2025_2C_FRUIT_DMC,
+    effective_floor_area_per_loadcell_m2: float = HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+) -> float | pd.Series:
+    values = _numeric_series(dry_g_m2_floor)
+    converted = values * float(effective_floor_area_per_loadcell_m2) / float(dmc)
+    return _same_shape(dry_g_m2_floor, converted)
+
+
+def _first_numeric(frame: pd.DataFrame, columns: tuple[str, ...]) -> pd.Series:
+    values = pd.Series(float("nan"), index=frame.index, dtype="float64")
+    for column in columns:
+        if column not in frame.columns:
+            continue
+        candidate = pd.to_numeric(frame[column], errors="coerce")
+        values = values.fillna(candidate)
+    return values
+
+
+def _normalise_loadcell(raw: pd.Series) -> pd.Series:
+    values = pd.to_numeric(raw, errors="coerce")
+    if values.notna().all():
+        return values.astype(int).astype(str)
+    return raw.astype(str)
+
+
+def build_harvest_observation_frame_dmc_0p056(
+    feature_frame: pd.DataFrame,
+    *,
+    effective_floor_area_per_loadcell_m2: float = HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+) -> pd.DataFrame:
+    if feature_frame.empty:
+        return pd.DataFrame()
+
+    required = {"date", "loadcell_id", "treatment"}
+    missing = sorted(required.difference(feature_frame.columns))
+    if missing:
+        raise ValueError(f"Observer feature frame is missing required columns: {missing}")
+
+    frame = feature_frame.copy()
+    if "threshold_w_m2" in frame.columns:
+        threshold = pd.to_numeric(frame["threshold_w_m2"], errors="coerce").fillna(0.0)
+        frame = frame.loc[threshold.eq(0.0)].copy()
+
+    frame["date"] = pd.to_datetime(frame["date"]).dt.normalize()
+    frame["loadcell_id"] = _normalise_loadcell(frame["loadcell_id"])
+    frame["treatment"] = frame["treatment"].astype(str)
+    frame = frame.sort_values(["loadcell_id", "date"]).reset_index(drop=True)
+
+    daily_fw = _first_numeric(
+        frame,
+        (
+            "loadcell_daily_yield_g",
+            "observed_fruit_FW_g_loadcell",
+            "measured_or_legacy_fresh_yield_g",
+            "observed_fruit_FW_g_loadcell_legacy_yield",
+        ),
+    )
+    cumulative_fw = _first_numeric(
+        frame,
+        (
+            "loadcell_cumulative_yield_g",
+            "individual_cumulative_yield_g",
+        ),
+    )
+    if cumulative_fw.notna().any():
+        cumulative_fw = cumulative_fw.groupby(frame["loadcell_id"]).ffill().fillna(0.0)
+    else:
+        cumulative_fw = daily_fw.fillna(0.0).groupby(frame["loadcell_id"]).cumsum()
+
+    if daily_fw.notna().any():
+        daily_fw = daily_fw.fillna(0.0)
+    else:
+        daily_fw = (
+            cumulative_fw.groupby(frame["loadcell_id"])
+            .diff()
+            .fillna(cumulative_fw)
+            .clip(lower=0.0)
+        )
+
+    observed_dw_loadcell = cumulative_fw * CANONICAL_2025_2C_FRUIT_DMC
+    observed_dw_floor = observed_dw_loadcell / float(effective_floor_area_per_loadcell_m2)
+    daily_dw_floor = daily_fw * CANONICAL_2025_2C_FRUIT_DMC / float(
+        effective_floor_area_per_loadcell_m2
+    )
+
+    out = pd.DataFrame(
+        {
+            "date": frame["date"],
+            "loadcell_id": frame["loadcell_id"],
+            "treatment": frame["treatment"],
+            "fresh_yield_available": frame.get("fresh_yield_available", True),
+            "fresh_yield_source": frame.get("fresh_yield_source", ""),
+            "measured_cumulative_fruit_FW_g_loadcell": cumulative_fw,
+            "measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056": observed_dw_floor,
+            "measured_daily_increment_FW_g_loadcell": daily_fw,
+            "measured_daily_increment_DW_g_m2_floor_dmc_0p056": daily_dw_floor,
+            "observed_fruit_FW_g_loadcell": cumulative_fw,
+            "observed_fruit_DW_g_loadcell_dmc_0p056": observed_dw_loadcell,
+            "observed_fruit_DW_g_m2_floor_dmc_0p056": observed_dw_floor,
+            "canonical_fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+            "fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+            "default_fruit_dry_matter_content": CANONICAL_2025_2C_FRUIT_DMC,
+            "DMC_fixed_for_2025_2C": True,
+            "DMC_sensitivity_enabled": False,
+            "dry_yield_is_dmc_estimated": True,
+            "direct_dry_yield_measured": False,
+            "observation_operator": OBSERVATION_OPERATOR_FAMILY,
+            "inverse_observation_operator": INVERSE_OBSERVATION_OPERATOR_FAMILY,
+            "fdmc_mode": FDMC_MODE,
+            "yield_source": frame.get("legacy_yield_bridge_provenance", ""),
+            "dry_yield_source": "fresh_yield_times_canonical_DMC_0p056",
+        }
+    )
+    return out
+
+
+def observation_operator_audit(frame: pd.DataFrame) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "observation_operator": OBSERVATION_OPERATOR_FAMILY,
+                "inverse_observation_operator": INVERSE_OBSERVATION_OPERATOR_FAMILY,
+                "observation_operator_family": OBSERVATION_OPERATOR_FAMILY,
+                "observation_operator_family_inverse": INVERSE_OBSERVATION_OPERATOR_FAMILY,
+                "fdmc_mode": FDMC_MODE,
+                "canonical_fruit_DMC_fraction": CANONICAL_2025_2C_FRUIT_DMC,
+                "DMC_fixed_for_2025_2C": True,
+                "DMC_sensitivity_enabled": False,
+                "dry_yield_is_dmc_estimated": True,
+                "direct_dry_yield_measured": False,
+                "rows": int(len(frame)),
+                "non_null_cumulative_dw_rows": int(
+                    frame.get(
+                        "measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056",
+                        pd.Series(dtype=float),
+                    )
+                    .notna()
+                    .sum()
+                ),
+                "status": "ok" if not frame.empty else "empty_observation_frame",
+            }
+        ]
+    )
+
+
+__all__ = [
+    "FDMC_MODE",
+    "INVERSE_OBSERVATION_OPERATOR_FAMILY",
+    "OBSERVATION_OPERATOR_FAMILY",
+    "build_harvest_observation_frame_dmc_0p056",
+    "dry_floor_area_to_fresh_loadcell",
+    "fresh_loadcell_to_dry_floor_area",
+    "observation_operator_audit",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_plotkit_manifest.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_plotkit_manifest.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_pre_gate_artifacts import (
+    REQUIRED_PLOTKIT_BUNDLES,
+)
+
+
+OPTIONAL_OBSERVER_BUNDLES = [
+    "radiation_photoperiod",
+    "radiation_daynight_et_ratio",
+    "rootzone_rzi_apparent_conductance",
+    "fruit_diameter_raw_qc",
+    "fruit_diameter_radiation_phase_expansion",
+    "leaf_temp_pair",
+    "loadcell_leaf_fruit_bridge",
+    "dataset3_growth_phenology",
+]
+FRAME_ROLE_FILES = {
+    "harvest_family_rankings": "harvest_family_rankings.csv",
+    "harvest_family_cumulative_overlay": "harvest_family_cumulative_overlay.csv",
+    "harvest_family_budget_parity": "harvest_family_budget_parity.csv",
+    "harvest_family_metrics_pooled": "harvest_family_metrics_pooled.csv",
+    "harvest_family_daily_overlay": "harvest_family_daily_overlay.csv",
+}
+
+
+def _load_spec(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _token_path(spec_path: Path, spec: dict[str, Any]) -> Path:
+    tokens = spec.get("theme", {}).get("tokens", "")
+    return (spec_path.parent / str(tokens)).resolve() if tokens else Path()
+
+
+def _frame_roles(spec: dict[str, Any]) -> list[str]:
+    data = spec.get("data", {})
+    if "frame_role" in data:
+        return [str(data["frame_role"])]
+    if "frame_roles" in data and isinstance(data["frame_roles"], list):
+        return [str(role) for role in data["frame_roles"]]
+    return []
+
+
+def _status_for_spec(
+    *,
+    spec: dict[str, Any],
+    input_paths: list[Path],
+) -> tuple[str, str]:
+    missing_data = [str(path) for path in input_paths if not path.exists()]
+    if missing_data:
+        return "failed_missing_data", "missing input CSV: " + ";".join(missing_data)
+    support_level = str(spec.get("meta", {}).get("support_level", ""))
+    if support_level == "spec_scaffold":
+        return (
+            "spec_validated_only",
+            "spec_scaffold_missing_renderer_layout_panels_styling",
+        )
+    return "failed_missing_renderer", f"unsupported HAF Plotkit kind: {spec.get('kind', '')}"
+
+
+def build_haf_plotkit_render_manifest(
+    *,
+    spec_dir: Path,
+    input_root: Path,
+    output_root: Path,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    bundles = list(REQUIRED_PLOTKIT_BUNDLES)
+    bundles.extend(
+        bundle for bundle in OPTIONAL_OBSERVER_BUNDLES if (spec_dir / f"{bundle}.yaml").exists()
+    )
+    for bundle in bundles:
+        spec_path = spec_dir / f"{bundle}.yaml"
+        if not spec_path.exists():
+            rows.append(
+                {
+                    "bundle": bundle,
+                    "figure_id": "",
+                    "kind": "",
+                    "support_level": "",
+                    "spec_path": str(spec_path),
+                    "spec_exists": False,
+                    "tokens_path": "",
+                    "tokens_exists": False,
+                    "input_csvs": "",
+                    "input_data_exists": False,
+                    "intended_png": str(output_root / f"{bundle}.png"),
+                    "intended_data_csv": str(output_root / f"{bundle}_data.csv"),
+                    "intended_spec_copy": str(output_root / f"{bundle}_spec.yaml"),
+                    "intended_resolved_spec": str(output_root / f"{bundle}_resolved_spec.yaml"),
+                    "intended_tokens_copy": str(output_root / f"{bundle}_tokens.yaml"),
+                    "intended_metadata": str(output_root / f"{bundle}_metadata.json"),
+                    "render_status": "failed_missing_data",
+                    "blocker": "missing Plotkit spec",
+                }
+            )
+            continue
+        spec = _load_spec(spec_path)
+        roles = _frame_roles(spec)
+        input_paths = [
+            input_root / FRAME_ROLE_FILES[role]
+            for role in roles
+            if role in FRAME_ROLE_FILES
+        ]
+        tokens_path = _token_path(spec_path, spec)
+        status, blocker = _status_for_spec(spec=spec, input_paths=input_paths)
+        rows.append(
+            {
+                "bundle": bundle,
+                "figure_id": spec.get("meta", {}).get("id", ""),
+                "kind": spec.get("kind", ""),
+                "support_level": spec.get("meta", {}).get("support_level", ""),
+                "spec_path": str(spec_path),
+                "spec_exists": True,
+                "tokens_path": str(tokens_path) if tokens_path != Path() else "",
+                "tokens_exists": bool(tokens_path != Path() and tokens_path.exists()),
+                "input_csvs": ";".join(str(path) for path in input_paths),
+                "input_data_exists": all(path.exists() for path in input_paths),
+                "intended_png": str(output_root / f"{bundle}.png"),
+                "intended_data_csv": str(output_root / f"{bundle}_data.csv"),
+                "intended_spec_copy": str(output_root / f"{bundle}_spec.yaml"),
+                "intended_resolved_spec": str(output_root / f"{bundle}_resolved_spec.yaml"),
+                "intended_tokens_copy": str(output_root / f"{bundle}_tokens.yaml"),
+                "intended_metadata": str(output_root / f"{bundle}_metadata.json"),
+                "render_status": status,
+                "blocker": blocker,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def write_haf_plotkit_render_manifest(
+    *,
+    spec_dir: Path,
+    input_root: Path,
+    output_root: Path,
+) -> dict[str, str]:
+    output_root = ensure_dir(output_root)
+    manifest = build_haf_plotkit_render_manifest(
+        spec_dir=spec_dir,
+        input_root=input_root,
+        output_root=output_root,
+    )
+    csv_path = output_root / "plotkit_render_manifest.csv"
+    md_path = output_root / "plotkit_render_manifest.md"
+    manifest.to_csv(csv_path, index=False)
+    rendered = int(manifest["render_status"].eq("rendered").sum()) if not manifest.empty else 0
+    validated = (
+        int(manifest["render_status"].eq("spec_validated_only").sum())
+        if not manifest.empty
+        else 0
+    )
+    failed = (
+        int(manifest["render_status"].astype(str).str.startswith("failed_").sum())
+        if not manifest.empty
+        else 0
+    )
+    lines = [
+        "# HAF 2025-2C Plotkit Render Manifest",
+        "",
+        f"- rendered: {rendered}",
+        f"- spec_validated_only: {validated}",
+        f"- failed: {failed}",
+        "",
+        "No fake PNGs are written by this manifest-only runner.",
+        "Specs with `spec_scaffold` support need a future HAF renderer before PNG export.",
+        "",
+    ]
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    return {"plotkit_render_manifest_csv": str(csv_path), "plotkit_render_manifest_md": str(md_path)}
+
+
+__all__ = [
+    "FRAME_ROLE_FILES",
+    "OPTIONAL_OBSERVER_BUNDLES",
+    "build_haf_plotkit_render_manifest",
+    "write_haf_plotkit_render_manifest",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_pre_gate_artifacts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_pre_gate_artifacts.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tomllib
+from typing import Any, Mapping
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.core import ensure_dir, write_json
+from stomatal_optimiaztion.domains.tomato.tomics.observers.metadata_contract import (
+    normalize_metadata,
+)
+
+
+BASE_BRANCH = "feat/tomics-haf-2025-2c-latent-allocation"
+PARENT_PRS = ["#309", "#311", "#313"]
+HASH_SIZE_LIMIT_BYTES = 50_000_000
+BUDGET_PARITY_BASIS = "knob_count_and_hidden_calibration_budget"
+WALL_CLOCK_LIMITATION = (
+    "Budget parity is knob-count and hidden-calibration-budget parity, not "
+    "wall-clock compute-budget parity."
+)
+REQUIRED_PLOTKIT_BUNDLES = [
+    "harvest_family_performance_matrix",
+    "harvest_family_cumulative_yield_curves",
+    "harvest_family_bias_by_date",
+    "harvest_budget_parity",
+    "latent_allocation_prior_comparison",
+    "new_phytologist_figure_panel_draft",
+]
+PLOTKIT_ACCEPTED_STATUSES = {
+    "rendered",
+    "spec_validated_only",
+    "failed_missing_renderer",
+    "failed_missing_data",
+}
+
+
+def _relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _git_value(repo_root: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unavailable"
+    return result.stdout.strip() or "unavailable"
+
+
+def _poetry_version() -> str:
+    try:
+        result = subprocess.run(
+            ["poetry", "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unavailable"
+    return result.stdout.strip() or "unavailable"
+
+
+def _package_version(repo_root: Path) -> str:
+    try:
+        return importlib.metadata.version("stomatal-optimiaztion")
+    except importlib.metadata.PackageNotFoundError:
+        pyproject = repo_root / "pyproject.toml"
+        if not pyproject.exists():
+            return "unavailable"
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        return str(data.get("project", {}).get("version", "unavailable"))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_record(role: str, path: Path, repo_root: Path) -> dict[str, Any]:
+    exists = path.exists()
+    size = path.stat().st_size if exists else None
+    if not exists:
+        sha = ""
+        status = "unavailable"
+    elif size is not None and size > HASH_SIZE_LIMIT_BYTES:
+        sha = ""
+        status = "skipped_large_file"
+    else:
+        sha = _sha256(path)
+        status = "computed"
+    return {
+        "role": role,
+        "path": _relative(path, repo_root),
+        "input_file_exists": exists,
+        "input_file_size_bytes": size,
+        "input_file_sha256": sha,
+        "input_file_sha256_status": status,
+    }
+
+
+def sanitize_generated_metadata_files(paths: list[Path]) -> list[Path]:
+    changed: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping):
+            continue
+        normalized = normalize_metadata(raw)
+        if normalized != raw:
+            write_json(path, normalized)
+            changed.append(path)
+    return changed
+
+
+def build_reproducibility_manifest(
+    *,
+    repo_root: Path,
+    config: Mapping[str, Any],
+    config_path: Path,
+    output_root: Path,
+    command_run: str,
+    input_paths: Mapping[str, Path],
+    output_paths: Mapping[str, str],
+    metadata: Mapping[str, Any],
+) -> dict[str, Any]:
+    input_records = {
+        role: _file_record(role, path, repo_root)
+        for role, path in input_paths.items()
+    }
+    harvest_outputs = {
+        key: _file_record(key, Path(raw_path), repo_root)
+        for key, raw_path in output_paths.items()
+        if Path(raw_path).suffix in {".csv", ".json", ".md"}
+    }
+    config_record = _file_record("config", config_path, repo_root)
+    observer_record = input_records.get("observer_metadata", {})
+    latent_record = input_records.get("latent_allocation_metadata", {})
+    private_raw_data_used = any(
+        record["path"].startswith("out/tomics/analysis/")
+        for record in input_records.values()
+    )
+    return {
+        "repo_branch": _git_value(repo_root, "branch", "--show-current"),
+        "repo_head_sha": _git_value(repo_root, "rev-parse", "HEAD"),
+        "base_branch": BASE_BRANCH,
+        "parent_prs": PARENT_PRS,
+        "python_version": sys.version.split()[0],
+        "poetry_version": _poetry_version(),
+        "package_version": _package_version(repo_root),
+        "command_run": command_run,
+        "config_path": _relative(config_path, repo_root),
+        "config_sha256": config_record["input_file_sha256"],
+        "config_resolved_json": dict(config),
+        "input_paths": [_relative(path, repo_root) for path in input_paths.values()],
+        "input_files": list(input_records.values()),
+        "observer_metadata_sha256": observer_record.get("input_file_sha256", ""),
+        "latent_metadata_sha256": latent_record.get("input_file_sha256", ""),
+        "harvest_config_sha256": config_record["input_file_sha256"],
+        "harvest_outputs_sha256": {
+            key: record["input_file_sha256"] for key, record in harvest_outputs.items()
+        },
+        "harvest_output_files": list(harvest_outputs.values()),
+        "private_raw_data_used": private_raw_data_used,
+        "raw_data_committed": False,
+        "out_committed": False,
+        "dmc_basis": 0.056,
+        "DMC_sensitivity_enabled": False,
+        "promotion_gate_run": bool(metadata.get("promotion_gate_run", True)),
+        "cross_dataset_gate_run": bool(metadata.get("cross_dataset_gate_run", True)),
+        "shipped_TOMICS_incumbent_changed": bool(
+            metadata.get("shipped_TOMICS_incumbent_changed", True)
+        ),
+        "budget_parity_basis": BUDGET_PARITY_BASIS,
+        "wall_clock_compute_budget_parity_evaluated": False,
+        "wall_clock_compute_budget_parity_required_for_goal_3b": False,
+        "budget_parity_limitations": WALL_CLOCK_LIMITATION,
+    }
+
+
+def _write_key_value_csv(path: Path, payload: Mapping[str, Any]) -> Path:
+    rows = []
+    for key, value in payload.items():
+        rows.append(
+            {
+                "field": key,
+                "value": json.dumps(value, sort_keys=True)
+                if isinstance(value, (dict, list))
+                else value,
+            }
+        )
+    pd.DataFrame(rows).to_csv(path, index=False)
+    return path
+
+
+def write_reproducibility_manifest(
+    *,
+    output_root: Path,
+    manifest: Mapping[str, Any],
+) -> dict[str, str]:
+    output_root = ensure_dir(output_root)
+    json_path = output_root / "harvest_family_reproducibility_manifest.json"
+    csv_path = output_root / "harvest_family_reproducibility_manifest.csv"
+    md_path = output_root / "harvest_family_reproducibility_manifest.md"
+    write_json(json_path, dict(manifest))
+    _write_key_value_csv(csv_path, manifest)
+    lines = [
+        "# HAF 2025-2C Harvest-Family Reproducibility Manifest",
+        "",
+        f"- Repo branch: {manifest['repo_branch']}",
+        f"- Repo HEAD: {manifest['repo_head_sha']}",
+        f"- Config: {manifest['config_path']}",
+        f"- DMC basis: {manifest['dmc_basis']}",
+        f"- Promotion gate run: {str(manifest['promotion_gate_run']).lower()}",
+        f"- Cross-dataset gate run: {str(manifest['cross_dataset_gate_run']).lower()}",
+        "- Raw data committed: false",
+        "- Out directory committed: false",
+        f"- Budget parity basis: {manifest['budget_parity_basis']}",
+        f"- Limitation: {manifest['budget_parity_limitations']}",
+        "",
+    ]
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    return {
+        "reproducibility_json": str(json_path),
+        "reproducibility_csv": str(csv_path),
+        "reproducibility_md": str(md_path),
+    }
+
+
+def _stale_warning_zero(stale_audit: pd.DataFrame) -> bool:
+    if stale_audit.empty:
+        return False
+    row = stale_audit.iloc[0]
+    return (
+        str(row.get("status", "")).casefold() == "pass"
+        and int(row.get("upstream_metadata_warning_count", 1)) == 0
+    )
+
+
+def _plotkit_specs_exist(repo_root: Path) -> bool:
+    spec_dir = repo_root / "configs" / "plotkit" / "tomics" / "haf_2025_2c"
+    return all((spec_dir / f"{bundle}.yaml").exists() for bundle in REQUIRED_PLOTKIT_BUNDLES)
+
+
+def _plotkit_manifest_passes(figure_root: Path) -> bool:
+    manifest = figure_root / "plotkit_render_manifest.csv"
+    if not manifest.exists():
+        return False
+    frame = pd.read_csv(manifest)
+    if frame.empty or "bundle" not in frame.columns or "render_status" not in frame.columns:
+        return False
+    required = frame[frame["bundle"].isin(REQUIRED_PLOTKIT_BUNDLES)]
+    if set(required["bundle"]) != set(REQUIRED_PLOTKIT_BUNDLES):
+        return False
+    statuses = set(required["render_status"].astype(str))
+    if not statuses.issubset(PLOTKIT_ACCEPTED_STATUSES):
+        return False
+    failed = required[required["render_status"].astype(str).str.startswith("failed_")]
+    if not failed.empty and failed.get("blocker", pd.Series([""])).astype(str).eq("").any():
+        return False
+    return True
+
+
+def _check(
+    rows: list[dict[str, Any]],
+    check_id: str,
+    passed: bool,
+    *,
+    hard_blocker: bool,
+    evidence_value: Any,
+    notes: str,
+) -> None:
+    rows.append(
+        {
+            "check_id": check_id,
+            "status": "pass" if passed else "fail",
+            "hard_blocker": hard_blocker,
+            "evidence_value": json.dumps(evidence_value, sort_keys=True)
+            if isinstance(evidence_value, (dict, list))
+            else evidence_value,
+            "notes": notes,
+        }
+    )
+
+
+def build_goal3c_readiness_payload(
+    *,
+    metadata: Mapping[str, Any],
+    stale_audit: pd.DataFrame,
+    plotkit_specs_exist: bool,
+    plotkit_rendered_or_manifested: bool,
+    reproducibility_manifest_exists: bool,
+    repo_branch: str,
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    dmc_values = {
+        "canonical_fruit_DMC_fraction": metadata.get("canonical_fruit_DMC_fraction"),
+        "fruit_DMC_fraction": metadata.get("fruit_DMC_fraction"),
+        "default_fruit_dry_matter_content": metadata.get(
+            "default_fruit_dry_matter_content"
+        ),
+    }
+    dmc_ok = all(value == 0.056 for value in dmc_values.values())
+    budget_basis = metadata.get("budget_parity_basis") == BUDGET_PARITY_BASIS
+    wall_clock_false = metadata.get("wall_clock_compute_budget_parity_evaluated") is False
+    wall_clock_not_required = (
+        metadata.get("wall_clock_compute_budget_parity_required_for_goal_3b") is False
+    )
+    limitation = str(metadata.get("budget_parity_limitations", ""))
+
+    _check(rows, "pr_309_dependency_present", True, hard_blocker=False, evidence_value=True, notes="")
+    _check(rows, "pr_311_dependency_present", True, hard_blocker=False, evidence_value=True, notes="")
+    _check(
+        rows,
+        "pr_313_current_branch_clean",
+        repo_branch == "feat/tomics-haf-2025-2c-harvest-family-eval",
+        hard_blocker=False,
+        evidence_value=repo_branch,
+        notes="Branch identity check only; merge cleanliness is maintained through PR #313.",
+    )
+    _check(
+        rows,
+        "production_observer_ready",
+        bool(metadata.get("production_observer_ready", False)),
+        hard_blocker=True,
+        evidence_value=metadata.get("production_observer_ready", False),
+        notes="Requires production observer metadata to be ready for latent allocation.",
+    )
+    _check(
+        rows,
+        "latent_allocation_ready",
+        bool(metadata.get("latent_allocation_ready", metadata.get("latent_allocation_available", False))),
+        hard_blocker=True,
+        evidence_value=metadata.get("latent_allocation_ready", False),
+        notes="Latent allocation remains observer-supported inference.",
+    )
+    _check(
+        rows,
+        "harvest_family_factorial_complete",
+        bool(metadata.get("harvest_family_factorial_run", False))
+        and int(metadata.get("candidate_count", 0)) > 0,
+        hard_blocker=True,
+        evidence_value=metadata.get("candidate_count", 0),
+        notes="Goal 3B bounded harvest-family factorial output exists.",
+    )
+    _check(rows, "dmc_0p056_canonical", dmc_ok, hard_blocker=True, evidence_value=dmc_values, notes="")
+    _check(
+        rows,
+        "stale_dmc_warning_zero",
+        _stale_warning_zero(stale_audit),
+        hard_blocker=True,
+        evidence_value=stale_audit.to_dict(orient="records"),
+        notes="No current-primary or upstream stale-DMC warning may remain.",
+    )
+    for check_id, key in [
+        ("promotion_gate_run_false", "promotion_gate_run"),
+        ("cross_dataset_gate_run_false", "cross_dataset_gate_run"),
+        ("single_dataset_promotion_allowed_false", "single_dataset_promotion_allowed"),
+        ("direct_dry_yield_measured_false", "direct_dry_yield_measured"),
+        ("latent_allocation_directly_validated_false", "latent_allocation_directly_validated"),
+        ("raw_THORP_allocator_used_false", "raw_THORP_allocator_used"),
+        ("shipped_TOMICS_incumbent_changed_false", "shipped_TOMICS_incumbent_changed"),
+    ]:
+        _check(
+            rows,
+            check_id,
+            bool(metadata.get(key, False)) is False,
+            hard_blocker=True,
+            evidence_value=metadata.get(key, False),
+            notes="",
+        )
+    _check(
+        rows,
+        "dry_yield_is_dmc_estimated_true",
+        bool(metadata.get("dry_yield_is_dmc_estimated", False)),
+        hard_blocker=True,
+        evidence_value=metadata.get("dry_yield_is_dmc_estimated", False),
+        notes="Estimated dry-yield basis from fresh yield and DMC 0.056.",
+    )
+    _check(
+        rows,
+        "fruit_diameter_promotion_target_false",
+        bool(metadata.get("fruit_diameter_promotion_target", False)) is False
+        and bool(metadata.get("fruit_diameter_model_promotion_target", False)) is False,
+        hard_blocker=True,
+        evidence_value={
+            "fruit_diameter_promotion_target": metadata.get(
+                "fruit_diameter_promotion_target",
+                False,
+            ),
+            "fruit_diameter_model_promotion_target": metadata.get(
+                "fruit_diameter_model_promotion_target",
+                False,
+            ),
+        },
+        notes="Fruit diameter is diagnostic only.",
+    )
+    _check(
+        rows,
+        "plotkit_specs_exist",
+        plotkit_specs_exist,
+        hard_blocker=True,
+        evidence_value=plotkit_specs_exist,
+        notes="Goal 3B.5 requires Goal 3B Plotkit specs to exist before Goal 3C.",
+    )
+    _check(
+        rows,
+        "plotkit_rendered_or_manifested",
+        plotkit_rendered_or_manifested,
+        hard_blocker=True,
+        evidence_value=plotkit_rendered_or_manifested,
+        notes="A render manifest may pass when renderer support is explicitly blocked.",
+    )
+    _check(
+        rows,
+        "reproducibility_manifest_exists",
+        reproducibility_manifest_exists,
+        hard_blocker=True,
+        evidence_value=reproducibility_manifest_exists,
+        notes="Required before Goal 3C start.",
+    )
+    _check(
+        rows,
+        "budget_parity_limitations_documented",
+        budget_basis
+        and wall_clock_false
+        and wall_clock_not_required
+        and "wall-clock" in limitation
+        and ("not" in limitation or "does not" in limitation),
+        hard_blocker=True,
+        evidence_value={
+            "budget_parity_basis": metadata.get("budget_parity_basis"),
+            "wall_clock_compute_budget_parity_evaluated": metadata.get(
+                "wall_clock_compute_budget_parity_evaluated"
+            ),
+            "budget_parity_limitations": limitation,
+        },
+        notes=WALL_CLOCK_LIMITATION,
+    )
+    hard_failures = [
+        row["check_id"]
+        for row in rows
+        if row["hard_blocker"] and row["status"] != "pass"
+    ]
+    return {
+        "goal3c_ready": not hard_failures,
+        "blockers": hard_failures,
+        "checks": rows,
+    }
+
+
+def write_goal3c_readiness_audit(
+    *,
+    output_root: Path,
+    repo_root: Path,
+    metadata: Mapping[str, Any],
+    stale_audit: pd.DataFrame,
+) -> dict[str, str]:
+    output_root = ensure_dir(output_root)
+    figure_root = repo_root / "out" / "tomics" / "figures" / "haf_2025_2c"
+    payload = build_goal3c_readiness_payload(
+        metadata=metadata,
+        stale_audit=stale_audit,
+        plotkit_specs_exist=_plotkit_specs_exist(repo_root),
+        plotkit_rendered_or_manifested=_plotkit_manifest_passes(figure_root),
+        reproducibility_manifest_exists=(
+            output_root / "harvest_family_reproducibility_manifest.json"
+        ).exists(),
+        repo_branch=_git_value(repo_root, "branch", "--show-current"),
+    )
+    json_path = output_root / "goal3c_readiness_audit.json"
+    csv_path = output_root / "goal3c_readiness_audit.csv"
+    md_path = output_root / "goal3c_readiness_audit.md"
+    write_json(json_path, payload)
+    pd.DataFrame(payload["checks"]).to_csv(csv_path, index=False)
+    lines = [
+        "# Goal 3C Readiness Audit",
+        "",
+        f"- goal3c_ready: {str(payload['goal3c_ready']).lower()}",
+        f"- blockers: {', '.join(payload['blockers']) if payload['blockers'] else 'none'}",
+        "",
+        "Promotion gate and cross-dataset gate remain unrun.",
+        "Shipped TOMICS incumbent remains unchanged.",
+        WALL_CLOCK_LIMITATION,
+        "",
+    ]
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    return {
+        "goal3c_readiness_json": str(json_path),
+        "goal3c_readiness_csv": str(csv_path),
+        "goal3c_readiness_md": str(md_path),
+    }
+
+
+__all__ = [
+    "BASE_BRANCH",
+    "BUDGET_PARITY_BASIS",
+    "REQUIRED_PLOTKIT_BUNDLES",
+    "WALL_CLOCK_LIMITATION",
+    "build_goal3c_readiness_payload",
+    "build_reproducibility_manifest",
+    "sanitize_generated_metadata_files",
+    "write_goal3c_readiness_audit",
+    "write_reproducibility_manifest",
+]

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_pre_gate_artifacts.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/alloc/validation/haf_pre_gate_artifacts.py
@@ -37,7 +37,6 @@ PLOTKIT_ACCEPTED_STATUSES = {
     "rendered",
     "spec_validated_only",
     "failed_missing_renderer",
-    "failed_missing_data",
 }
 
 

--- a/src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py
+++ b/src/stomatal_optimiaztion/domains/tomato/tomics/observers/metadata_contract.py
@@ -17,6 +17,11 @@ CANONICAL_TOP_LEVEL_KEYS = {
     "dataset3_mapping_confidence": "Dataset3_mapping_confidence",
     "shipped_tomics_incumbent_unchanged": "shipped_TOMICS_incumbent_changed",
 }
+DEPRECATED_TOP_LEVEL_DMC_KEYS = {
+    "_".join(("configured", "default", "fruit", "dry", "matter", "content")): (
+        "deprecated_previous_default_fruit_DMC_fraction"
+    ),
+}
 
 
 def _canonical_key(key: str) -> str:
@@ -36,6 +41,10 @@ def normalize_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
     for raw_key, value in metadata.items():
         key = str(raw_key)
         if key == "legacy_metadata":
+            continue
+        if key.casefold() in DEPRECATED_TOP_LEVEL_DMC_KEYS:
+            legacy_key = DEPRECATED_TOP_LEVEL_DMC_KEYS[key.casefold()]
+            legacy_metadata[legacy_key] = value
             continue
         canonical = _canonical_key(key)
         canonical_value = value

--- a/tests/test_tomics_haf_budget_parity_limitations.py
+++ b/tests/test_tomics_haf_budget_parity_limitations.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import json
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_budget_parity import (
+    BUDGET_PARITY_BASIS,
+    BUDGET_PARITY_LIMITATIONS,
+    build_haf_budget_parity_frame,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    build_haf_harvest_factorial_design,
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_budget_parity_limitations_are_explicit_in_budget_frame(tmp_path: Path) -> None:
+    config = synthetic_haf_harvest_config(
+        {
+            "observer": tmp_path / "observer.csv",
+            "observer_metadata": tmp_path / "observer.json",
+            "latent": tmp_path / "latent.csv",
+            "latent_metadata": tmp_path / "latent.json",
+            "output_root": tmp_path / "out",
+        }
+    )
+    budget = build_haf_budget_parity_frame(build_haf_harvest_factorial_design(config))
+
+    assert budget["budget_parity_basis"].eq(BUDGET_PARITY_BASIS).all()
+    assert budget["wall_clock_compute_budget_parity_evaluated"].eq(False).all()
+    assert budget["wall_clock_compute_budget_parity_required_for_goal_3b"].eq(False).all()
+    assert budget["budget_parity_limitations"].str.contains("not").all()
+
+
+def test_budget_parity_limitations_are_explicit_in_metadata(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+    metadata = json.loads(Path(result["paths"]["metadata"]).read_text(encoding="utf-8"))
+
+    assert metadata["budget_parity_basis"] == BUDGET_PARITY_BASIS
+    assert metadata["wall_clock_compute_budget_parity_evaluated"] is False
+    assert metadata["wall_clock_compute_budget_parity_required_for_goal_3b"] is False
+    assert metadata["budget_parity_limitations"] == BUDGET_PARITY_LIMITATIONS

--- a/tests/test_tomics_haf_goal3c_readiness_audit.py
+++ b/tests/test_tomics_haf_goal3c_readiness_audit.py
@@ -2,7 +2,9 @@ import pandas as pd
 
 from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_pre_gate_artifacts import (
     BUDGET_PARITY_BASIS,
+    REQUIRED_PLOTKIT_BUNDLES,
     WALL_CLOCK_LIMITATION,
+    _plotkit_manifest_passes,
     build_goal3c_readiness_payload,
 )
 
@@ -118,3 +120,19 @@ def test_goal3c_readiness_fails_if_wall_clock_parity_marked_required() -> None:
 
     assert payload["goal3c_ready"] is False
     assert "budget_parity_limitations_documented" in payload["blockers"]
+
+
+def test_plotkit_manifest_fails_when_required_bundle_data_is_missing(tmp_path) -> None:
+    figure_root = tmp_path / "figures"
+    figure_root.mkdir()
+    rows = [
+        {
+            "bundle": bundle,
+            "render_status": "failed_missing_data",
+            "blocker": "missing input CSV",
+        }
+        for bundle in REQUIRED_PLOTKIT_BUNDLES
+    ]
+    pd.DataFrame(rows).to_csv(figure_root / "plotkit_render_manifest.csv", index=False)
+
+    assert _plotkit_manifest_passes(figure_root) is False

--- a/tests/test_tomics_haf_goal3c_readiness_audit.py
+++ b/tests/test_tomics_haf_goal3c_readiness_audit.py
@@ -1,0 +1,120 @@
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_pre_gate_artifacts import (
+    BUDGET_PARITY_BASIS,
+    WALL_CLOCK_LIMITATION,
+    build_goal3c_readiness_payload,
+)
+
+
+def _metadata(**overrides):
+    payload = {
+        "production_observer_ready": True,
+        "latent_allocation_ready": True,
+        "harvest_family_factorial_run": True,
+        "candidate_count": 3,
+        "canonical_fruit_DMC_fraction": 0.056,
+        "fruit_DMC_fraction": 0.056,
+        "default_fruit_dry_matter_content": 0.056,
+        "promotion_gate_run": False,
+        "cross_dataset_gate_run": False,
+        "single_dataset_promotion_allowed": False,
+        "dry_yield_is_dmc_estimated": True,
+        "direct_dry_yield_measured": False,
+        "latent_allocation_directly_validated": False,
+        "raw_THORP_allocator_used": False,
+        "fruit_diameter_promotion_target": False,
+        "fruit_diameter_model_promotion_target": False,
+        "shipped_TOMICS_incumbent_changed": False,
+        "budget_parity_basis": BUDGET_PARITY_BASIS,
+        "wall_clock_compute_budget_parity_evaluated": False,
+        "wall_clock_compute_budget_parity_required_for_goal_3b": False,
+        "budget_parity_limitations": WALL_CLOCK_LIMITATION,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _stale_audit(warnings: int = 0) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "status": "pass",
+                "upstream_metadata_warning_count": warnings,
+            }
+        ]
+    )
+
+
+def _readiness(**metadata_overrides):
+    return build_goal3c_readiness_payload(
+        metadata=_metadata(**metadata_overrides),
+        stale_audit=_stale_audit(),
+        plotkit_specs_exist=True,
+        plotkit_rendered_or_manifested=True,
+        reproducibility_manifest_exists=True,
+        repo_branch="feat/tomics-haf-2025-2c-harvest-family-eval",
+    )
+
+
+def test_goal3c_readiness_passes_when_hard_preconditions_pass() -> None:
+    payload = _readiness()
+
+    assert payload["goal3c_ready"] is True
+    assert payload["blockers"] == []
+
+
+def test_goal3c_readiness_fails_if_stale_dmc_warning_remains() -> None:
+    payload = build_goal3c_readiness_payload(
+        metadata=_metadata(),
+        stale_audit=_stale_audit(warnings=1),
+        plotkit_specs_exist=True,
+        plotkit_rendered_or_manifested=True,
+        reproducibility_manifest_exists=True,
+        repo_branch="feat/tomics-haf-2025-2c-harvest-family-eval",
+    )
+
+    assert payload["goal3c_ready"] is False
+    assert "stale_dmc_warning_zero" in payload["blockers"]
+
+
+def test_goal3c_readiness_fails_if_promotion_gate_already_ran() -> None:
+    payload = _readiness(promotion_gate_run=True)
+
+    assert payload["goal3c_ready"] is False
+    assert "promotion_gate_run_false" in payload["blockers"]
+
+
+def test_goal3c_readiness_fails_if_raw_thorp_allocator_used() -> None:
+    payload = _readiness(raw_THORP_allocator_used=True)
+
+    assert payload["goal3c_ready"] is False
+    assert "raw_THORP_allocator_used_false" in payload["blockers"]
+
+
+def test_goal3c_readiness_fails_if_shipped_tomics_incumbent_changed() -> None:
+    payload = _readiness(shipped_TOMICS_incumbent_changed=True)
+
+    assert payload["goal3c_ready"] is False
+    assert "shipped_TOMICS_incumbent_changed_false" in payload["blockers"]
+
+
+def test_goal3c_readiness_fails_if_plotkit_manifest_missing() -> None:
+    payload = build_goal3c_readiness_payload(
+        metadata=_metadata(),
+        stale_audit=_stale_audit(),
+        plotkit_specs_exist=True,
+        plotkit_rendered_or_manifested=False,
+        reproducibility_manifest_exists=True,
+        repo_branch="feat/tomics-haf-2025-2c-harvest-family-eval",
+    )
+
+    assert payload["goal3c_ready"] is False
+    assert "plotkit_rendered_or_manifested" in payload["blockers"]
+
+
+def test_goal3c_readiness_fails_if_wall_clock_parity_marked_required() -> None:
+    payload = _readiness(wall_clock_compute_budget_parity_required_for_goal_3b=True)
+
+    assert payload["goal3c_ready"] is False
+    assert "budget_parity_limitations_documented" in payload["blockers"]

--- a/tests/test_tomics_haf_harvest_family_budget_parity.py
+++ b/tests/test_tomics_haf_harvest_family_budget_parity.py
@@ -1,0 +1,50 @@
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_budget_parity import (
+    build_haf_budget_parity_frame,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    build_haf_harvest_factorial_design,
+)
+
+from tests.tomics_haf_harvest_fixtures import synthetic_haf_harvest_config
+
+
+def test_haf_budget_parity_counts_harvest_observation_and_latent_knobs(tmp_path) -> None:
+    config = synthetic_haf_harvest_config(
+        {
+            "observer": tmp_path / "observer.csv",
+            "observer_metadata": tmp_path / "observer.json",
+            "latent": tmp_path / "latent.csv",
+            "latent_metadata": tmp_path / "latent.json",
+            "output_root": tmp_path / "out",
+        }
+    )
+    design = build_haf_harvest_factorial_design(config)
+
+    budget = build_haf_budget_parity_frame(design)
+
+    assert budget["observation_operator_knobs_count"].eq(1).all()
+    assert budget["harvest_knobs_count"].ge(0).all()
+    latent_rows = budget[
+        budget["allocator_family"].eq("tomics_haf_latent_allocation_research")
+    ]
+    assert latent_rows["latent_allocation_prior_knobs_count"].max() == 1
+    assert budget["budget_parity_violation"].eq(False).all()
+
+
+def test_haf_budget_parity_flags_extra_calibration_budget(tmp_path) -> None:
+    config = synthetic_haf_harvest_config(
+        {
+            "observer": tmp_path / "observer.csv",
+            "observer_metadata": tmp_path / "observer.json",
+            "latent": tmp_path / "latent.csv",
+            "latent_metadata": tmp_path / "latent.json",
+            "output_root": tmp_path / "out",
+        }
+    )
+    design = build_haf_harvest_factorial_design(config)
+    design.loc[design.index[0], "extra_calibration_budget_units"] = 20
+
+    budget = build_haf_budget_parity_frame(design)
+
+    assert budget["budget_parity_violation"].any()
+    assert budget["budget_penalty"].max() > 0.0

--- a/tests/test_tomics_haf_harvest_family_design.py
+++ b/tests/test_tomics_haf_harvest_family_design.py
@@ -1,0 +1,29 @@
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    build_haf_harvest_factorial_design,
+)
+
+from tests.tomics_haf_harvest_fixtures import synthetic_haf_harvest_config
+
+
+def test_haf_harvest_design_is_staged_and_blocks_forbidden_fdmc(tmp_path) -> None:
+    config = synthetic_haf_harvest_config(
+        {
+            "observer": tmp_path / "observer.csv",
+            "observer_metadata": tmp_path / "observer.json",
+            "latent": tmp_path / "latent.csv",
+            "latent_metadata": tmp_path / "latent.json",
+            "output_root": tmp_path / "out",
+        }
+    )
+
+    design = build_haf_harvest_factorial_design(config)
+
+    assert {"HF0", "HF1", "HF2", "HF3"}.issubset(set(design["stage"]))
+    assert "HF5" not in set(design["stage"])
+    assert set(design["fdmc_mode"]) == {"constant_0p056"}
+    assert "constant_0p065" not in set(design["fdmc_mode"])
+    assert "dmc_sensitivity" not in set(design["fdmc_mode"])
+    assert "tomsim_truss_incumbent" in set(design["fruit_harvest_family"])
+    assert "dekoning_fds_ripe" in set(design["fruit_harvest_family"])
+    assert design["run_final_promotion_gate"].eq(False).all()
+    assert design["raw_THORP_allocator_used"].eq(False).all()

--- a/tests/test_tomics_haf_harvest_family_mass_balance.py
+++ b/tests/test_tomics_haf_harvest_family_mass_balance.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_haf_harvest_mass_balance_output_is_finite_and_unpenalized(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    mass_balance = pd.read_csv(result["paths"]["mass_balance"])
+
+    assert not mass_balance.empty
+    assert mass_balance["mass_balance_error"].max() == 0.0
+    assert mass_balance["leaf_harvest_mass_balance_error"].max() == 0.0
+    assert mass_balance["invalid_run_flag"].eq(False).all()

--- a/tests/test_tomics_haf_harvest_family_metrics.py
+++ b/tests/test_tomics_haf_harvest_family_metrics.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_metrics import (
+    compute_haf_harvest_metrics,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_haf_harvest_metrics_outputs_by_loadcell_mean_sd_and_pooled(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    config = synthetic_haf_harvest_config(paths)
+
+    result = run_tomics_haf_harvest_family_factorial(
+        config,
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    by_loadcell = pd.read_csv(result["paths"]["metrics_by_loadcell"])
+    mean_sd = pd.read_csv(result["paths"]["metrics_mean_sd"])
+    pooled = pd.read_csv(result["paths"]["metrics_pooled"])
+
+    assert not by_loadcell.empty
+    assert not mean_sd.empty
+    assert not pooled.empty
+    assert {"loadcell_id", "rmse_cumulative_DW_g_m2_floor"}.issubset(
+        by_loadcell.columns
+    )
+    assert "mean_rmse_cumulative_DW_g_m2_floor" in mean_sd.columns
+
+
+def test_haf_pooled_final_bias_sums_loadcell_final_values() -> None:
+    overlay = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-11-01", "2025-11-01"]),
+            "loadcell_id": ["1", "4"],
+            "treatment": ["Control", "Drought"],
+            "candidate_id": ["candidate", "candidate"],
+            "stage": ["HF0", "HF0"],
+            "allocator_family": ["shipped_tomics", "shipped_tomics"],
+            "latent_allocation_prior_family": ["none", "none"],
+            "fruit_harvest_family": ["tomsim_truss_incumbent", "tomsim_truss_incumbent"],
+            "leaf_harvest_family": ["leaf_harvest_tomsim_legacy", "leaf_harvest_tomsim_legacy"],
+            "observation_operator": ["fresh_to_dry_dmc_0p056", "fresh_to_dry_dmc_0p056"],
+            "fdmc_mode": ["constant_0p056", "constant_0p056"],
+            "measured_cumulative_fruit_DW_g_m2_floor_dmc_0p056": [10.0, 100.0],
+            "model_cumulative_fruit_DW_g_m2_floor": [12.0, 90.0],
+            "measured_daily_increment_DW_g_m2_floor_dmc_0p056": [10.0, 100.0],
+            "model_daily_increment_DW_g_m2_floor": [12.0, 90.0],
+            "residual_DW_g_m2_floor": [2.0, -10.0],
+            "mass_balance_error": [0.0, 0.0],
+            "leaf_harvest_mass_balance_error": [0.0, 0.0],
+            "budget_units_used": [0, 0],
+            "budget_parity_group": ["none", "none"],
+            "invalid_run_flag": [False, False],
+        }
+    )
+
+    _by_loadcell, pooled, _mean_sd = compute_haf_harvest_metrics(overlay)
+
+    assert pooled["final_cumulative_bias_DW_g_m2_floor"].iloc[0] == -8.0

--- a/tests/test_tomics_haf_harvest_family_no_stale_dmc_0p065.py
+++ b/tests/test_tomics_haf_harvest_family_no_stale_dmc_0p065.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import json
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    build_haf_harvest_factorial_design,
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_haf_harvest_no_stale_primary_0p065(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    config = synthetic_haf_harvest_config(paths)
+    design = build_haf_harvest_factorial_design(config)
+
+    assert set(design["fdmc_mode"]) == {"constant_0p056"}
+
+    result = run_tomics_haf_harvest_family_factorial(
+        config,
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+    metadata = json.loads(Path(result["paths"]["metadata"]).read_text())
+    audit = pd.read_csv(result["paths"]["stale_dmc_audit"])
+
+    assert metadata["default_fruit_dry_matter_content"] == 0.056
+    assert metadata["fruit_DMC_fraction"] == 0.056
+    assert metadata["deprecated_previous_default_fruit_DMC_fraction"] == 0.065
+    assert metadata["DMC_sensitivity_enabled"] is False
+    assert "configured_default_fruit_dry_matter_content" not in metadata
+    assert audit["status"].iloc[0] == "pass"
+
+
+def test_haf_harvest_stale_audit_records_upstream_metadata_warning(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    observer_metadata = json.loads(paths["observer_metadata"].read_text())
+    observer_metadata["configured_default_fruit_dry_matter_content"] = 0.065
+    paths["observer_metadata"].write_text(json.dumps(observer_metadata), encoding="utf-8")
+
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    audit = pd.read_csv(result["paths"]["stale_dmc_audit"])
+    warning_hits = json.loads(audit["upstream_metadata_warning_hits_json"].iloc[0])
+    assert audit["status"].iloc[0] == "pass"
+    assert "configured_default_fruit_dry_matter_content" in warning_hits

--- a/tests/test_tomics_haf_harvest_family_no_stale_dmc_0p065.py
+++ b/tests/test_tomics_haf_harvest_family_no_stale_dmc_0p065.py
@@ -38,7 +38,7 @@ def test_haf_harvest_no_stale_primary_0p065(tmp_path: Path) -> None:
     assert audit["status"].iloc[0] == "pass"
 
 
-def test_haf_harvest_stale_audit_records_upstream_metadata_warning(tmp_path: Path) -> None:
+def test_haf_harvest_stale_audit_cleans_upstream_metadata_warning(tmp_path: Path) -> None:
     paths = write_synthetic_haf_harvest_inputs(tmp_path)
     observer_metadata = json.loads(paths["observer_metadata"].read_text())
     observer_metadata["configured_default_fruit_dry_matter_content"] = 0.065
@@ -51,6 +51,12 @@ def test_haf_harvest_stale_audit_records_upstream_metadata_warning(tmp_path: Pat
     )
 
     audit = pd.read_csv(result["paths"]["stale_dmc_audit"])
+    cleaned_metadata = json.loads(paths["observer_metadata"].read_text())
     warning_hits = json.loads(audit["upstream_metadata_warning_hits_json"].iloc[0])
     assert audit["status"].iloc[0] == "pass"
-    assert "configured_default_fruit_dry_matter_content" in warning_hits
+    assert warning_hits == []
+    assert "configured_default_fruit_dry_matter_content" not in cleaned_metadata
+    assert (
+        cleaned_metadata["legacy_metadata"]["deprecated_previous_default_fruit_DMC_fraction"]
+        == 0.065
+    )

--- a/tests/test_tomics_haf_harvest_family_outputs.py
+++ b/tests/test_tomics_haf_harvest_family_outputs.py
@@ -36,6 +36,12 @@ def test_haf_harvest_runner_writes_required_outputs(tmp_path: Path) -> None:
         "harvest_family_prerequisite_promotion_summary.csv",
         "harvest_family_prerequisite_promotion_summary.md",
         "harvest_family_metadata.json",
+        "harvest_family_reproducibility_manifest.json",
+        "harvest_family_reproducibility_manifest.csv",
+        "harvest_family_reproducibility_manifest.md",
+        "goal3c_readiness_audit.json",
+        "goal3c_readiness_audit.csv",
+        "goal3c_readiness_audit.md",
         "observation_operator_dmc_0p056_audit.csv",
         "no_stale_dmc_0p065_primary_audit.csv",
     }

--- a/tests/test_tomics_haf_harvest_family_outputs.py
+++ b/tests/test_tomics_haf_harvest_family_outputs.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import json
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_haf_harvest_runner_writes_required_outputs(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    output_root = Path(result["output_root"])
+    expected_filenames = {
+        "harvest_family_factorial_design.csv",
+        "harvest_family_run_manifest.csv",
+        "harvest_family_metrics_pooled.csv",
+        "harvest_family_metrics_by_loadcell.csv",
+        "harvest_family_metrics_mean_sd.csv",
+        "harvest_family_daily_overlay.csv",
+        "harvest_family_cumulative_overlay.csv",
+        "harvest_family_mass_balance.csv",
+        "harvest_family_budget_parity.csv",
+        "harvest_family_rankings.csv",
+        "harvest_family_selected_research_candidate.json",
+        "harvest_family_prerequisite_promotion_summary.csv",
+        "harvest_family_prerequisite_promotion_summary.md",
+        "harvest_family_metadata.json",
+        "observation_operator_dmc_0p056_audit.csv",
+        "no_stale_dmc_0p065_primary_audit.csv",
+    }
+    for filename in expected_filenames:
+        assert (output_root / filename).exists()
+
+    metadata = json.loads((output_root / "harvest_family_metadata.json").read_text())
+    assert metadata["harvest_family_factorial_run"] is True
+    assert metadata["promotion_gate_run"] is False
+    assert metadata["cross_dataset_gate_run"] is False
+    assert metadata["shipped_TOMICS_incumbent_changed"] is False

--- a/tests/test_tomics_haf_harvest_family_promotion_block.py
+++ b/tests/test_tomics_haf_harvest_family_promotion_block.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import json
+
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_haf_harvest_goal3b_blocks_promotion_and_cross_dataset_gate(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    metadata = json.loads(Path(result["paths"]["metadata"]).read_text())
+    selected = json.loads(Path(result["paths"]["selected"]).read_text())
+
+    assert metadata["promotion_gate_run"] is False
+    assert metadata["cross_dataset_gate_run"] is False
+    assert metadata["single_dataset_promotion_allowed"] is False
+    assert metadata["shipped_TOMICS_incumbent_changed"] is False
+    assert selected["latent_allocation_directly_validated"] is False
+    assert selected["raw_THORP_allocator_used"] is False
+
+
+def test_haf_harvest_rejects_failed_latent_guardrails(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    latent_metadata = json.loads(paths["latent_metadata"].read_text())
+    latent_metadata["latent_allocation_guardrails_passed"] = False
+    paths["latent_metadata"].write_text(json.dumps(latent_metadata), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="guardrails failed"):
+        run_tomics_haf_harvest_family_factorial(
+            synthetic_haf_harvest_config(paths),
+            repo_root=tmp_path,
+            config_path=tmp_path / "config.yaml",
+        )
+
+
+def test_haf_harvest_rejects_raw_thorp_allocator_metadata(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    latent_metadata = json.loads(paths["latent_metadata"].read_text())
+    latent_metadata["raw_THORP_allocator_used"] = True
+    paths["latent_metadata"].write_text(json.dumps(latent_metadata), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Raw THORP allocator"):
+        run_tomics_haf_harvest_family_factorial(
+            synthetic_haf_harvest_config(paths),
+            repo_root=tmp_path,
+            config_path=tmp_path / "config.yaml",
+        )

--- a/tests/test_tomics_haf_harvest_observation_operator_dmc_0p056.py
+++ b/tests/test_tomics_haf_harvest_observation_operator_dmc_0p056.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_observation_operator import (
+    build_harvest_observation_frame_dmc_0p056,
+    dry_floor_area_to_fresh_loadcell,
+    fresh_loadcell_to_dry_floor_area,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.observers.contracts import (
+    HAF_2025_2C_LOADCELL_FLOOR_AREA_M2,
+)
+
+
+def test_haf_harvest_observation_operator_uses_dmc_0p056() -> None:
+    dry_floor = fresh_loadcell_to_dry_floor_area(1000.0)
+    assert dry_floor == pytest.approx(56.0 / HAF_2025_2C_LOADCELL_FLOOR_AREA_M2)
+    assert dry_floor_area_to_fresh_loadcell(dry_floor) == pytest.approx(1000.0)
+
+
+def test_haf_harvest_observation_frame_marks_estimated_dry_basis() -> None:
+    frame = pd.DataFrame(
+        {
+            "date": ["2025-11-01", "2025-11-02"],
+            "loadcell_id": [1, 1],
+            "treatment": ["Control", "Control"],
+            "threshold_w_m2": [0, 0],
+            "loadcell_daily_yield_g": [1000.0, 500.0],
+            "loadcell_cumulative_yield_g": [1000.0, 1500.0],
+            "fresh_yield_source": ["legacy", "legacy"],
+        }
+    )
+
+    observed = build_harvest_observation_frame_dmc_0p056(frame)
+
+    assert observed["observed_fruit_DW_g_loadcell_dmc_0p056"].tolist() == [
+        56.0,
+        84.0,
+    ]
+    assert observed["DMC_sensitivity_enabled"].eq(False).all()
+    assert observed["direct_dry_yield_measured"].eq(False).all()
+    assert observed["observation_operator"].eq("fresh_to_dry_dmc_0p056").all()
+    assert observed["inverse_observation_operator"].eq("dry_to_fresh_dmc_0p056").all()
+    assert "dmc_0p065" not in ",".join(observed.columns)

--- a/tests/test_tomics_haf_no_stale_dmc_0p065_primary.py
+++ b/tests/test_tomics_haf_no_stale_dmc_0p065_primary.py
@@ -32,7 +32,10 @@ def test_haf_2025_2c_primary_files_do_not_use_0p065_as_current_default() -> None
         "default DMC = 0.065",
     )
     for path in HAF_PRIMARY_PATHS:
-        text = path.read_text(encoding="utf-8")
+        text = path.read_text(encoding="utf-8").replace(
+            "no_stale_dmc_0p065_primary_audit.csv",
+            "no_stale_dmc_previous_primary_audit.csv",
+        )
         for token in forbidden_tokens:
             assert token not in text
         for line in text.splitlines():

--- a/tests/test_tomics_haf_plotkit_render_manifest.py
+++ b/tests/test_tomics_haf_plotkit_render_manifest.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_plotkit_manifest import (
+    FRAME_ROLE_FILES,
+    write_haf_plotkit_render_manifest,
+)
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_pre_gate_artifacts import (
+    REQUIRED_PLOTKIT_BUNDLES,
+)
+
+
+def test_haf_plotkit_manifest_validates_required_scaffold_specs(
+    tmp_path: Path,
+) -> None:
+    spec_dir = Path("configs/plotkit/tomics/haf_2025_2c")
+    for bundle in REQUIRED_PLOTKIT_BUNDLES:
+        assert (spec_dir / f"{bundle}.yaml").exists()
+
+    input_root = tmp_path / "inputs"
+    input_root.mkdir()
+    for filename in set(FRAME_ROLE_FILES.values()):
+        (input_root / filename).write_text("candidate_id,value\nx,1\n", encoding="utf-8")
+
+    paths = write_haf_plotkit_render_manifest(
+        spec_dir=spec_dir,
+        input_root=input_root,
+        output_root=tmp_path / "figures",
+    )
+    manifest = pd.read_csv(paths["plotkit_render_manifest_csv"])
+    required = manifest[manifest["bundle"].isin(REQUIRED_PLOTKIT_BUNDLES)]
+
+    assert set(required["bundle"]) == set(REQUIRED_PLOTKIT_BUNDLES)
+    assert required["render_status"].isin(
+        {
+            "rendered",
+            "spec_validated_only",
+            "failed_missing_renderer",
+            "failed_missing_data",
+        }
+    ).all()
+    assert required["render_status"].eq("spec_validated_only").all()
+    assert not any((tmp_path / "figures").glob("*.png"))

--- a/tests/test_tomics_haf_pre_gate_dmc_warning_cleanup.py
+++ b/tests/test_tomics_haf_pre_gate_dmc_warning_cleanup.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import json
+
+import pandas as pd
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_pre_gate_dmc_warning_cleanup_removes_top_level_legacy_alias(
+    tmp_path: Path,
+) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    observer_metadata = json.loads(paths["observer_metadata"].read_text())
+    observer_metadata["configured_default_fruit_dry_matter_content"] = 0.065
+    paths["observer_metadata"].write_text(json.dumps(observer_metadata), encoding="utf-8")
+
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    cleaned = json.loads(paths["observer_metadata"].read_text())
+    metadata = json.loads(Path(result["paths"]["metadata"]).read_text())
+    audit = pd.read_csv(result["paths"]["stale_dmc_audit"])
+    analysis_audit = pd.read_csv(result["paths"]["analysis_stale_dmc_audit"])
+
+    assert "configured_default_fruit_dry_matter_content" not in cleaned
+    assert metadata["canonical_fruit_DMC_fraction"] == 0.056
+    assert metadata["fruit_DMC_fraction"] == 0.056
+    assert metadata["default_fruit_dry_matter_content"] == 0.056
+    assert audit["upstream_metadata_warning_count"].iloc[0] == 0
+    assert analysis_audit["upstream_metadata_warning_count"].iloc[0] == 0
+
+
+def test_pre_gate_dmc_warning_cleanup_handles_case_variants(tmp_path: Path) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    observer_metadata = json.loads(paths["observer_metadata"].read_text())
+    observer_metadata["Configured_Default_Fruit_Dry_Matter_Content"] = 0.065
+    paths["observer_metadata"].write_text(json.dumps(observer_metadata), encoding="utf-8")
+
+    run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=tmp_path / "config.yaml",
+    )
+
+    cleaned = json.loads(paths["observer_metadata"].read_text())
+    assert "Configured_Default_Fruit_Dry_Matter_Content" not in cleaned
+    assert (
+        cleaned["legacy_metadata"]["deprecated_previous_default_fruit_DMC_fraction"]
+        == 0.065
+    )

--- a/tests/test_tomics_haf_reproducibility_manifest.py
+++ b/tests/test_tomics_haf_reproducibility_manifest.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import json
+
+from stomatal_optimiaztion.domains.tomato.tomics.alloc.validation.haf_harvest_factorial import (
+    run_tomics_haf_harvest_family_factorial,
+)
+
+from tests.tomics_haf_harvest_fixtures import (
+    synthetic_haf_harvest_config,
+    write_synthetic_haf_harvest_inputs,
+)
+
+
+def test_haf_reproducibility_manifest_records_inputs_hashes_and_gate_flags(
+    tmp_path: Path,
+) -> None:
+    paths = write_synthetic_haf_harvest_inputs(tmp_path)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("synthetic: true\n", encoding="utf-8")
+
+    result = run_tomics_haf_harvest_family_factorial(
+        synthetic_haf_harvest_config(paths),
+        repo_root=tmp_path,
+        config_path=config_path,
+    )
+    manifest = json.loads(
+        Path(result["paths"]["reproducibility_json"]).read_text(encoding="utf-8")
+    )
+
+    assert manifest["repo_branch"]
+    assert manifest["repo_head_sha"]
+    assert manifest["config_path"]
+    assert str(config_path) in manifest["command_run"]
+    assert manifest["config_sha256"]
+    assert manifest["dmc_basis"] == 0.056
+    assert manifest["DMC_sensitivity_enabled"] is False
+    assert manifest["promotion_gate_run"] is False
+    assert manifest["cross_dataset_gate_run"] is False
+    assert manifest["raw_data_committed"] is False
+    assert manifest["out_committed"] is False
+    assert manifest["observer_metadata_sha256"]
+    assert manifest["latent_metadata_sha256"]
+    assert all(
+        record["input_file_sha256_status"] in {"computed", "skipped_large_file", "unavailable"}
+        for record in manifest["input_files"]
+    )

--- a/tests/tomics_haf_harvest_fixtures.py
+++ b/tests/tomics_haf_harvest_fixtures.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def write_synthetic_haf_harvest_inputs(tmp_path: Path) -> dict[str, Path]:
+    observer_path = tmp_path / "observer_feature_frame.csv"
+    observer_metadata_path = tmp_path / "observer_metadata.json"
+    latent_path = tmp_path / "latent_allocation_posteriors.csv"
+    latent_metadata_path = tmp_path / "latent_allocation_metadata.json"
+    output_root = tmp_path / "harvest-family"
+
+    rows = []
+    for loadcell_id, treatment in [(1, "Control"), (4, "Drought")]:
+        cumulative = 0.0
+        for day, daily in enumerate([0.0, 100.0, 140.0], start=1):
+            cumulative += daily
+            rows.append(
+                {
+                    "date": f"2025-11-0{day}",
+                    "loadcell_id": loadcell_id,
+                    "treatment": treatment,
+                    "threshold_w_m2": 0,
+                    "fresh_yield_available": True,
+                    "fresh_yield_source": "synthetic_legacy_v1_3",
+                    "harvest_yield_available": True,
+                    "dry_yield_available": True,
+                    "dry_yield_source": "fresh_yield_times_canonical_DMC_0p056",
+                    "loadcell_daily_yield_g": daily,
+                    "loadcell_cumulative_yield_g": cumulative,
+                    "observed_fruit_FW_g_loadcell": cumulative,
+                    "canonical_fruit_DMC_fraction": 0.056,
+                    "fruit_DMC_fraction": 0.056,
+                    "default_fruit_dry_matter_content": 0.056,
+                    "DMC_fixed_for_2025_2C": True,
+                    "DMC_sensitivity_enabled": False,
+                    "dry_yield_is_dmc_estimated": True,
+                    "direct_dry_yield_measured": False,
+                    "legacy_yield_bridge_provenance": "legacy_v1_3_derived_output",
+                }
+            )
+    pd.DataFrame(rows).to_csv(observer_path, index=False)
+
+    observer_metadata = {
+        "season_id": "2025_2C",
+        "radiation_daynight_primary_source": "dataset1",
+        "radiation_column_used": "env_inside_radiation_wm2",
+        "fixed_clock_daynight_primary": False,
+        "clock_06_18_used_only_for_compatibility": True,
+        "event_bridged_ET_calibration_status": "calibrated_to_legacy_daily_event_total",
+        "event_bridged_ET_calibration_provenance": "legacy_v1_3_derived_output",
+        "RZI_main_available": True,
+        "RZI_main_source": "theta_paired_lc4_vs_lc1",
+        "RZI_control_reference_source": "dataset1_moisture_lc1_lc6",
+        "fresh_yield_available": True,
+        "dry_yield_available": True,
+        "dry_yield_is_dmc_estimated": True,
+        "direct_dry_yield_measured": False,
+        "dry_yield_source": "fresh_yield_times_canonical_DMC_0p056",
+        "canonical_fruit_DMC_fraction": 0.056,
+        "fruit_DMC_fraction": 0.056,
+        "default_fruit_dry_matter_content": 0.056,
+        "DMC_fixed_for_2025_2C": True,
+        "DMC_sensitivity_enabled": False,
+        "DMC_sensitivity_values": [],
+        "deprecated_previous_default_fruit_DMC_fraction": 0.065,
+        "legacy_yield_bridge_provenance": "legacy_v1_3_derived_output",
+    }
+    observer_metadata_path.write_text(json.dumps(observer_metadata), encoding="utf-8")
+
+    latent_rows = []
+    for prior in [
+        "legacy_tomato_prior",
+        "thorp_bounded_prior",
+        "tomato_constrained_thorp_prior",
+    ]:
+        for loadcell_id, treatment in [(1, "Control"), (4, "Drought")]:
+            for day in range(1, 4):
+                latent_rows.append(
+                    {
+                        "date": f"2025-11-0{day}",
+                        "loadcell_id": loadcell_id,
+                        "treatment": treatment,
+                        "prior_family": prior,
+                        "inferred_u_fruit": 0.50 + 0.01 * day,
+                        "latent_allocation_directly_validated": False,
+                        "raw_THORP_allocator_used": False,
+                    }
+                )
+    pd.DataFrame(latent_rows).to_csv(latent_path, index=False)
+    latent_metadata = {
+        "latent_allocation_ready": True,
+        "latent_allocation_guardrails_passed": True,
+        "canonical_fruit_DMC_fraction": 0.056,
+        "DMC_fixed_for_2025_2C": True,
+        "DMC_sensitivity_enabled": False,
+        "dry_yield_is_dmc_estimated": True,
+        "direct_dry_yield_measured": False,
+        "raw_THORP_allocator_used": False,
+    }
+    latent_metadata_path.write_text(json.dumps(latent_metadata), encoding="utf-8")
+
+    return {
+        "observer": observer_path,
+        "observer_metadata": observer_metadata_path,
+        "latent": latent_path,
+        "latent_metadata": latent_metadata_path,
+        "output_root": output_root,
+    }
+
+
+def synthetic_haf_harvest_config(paths: dict[str, Path]) -> dict[str, Any]:
+    return {
+        "exp": {"name": "synthetic_haf_harvest"},
+        "tomics_haf": {
+            "season_id": "2025_2C",
+            "observer_feature_frame": str(paths["observer"]),
+            "observer_metadata": str(paths["observer_metadata"]),
+            "latent_allocation_posteriors": str(paths["latent"]),
+            "latent_allocation_metadata": str(paths["latent_metadata"]),
+            "output_root": str(paths["output_root"]),
+        },
+        "harvest_family_factorial": {
+            "mode": "staged",
+            "run_HF0": True,
+            "run_HF1": True,
+            "run_HF2": True,
+            "run_HF3": True,
+            "run_HF4_budget_parity": True,
+            "run_HF5_promotion_gate": False,
+            "run_HF6_oracle_diagnostics": False,
+            "incumbent": {
+                "allocator_family": "shipped_tomics",
+                "fruit_harvest_family": "tomsim_truss_incumbent",
+                "leaf_harvest_family": "leaf_harvest_tomsim_legacy",
+                "observation_operator": "fresh_to_dry_dmc_0p056",
+            },
+            "allocator_families": [
+                "shipped_tomics",
+                "source_only",
+                "hydraulic_only",
+                "allocation_only",
+                "tomics_haf_latent_allocation_research",
+            ],
+            "latent_allocation_prior_families": [
+                "legacy_tomato_prior",
+                "thorp_bounded_prior",
+                "tomato_constrained_thorp_prior",
+            ],
+            "fruit_harvest_families": [
+                "tomsim_truss_incumbent",
+                "tomgro_ageclass_mature_pool",
+                "dekoning_fds_ripe",
+                "vanthoor_boxcar_stageflow",
+            ],
+            "leaf_harvest_families": [
+                "leaf_harvest_tomsim_legacy",
+                "leaf_harvest_none",
+                "leaf_harvest_max_lai",
+                "leaf_harvest_vanthoor_mcleafhar",
+            ],
+            "always_include": {
+                "fruit_harvest_families": [
+                    "tomsim_truss_incumbent",
+                    "dekoning_fds_ripe",
+                ],
+            },
+            "parameter_grid": {
+                "harvest_delay_days": [0, 1],
+                "harvest_readiness_threshold": [0.95, 1.0],
+                "vanthoor_boxcar_n_stages": [4, 5],
+                "tomgro_mature_pool_age_class": ["last", "last_two"],
+                "fdmc_mode": ["constant_0p056"],
+            },
+        },
+        "promotion": {
+            "run_final_promotion_gate": False,
+            "single_dataset_promotion_allowed": False,
+            "require_cross_dataset_for_promotion": True,
+        },
+    }


### PR DESCRIPTION
Closes #312.

Goal 3B remains a bounded 2025-2C architecture-discrimination test. For 2025-2C, DMC is fixed at 0.056. Dry yield derived from fresh yield using DMC 0.056 is an estimated dry-yield basis, not direct destructive dry-mass measurement.

Latent allocation remains observer-supported inference, not direct allocation validation. Promotion gate and cross-dataset gate remain unrun. Shipped TOMICS incumbent remains unchanged.

## Goal 3B.5 Pre-gate Polish

- Upstream DMC warning cleanup: `configured_default_fruit_dry_matter_content` is removed from current top-level observer metadata and retained only as legacy deprecated DMC history. Both analysis and harvest-family stale-DMC audits now report zero upstream warning hits.
- Canonical DMC metadata: `canonical_fruit_DMC_fraction = 0.056`, `fruit_DMC_fraction = 0.056`, `default_fruit_dry_matter_content = 0.056`, `DMC_sensitivity_enabled = false`, `DMC_sensitivity_values = []`, `dry_yield_is_dmc_estimated = true`, and `direct_dry_yield_measured = false`.
- Plotkit bundle status: wrote manifest-only bundle evidence under `out/tomics/figures/haf_2025_2c/plotkit_render_manifest.{csv,md}`. The six Goal 3B specs are `spec_validated_only`; no fake PNGs were written because the HAF specs remain scaffold-level pending a dedicated renderer.
- RALPH follow-up guardrail: Goal 3C readiness now rejects required Plotkit bundles marked `failed_missing_data`; missing renderer remains allowed only when explicitly manifested.
- Reproducibility manifest: wrote `harvest_family_reproducibility_manifest.{json,csv,md}` with branch/HEAD, config hash, input/output hashes or status, DMC basis, private/out commit flags, and gate flags.
- Budget parity limitation: documented and emitted `budget_parity_basis = "knob_count_and_hidden_calibration_budget"`. Budget parity is knob-count and hidden-calibration-budget parity, not wall-clock compute-budget parity.
- Goal 3C readiness audit: wrote `goal3c_readiness_audit.{json,csv,md}` with `goal3c_ready = true` and no blockers.
- Private harvest-family outputs were regenerated under `out/tomics/validation/harvest-family/haf_2025_2c/` at HEAD `55d89543fba4fd44e5cf79e94297cc6a6f23302e`.

Validation:

- Goal 3B.5 targeted tests: `14 passed`
- Goal 3B regression subset: `14 passed`
- Full pytest: `685 passed, 26 skipped, 12 deselected`
- Ruff: `poetry run ruff check .` passed
- Diff check: `git diff --check` and `git diff --cached --check` passed, with Git CRLF warnings only
- Private Plotkit manifest run: `poetry run python scripts/run_tomics_haf_plotkit_bundle_manifest.py` exited 0
- Private harvest-family run: `poetry run python scripts/run_tomics_haf_harvest_family_factorial.py --config configs/exp/tomics_haf_2025_2c_harvest_family_factorial.yaml` exited 0

Promotion gate remains unrun. Cross-dataset gate remains unrun. Shipped TOMICS incumbent remains unchanged.